### PR TITLE
Optimize static responses

### DIFF
--- a/Sources/DestinyBlueprint/Epoll.swift
+++ b/Sources/DestinyBlueprint/Epoll.swift
@@ -71,10 +71,10 @@ public struct Epoll<let maxEvents: Int>: SocketAcceptor {
     @inlinable
     public mutating func wait(
         timeout: Int32 = -1,
-        acceptClient: (Int32) throws(SocketError) -> Int32?
+        acceptClient: (Int32) throws(SocketError) -> Int32?,
+        events: inout InlineArray<maxEvents, epoll_event>
     ) throws(EpollError) -> (loaded: Int, clients: InlineArray<maxEvents, Int32>) {
         var loadedClients:Int32 = -1
-        var events = InlineArray<maxEvents, epoll_event>(repeating: .init())
         var err:EpollError? = nil
         events.mutableSpan.withUnsafeBufferPointer { p in
             do throws(EpollError) {

--- a/Sources/DestinyBlueprint/InlineArrayProtocol.swift
+++ b/Sources/DestinyBlueprint/InlineArrayProtocol.swift
@@ -17,11 +17,11 @@ extension InlineArray: InlineArrayProtocol, HTTPSocketWritable {
     }
 
     @inlinable
-    public func write(to socket: borrowing some HTTPSocketProtocol & ~Copyable) async throws(SocketError) {
+    public func write(to socket: Int32) throws(SocketError) {
         var err:SocketError? = nil
         withUnsafePointer(to: self, {
             do throws(SocketError) {
-                try socket.writeBuffer($0, length: count)
+                try socket.socketWriteBuffer($0, length: count)
             } catch {
                 err = error
             }

--- a/Sources/DestinyBlueprint/InlineByteArrayProtocol.swift
+++ b/Sources/DestinyBlueprint/InlineByteArrayProtocol.swift
@@ -66,7 +66,7 @@ public struct InlineByteArray<let count: Int>: InlineByteArrayProtocol {
     }
 
     @inlinable
-    public func write(to socket: borrowing some HTTPSocketProtocol & ~Copyable) async throws(SocketError) {
-        try await _storage.write(to: socket)
+    public func write(to socket: Int32) throws(SocketError) {
+        try _storage.write(to: socket)
     }
 }

--- a/Sources/DestinyBlueprint/InlineVLArray.swift
+++ b/Sources/DestinyBlueprint/InlineVLArray.swift
@@ -20,7 +20,7 @@ public struct InlineVLArray<Element>: InlineArrayProtocol, @unchecked Sendable {
 
     @inlinable
     public static func create<E: Error>(amount: Int, initialize: (Int) -> Element, _ closure: (inout Self) throws(E) -> Void) rethrows {
-        try withUnsafeTemporaryAllocation(of: Element.self, capacity: amount, { p in
+        try withUnsafeTemporaryAllocation(of: Element.self, capacity: MemoryLayout<Element>.stride * amount, { p in
             for i in 0..<amount {
                 p[i] = initialize(i)
             }

--- a/Sources/DestinyBlueprint/SocketProtocol.swift
+++ b/Sources/DestinyBlueprint/SocketProtocol.swift
@@ -1,8 +1,4 @@
 
-#if canImport(Darwin)
-import Darwin
-#endif
-
 /// Core Socket protocol that handles incoming network requests.
 public protocol SocketProtocol: ~Copyable, Sendable {
     associatedtype Buffer:InlineByteArrayProtocol
@@ -78,16 +74,6 @@ extension SocketProtocol where Self: ~Copyable {
     public func writeString(
         _ string: String
     ) throws(SocketError) {
-        var err:SocketError? = nil
-        string.utf8Span.span.withUnsafeBufferPointer {
-            do throws(SocketError) {
-                try self.writeBuffer($0.baseAddress!, length: $0.count)
-            } catch {
-                err = error
-            }
-        }
-        if let err {
-            throw err
-        }
+        try fileDescriptor.socketWriteString(string)
     }
 }

--- a/Sources/DestinyBlueprint/extensions/Int32Extensions.swift
+++ b/Sources/DestinyBlueprint/extensions/Int32Extensions.swift
@@ -1,0 +1,111 @@
+
+#if canImport(Android)
+import Android
+#elseif canImport(Bionic)
+import Bionic
+#elseif canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif canImport(WASILibc)
+import WASILibc
+#elseif canImport(Windows)
+import Windows
+#elseif canImport(WinSDK)
+import WinSDK
+#endif
+
+// MARK: Receive
+extension Int32 {
+    @inlinable
+    public func socketReceive(_ baseAddress: UnsafeMutablePointer<UInt8>, _ length: Int, _ flags: Int32 = 0) -> Int {
+        return recv(self, baseAddress, length, flags)
+    }
+    @inlinable
+    public func socketReceive(_ baseAddress: UnsafeMutableRawPointer, _ length: Int, _ flags: Int32 = 0) -> Int {
+        return recv(self, baseAddress, length, flags)
+    }
+}
+
+// MARK: Write
+extension Int32 {
+    @inlinable
+    public func socketWriteBuffer(
+        _ pointer: UnsafeRawPointer,
+        length: Int
+    ) throws(SocketError) {
+        var sent = 0
+        while sent < length {
+            if Task.isCancelled { return }
+            let result = socketSendMultiplatform(pointer + sent, length - sent)
+            if result <= 0 {
+                throw SocketError.writeFailed()
+            }
+            sent += result
+        }
+    }
+
+    @inlinable
+    public func socketWriteBuffers<let count: Int>(
+        _ buffers: InlineArray<count, UnsafeBufferPointer<UInt8>>
+    ) throws(SocketError) {
+        var err:SocketError? = nil
+        withUnsafeTemporaryAllocation(of: iovec.self, capacity: count, { iovecs in
+            for i in buffers.indices {
+                let buffer = buffers[i]
+                iovecs[i] = .init(iov_base: .init(mutating: buffer.baseAddress), iov_len: buffer.count)
+            }
+            let result = writev(self, iovecs.baseAddress, Int32(count))
+            if result <= 0 {
+                err = SocketError.writeFailed()
+            }
+        })
+        if let err {
+            throw err
+        }
+    }
+
+    @inlinable
+    public func socketWriteString(
+        _ string: String
+    ) throws(SocketError) {
+        var err:SocketError? = nil
+        string.utf8Span.span.withUnsafeBufferPointer {
+            do throws(SocketError) {
+                try socketWriteBuffer($0.baseAddress!, length: $0.count)
+            } catch {
+                err = error
+            }
+        }
+        if let err {
+            throw err
+        }
+    }
+}
+
+// MARK: Send
+extension Int32 {
+    @inlinable
+    package func socketSendMultiplatform(_ pointer: UnsafeRawPointer, _ length: Int) -> Int {
+        #if canImport(Android) || canImport(Bionic) || canImport(Darwin) || canImport(Glibc) || canImport(Musl) || canImport(WASILibc) || canImport(Windows) || canImport(WinSDK)
+        return send(self, pointer, length, Int32(MSG_NOSIGNAL))
+        #else
+        return write(self, pointer, length)
+        #endif
+    }
+}
+
+// MARK: Close
+extension Int32 {
+    @inlinable
+    package func socketClose() {
+        #if canImport(SwiftGlibc) || canImport(Foundation)
+        shutdown(self, Int32(SHUT_RDWR)) // shutdown read and write (https://www.gnu.org/software/libc/manual/html_node/Closing-a-Socket.html)
+        close(self)
+        #else
+        #warning("Unable to shutdown and close file descriptor!")
+        #endif
+    }
+}

--- a/Sources/DestinyBlueprint/extensions/Int32Extensions.swift
+++ b/Sources/DestinyBlueprint/extensions/Int32Extensions.swift
@@ -5,8 +5,8 @@ import Android
 import Bionic
 #elseif canImport(Darwin)
 import Darwin
-#elseif canImport(Glibc)
-import Glibc
+#elseif canImport(SwiftGlibc)
+import SwiftGlibc
 #elseif canImport(Musl)
 import Musl
 #elseif canImport(WASILibc)

--- a/Sources/DestinyBlueprint/http/AsyncHTTPSocketWritable.swift
+++ b/Sources/DestinyBlueprint/http/AsyncHTTPSocketWritable.swift
@@ -1,37 +1,43 @@
 
 /// Types conforming to this protocol can write their contents to an HTTP Socket.
-public protocol HTTPSocketWritable: Sendable, ~Copyable {
-    /// Synchronously writes data to the socket.
+public protocol AsyncHTTPSocketWritable: Sendable, ~Copyable {
+    /// Asynchronously writes data to the socket.
     /// 
     /// - Parameters:
     ///   - socket: some noncopyable `HTTPSocketProtocol`.
     func write(
         to socket: Int32
-    ) throws(SocketError)
+    ) async throws(SocketError)
 }
 
-extension HTTPSocketWritable {
+extension AsyncHTTPSocketWritable {
+    /// Asynchronously writes data to the socket.
+    /// 
+    /// - Parameters:
+    ///   - socket: some noncopyable `HTTPSocketProtocol`.
     @inlinable
-    public func write(to socket: borrowing some HTTPSocketProtocol & ~Copyable) throws(SocketError) {
-        try write(to: socket.fileDescriptor)
+    public func write(
+        to socket: borrowing some HTTPSocketProtocol & ~Copyable
+    ) async throws(SocketError) {
+        try await write(to: socket.fileDescriptor)
     }
 }
 
 // MARK: Default conformances
-extension String: HTTPSocketWritable {
+extension String: AsyncHTTPSocketWritable {
     @inlinable
     public func write(
         to socket: Int32
-    ) throws(SocketError) {
+    ) async throws(SocketError) {
         try socket.socketWriteString(self)
     }
 }
 
-extension StaticString: HTTPSocketWritable {
+extension StaticString: AsyncHTTPSocketWritable {
     @inlinable
     public func write(
         to socket: Int32
-    ) throws(SocketError) {
+    ) async throws(SocketError) {
         var err:SocketError? = nil
         withUTF8Buffer {
             do throws(SocketError) {
@@ -46,11 +52,11 @@ extension StaticString: HTTPSocketWritable {
     }
 }
 
-extension [UInt8]: HTTPSocketWritable {
+extension [UInt8]: AsyncHTTPSocketWritable {
     @inlinable
     public func write(
         to socket: Int32
-    ) throws(SocketError) {
+    ) async throws(SocketError) {
         var err:SocketError? = nil
         self.withUnsafeBufferPointer {
             do throws(SocketError) {

--- a/Sources/DestinyBlueprint/http/router/HTTPRouterProtocol.swift
+++ b/Sources/DestinyBlueprint/http/router/HTTPRouterProtocol.swift
@@ -71,7 +71,7 @@ extension HTTPRouterProtocol {
         responder: borrowing some StaticRouteResponderProtocol
     ) async throws(ResponderError) {
         do throws(SocketError) {
-            try await responder.write(to: socket)
+            try responder.write(to: socket)
         } catch {
             throw .socketError(error)
         }

--- a/Sources/DestinyBlueprint/http/router/HTTPRouterProtocol.swift
+++ b/Sources/DestinyBlueprint/http/router/HTTPRouterProtocol.swift
@@ -27,37 +27,35 @@ public protocol HTTPRouterProtocol: Sendable, ~Copyable {
     /// Responds to a socket.
     /// 
     /// - Parameters:
-    ///   - client: File descriptor assigned to the socket.
-    ///   - socket: The socket.
+    ///   - socket: File descriptor assigned to the socket.
     ///   - request: A loaded request for the socket.
     ///   - logger: Logger of the socket acceptor that called this function.
     /// 
     /// - Returns: Whether or not a response was sent.
     func respond(
-        client: Int32,
-        socket: borrowing some HTTPSocketProtocol & ~Copyable,
+        socket: Int32,
         request: inout some HTTPRequestProtocol & ~Copyable,
         logger: Logger
     ) async throws(ResponderError) -> Bool
 
-    /// Writes a static responder to the socket.
+    /// Writes a static response to the socket.
     /// 
     /// - Parameters:
     ///   - socket: The socket to write to.
     ///   - responder: The static route responder that will write to the socket.
     func respondStatically(
-        socket: borrowing some HTTPSocketProtocol & ~Copyable,
+        socket: Int32,
         responder: some StaticRouteResponderProtocol
-    ) async throws(ResponderError)
+    ) throws(ResponderError)
 
-    /// Writes a dynamic responder to the socket.
+    /// Writes a dynamic response to the socket.
     /// 
     /// - Parameters:
     ///   - socket: The socket to write to.
     ///   - request: The socket's request.
     ///   - responder: The dynamic route responder that will write to the socket.
     func respondDynamically(
-        socket: borrowing some HTTPSocketProtocol & ~Copyable,
+        socket: Int32,
         request: inout some HTTPRequestProtocol & ~Copyable,
         responder: some DynamicRouteResponderProtocol
     ) async throws(ResponderError)
@@ -67,9 +65,9 @@ public protocol HTTPRouterProtocol: Sendable, ~Copyable {
 extension HTTPRouterProtocol {
     @inlinable
     public func respondStatically(
-        socket: borrowing some HTTPSocketProtocol & ~Copyable,
+        socket: Int32,
         responder: borrowing some StaticRouteResponderProtocol
-    ) async throws(ResponderError) {
+    ) throws(ResponderError) {
         do throws(SocketError) {
             try responder.write(to: socket)
         } catch {
@@ -110,7 +108,7 @@ extension HTTPRouterProtocol {
 
     @inlinable
     public func respondDynamically(
-        socket: borrowing some HTTPSocketProtocol & ~Copyable,
+        socket: Int32,
         request: inout some HTTPRequestProtocol & ~Copyable,
         responder: some DynamicRouteResponderProtocol
     ) async throws(ResponderError) {

--- a/Sources/DestinyBlueprint/http/router/HTTPRouterProtocol.swift
+++ b/Sources/DestinyBlueprint/http/router/HTTPRouterProtocol.swift
@@ -18,26 +18,6 @@ public protocol HTTPRouterProtocol: Sendable, ~Copyable {
         logger: Logger
     )
 
-    /// Handle dynamic middleware for a given request and dynamic response.
-    func handleDynamicMiddleware(
-        for request: inout some HTTPRequestProtocol & ~Copyable,
-        with response: inout some DynamicResponseProtocol
-    ) throws(ResponderError)
-
-    /// Responds to a socket.
-    /// 
-    /// - Parameters:
-    ///   - socket: File descriptor assigned to the socket.
-    ///   - request: A loaded request for the socket.
-    ///   - logger: Logger of the socket acceptor that called this function.
-    /// 
-    /// - Returns: Whether or not a response was sent.
-    func respond(
-        socket: Int32,
-        request: inout some HTTPRequestProtocol & ~Copyable,
-        logger: Logger
-    ) throws(ResponderError) -> Bool
-
     /// Writes a static response to the socket.
     /// 
     /// - Parameters:
@@ -59,60 +39,4 @@ public protocol HTTPRouterProtocol: Sendable, ~Copyable {
         request: inout some HTTPRequestProtocol & ~Copyable,
         responder: some DynamicRouteResponderProtocol
     ) throws(ResponderError)
-}
-
-// MARK: Defaults
-extension HTTPRouterProtocol {
-    @inlinable
-    public func respondStatically(
-        socket: Int32,
-        responder: borrowing some StaticRouteResponderProtocol
-    ) throws(ResponderError) {
-        do throws(SocketError) {
-            try responder.write(to: socket)
-        } catch {
-            throw .socketError(error)
-        }
-    }
-
-    @inlinable
-    public func defaultDynamicResponse(
-        request: inout some HTTPRequestProtocol & ~Copyable,
-        responder: some DynamicRouteResponderProtocol
-    ) throws(ResponderError) -> some DynamicResponseProtocol {
-        var response = responder.defaultResponse()
-        var index = 0
-        let maximumParameters = responder.pathComponentsCount
-        responder.forEachPathComponentParameterIndex { parameterIndex in
-            request.path(at: parameterIndex).inlineVLArray {
-                response.setParameter(at: index, value: $0)
-            }
-            if responder.pathComponent(at: parameterIndex) == .catchall {
-                var i = parameterIndex+1
-                request.forEachPath(offset: i) { path in
-                    path.inlineVLArray {
-                        if i < maximumParameters {
-                            response.setParameter(at: i, value: $0)
-                        } else {
-                            response.appendParameter(value: $0)
-                        }
-                    }
-                    i += 1
-                }
-            }
-            index += 1
-        }
-        return response
-    }
-
-    @inlinable
-    public func respondDynamically(
-        socket: Int32,
-        request: inout some HTTPRequestProtocol & ~Copyable,
-        responder: some DynamicRouteResponderProtocol
-    ) throws(ResponderError) {
-        var response = try defaultDynamicResponse(request: &request, responder: responder)
-        try handleDynamicMiddleware(for: &request, with: &response)
-        try responder.respond(to: socket, request: &request, response: &response)
-    }
 }

--- a/Sources/DestinyBlueprint/middleware/dynamic/ExistentialDynamicMiddlewareProtocol.swift
+++ b/Sources/DestinyBlueprint/middleware/dynamic/ExistentialDynamicMiddlewareProtocol.swift
@@ -10,5 +10,5 @@ public protocol ExistentialDynamicMiddlewareProtocol: DynamicMiddlewareProtocol,
     func handle(
         request: inout any HTTPRequestProtocol,
         response: inout any DynamicResponseProtocol
-    ) async throws(MiddlewareError) -> Bool
+    ) throws(MiddlewareError) -> Bool
 }

--- a/Sources/DestinyBlueprint/middleware/dynamic/OpaqueDynamicMiddlewareProtocol.swift
+++ b/Sources/DestinyBlueprint/middleware/dynamic/OpaqueDynamicMiddlewareProtocol.swift
@@ -10,5 +10,5 @@ public protocol OpaqueDynamicMiddlewareProtocol: DynamicMiddlewareProtocol, ~Cop
     func handle(
         request: inout some HTTPRequestProtocol & ~Copyable,
         response: inout some DynamicResponseProtocol
-    ) async throws(MiddlewareError) -> Bool
+    ) throws(MiddlewareError) -> Bool
 }

--- a/Sources/DestinyBlueprint/responders/ConditionalRouteResponderProtocol.swift
+++ b/Sources/DestinyBlueprint/responders/ConditionalRouteResponderProtocol.swift
@@ -12,5 +12,5 @@ public protocol ConditionalRouteResponderProtocol: CustomDebugStringConvertible,
         router: some HTTPRouterProtocol,
         socket: Int32,
         request: inout some HTTPRequestProtocol & ~Copyable
-    ) async throws(ResponderError) -> Bool
+    ) throws(ResponderError) -> Bool
 }

--- a/Sources/DestinyBlueprint/responders/ConditionalRouteResponderProtocol.swift
+++ b/Sources/DestinyBlueprint/responders/ConditionalRouteResponderProtocol.swift
@@ -10,7 +10,7 @@ public protocol ConditionalRouteResponderProtocol: CustomDebugStringConvertible,
     /// - Returns: Whether or not a route responder responded to the request.
     func respond(
         router: some HTTPRouterProtocol,
-        socket: borrowing some HTTPSocketProtocol & ~Copyable,
+        socket: Int32,
         request: inout some HTTPRequestProtocol & ~Copyable
     ) async throws(ResponderError) -> Bool
 }

--- a/Sources/DestinyBlueprint/responders/DynamicRouteResponderProtocol.swift
+++ b/Sources/DestinyBlueprint/responders/DynamicRouteResponderProtocol.swift
@@ -25,5 +25,5 @@ public protocol DynamicRouteResponderProtocol: RouteResponderProtocol, ~Copyable
         to socket: Int32,
         request: inout some HTTPRequestProtocol & ~Copyable,
         response: inout some DynamicResponseProtocol
-    ) async throws(ResponderError)
+    ) throws(ResponderError)
 }

--- a/Sources/DestinyBlueprint/responders/DynamicRouteResponderProtocol.swift
+++ b/Sources/DestinyBlueprint/responders/DynamicRouteResponderProtocol.swift
@@ -22,7 +22,7 @@ public protocol DynamicRouteResponderProtocol: RouteResponderProtocol, ~Copyable
     ///   - request: The socket's request.
     ///   - response: The http message to send to the socket.
     func respond(
-        to socket: borrowing some HTTPSocketProtocol & ~Copyable,
+        to socket: Int32,
         request: inout some HTTPRequestProtocol & ~Copyable,
         response: inout some DynamicResponseProtocol
     ) async throws(ResponderError)

--- a/Sources/DestinyBlueprint/responders/ErrorResponderProtocol.swift
+++ b/Sources/DestinyBlueprint/responders/ErrorResponderProtocol.swift
@@ -9,5 +9,5 @@ public protocol ErrorResponderProtocol: RouteResponderProtocol, ~Copyable {
         error: some Error,
         request: inout some HTTPRequestProtocol & ~Copyable,
         logger: Logger
-    ) async
+    )
 }

--- a/Sources/DestinyBlueprint/responders/StaticRouteResponderProtocol.swift
+++ b/Sources/DestinyBlueprint/responders/StaticRouteResponderProtocol.swift
@@ -14,7 +14,7 @@ extension AsyncStream where Element: HTTPSocketWritable {
         to socket: borrowing some HTTPSocketProtocol & ~Copyable
     ) async throws(SocketError) {
         for await value in self {
-            try await value.write(to: socket)
+            try value.write(to: socket)
         }
     }
 }

--- a/Sources/DestinyBlueprint/responders/StaticRouteResponderProtocol.swift
+++ b/Sources/DestinyBlueprint/responders/StaticRouteResponderProtocol.swift
@@ -7,14 +7,3 @@ public protocol StaticRouteResponderProtocol: RouteResponderProtocol, HTTPSocket
 extension String: StaticRouteResponderProtocol {}
 extension StaticString: StaticRouteResponderProtocol {}
 extension [UInt8]: StaticRouteResponderProtocol {}
-
-extension AsyncStream where Element: HTTPSocketWritable {
-    @inlinable
-    public func write(
-        to socket: borrowing some HTTPSocketProtocol & ~Copyable
-    ) async throws(SocketError) {
-        for await value in self {
-            try value.write(to: socket)
-        }
-    }
-}

--- a/Sources/DestinyBlueprint/routes/RouteGroupProtocol.swift
+++ b/Sources/DestinyBlueprint/routes/RouteGroupProtocol.swift
@@ -7,5 +7,5 @@ public protocol RouteGroupProtocol: Sendable, ~Copyable {
         router: some HTTPRouterProtocol,
         socket: Int32,
         request: inout some HTTPRequestProtocol & ~Copyable
-    ) async throws(ResponderError) -> Bool
+    ) throws(ResponderError) -> Bool
 }

--- a/Sources/DestinyBlueprint/routes/RouteGroupProtocol.swift
+++ b/Sources/DestinyBlueprint/routes/RouteGroupProtocol.swift
@@ -5,7 +5,7 @@ public protocol RouteGroupProtocol: Sendable, ~Copyable {
     /// - Returns: Whether or not this router group responded to the request.
     func respond(
         router: some HTTPRouterProtocol,
-        socket: borrowing some HTTPSocketProtocol & ~Copyable,
+        socket: Int32,
         request: inout some HTTPRequestProtocol & ~Copyable
     ) async throws(ResponderError) -> Bool
 }

--- a/Sources/DestinyBlueprint/storage/RouteGroupStorageProtocol.swift
+++ b/Sources/DestinyBlueprint/storage/RouteGroupStorageProtocol.swift
@@ -6,7 +6,7 @@ public protocol RouteGroupStorageProtocol: Sendable, ~Copyable {
     /// - Returns: Whether or not a response was sent.
     func respond(
         router: some HTTPRouterProtocol,
-        socket: borrowing some HTTPSocketProtocol & ~Copyable,
+        socket: Int32,
         request: inout some HTTPRequestProtocol & ~Copyable
     ) async throws(ResponderError) -> Bool
 }

--- a/Sources/DestinyBlueprint/storage/RouteGroupStorageProtocol.swift
+++ b/Sources/DestinyBlueprint/storage/RouteGroupStorageProtocol.swift
@@ -8,5 +8,5 @@ public protocol RouteGroupStorageProtocol: Sendable, ~Copyable {
         router: some HTTPRouterProtocol,
         socket: Int32,
         request: inout some HTTPRequestProtocol & ~Copyable
-    ) async throws(ResponderError) -> Bool
+    ) throws(ResponderError) -> Bool
 }

--- a/Sources/DestinyBlueprint/storage/RouterResponderStorageProtocol.swift
+++ b/Sources/DestinyBlueprint/storage/RouterResponderStorageProtocol.swift
@@ -38,5 +38,5 @@ public protocol RouterResponderStorageProtocol: Sendable, ~Copyable {
         router: some HTTPRouterProtocol,
         socket: Int32,
         request: inout some HTTPRequestProtocol & ~Copyable,
-    ) async throws(ResponderError) -> Bool
+    ) throws(ResponderError) -> Bool
 }

--- a/Sources/DestinyBlueprint/storage/RouterResponderStorageProtocol.swift
+++ b/Sources/DestinyBlueprint/storage/RouterResponderStorageProtocol.swift
@@ -12,7 +12,7 @@ public protocol RouterResponderStorageProtocol: Sendable, ~Copyable {
         router: some HTTPRouterProtocol,
         socket: borrowing Int32,
         request: inout some HTTPRequestProtocol & ~Copyable
-    ) async throws(ResponderError) -> Bool
+    ) throws(ResponderError) -> Bool
 
     /// Try to write a response to a socket, only checking static storage.
     /// 

--- a/Sources/DestinyBlueprint/storage/RouterResponderStorageProtocol.swift
+++ b/Sources/DestinyBlueprint/storage/RouterResponderStorageProtocol.swift
@@ -10,7 +10,7 @@ public protocol RouterResponderStorageProtocol: Sendable, ~Copyable {
     /// - Returns: Whether or not a response was sent.
     func respond(
         router: some HTTPRouterProtocol,
-        socket: borrowing some HTTPSocketProtocol & ~Copyable,
+        socket: borrowing Int32,
         request: inout some HTTPRequestProtocol & ~Copyable
     ) async throws(ResponderError) -> Bool
 
@@ -23,9 +23,9 @@ public protocol RouterResponderStorageProtocol: Sendable, ~Copyable {
     /// - Returns: Whether or not a response was sent.
     func respondStatically(
         router: some HTTPRouterProtocol,
-        socket: borrowing some HTTPSocketProtocol & ~Copyable,
+        socket: Int32,
         startLine: SIMD64<UInt8>
-    ) async throws(ResponderError) -> Bool
+    ) throws(ResponderError) -> Bool
 
     /// Try to write a response to a socket, only checking dynamic storage.
     /// 
@@ -36,7 +36,7 @@ public protocol RouterResponderStorageProtocol: Sendable, ~Copyable {
     /// - Returns: Whether or not a response was sent.
     func respondDynamically(
         router: some HTTPRouterProtocol,
-        socket: borrowing some HTTPSocketProtocol & ~Copyable,
+        socket: Int32,
         request: inout some HTTPRequestProtocol & ~Copyable,
     ) async throws(ResponderError) -> Bool
 }

--- a/Sources/DestinyBlueprint/storage/dynamic/DynamicResponderStorageProtocol.swift
+++ b/Sources/DestinyBlueprint/storage/dynamic/DynamicResponderStorageProtocol.swift
@@ -10,7 +10,7 @@ public protocol DynamicResponderStorageProtocol: Sendable, ~Copyable {
     /// - Returns: Whether or not a response was sent.
     func respond(
         router: some HTTPRouterProtocol,
-        socket: borrowing some HTTPSocketProtocol & ~Copyable,
+        socket: Int32,
         request: inout some HTTPRequestProtocol & ~Copyable
     ) async throws(ResponderError) -> Bool
 }

--- a/Sources/DestinyBlueprint/storage/dynamic/DynamicResponderStorageProtocol.swift
+++ b/Sources/DestinyBlueprint/storage/dynamic/DynamicResponderStorageProtocol.swift
@@ -12,5 +12,5 @@ public protocol DynamicResponderStorageProtocol: Sendable, ~Copyable {
         router: some HTTPRouterProtocol,
         socket: Int32,
         request: inout some HTTPRequestProtocol & ~Copyable
-    ) async throws(ResponderError) -> Bool
+    ) throws(ResponderError) -> Bool
 }

--- a/Sources/DestinyBlueprint/storage/static/StaticResponderStorageProtocol.swift
+++ b/Sources/DestinyBlueprint/storage/static/StaticResponderStorageProtocol.swift
@@ -10,7 +10,7 @@ public protocol StaticResponderStorageProtocol: Sendable, ~Copyable {
     /// - Returns: Whether or not a response was sent.
     func respond(
         router: some HTTPRouterProtocol,
-        socket: borrowing some HTTPSocketProtocol & ~Copyable,
+        socket: Int32,
         startLine: SIMD64<UInt8>
-    ) async throws(ResponderError) -> Bool
+    ) throws(ResponderError) -> Bool
 }

--- a/Sources/DestinyDefaults/AsyncHTTPChunkDataStream.swift
+++ b/Sources/DestinyDefaults/AsyncHTTPChunkDataStream.swift
@@ -1,7 +1,7 @@
 
 import DestinyBlueprint
 
-public struct AsyncHTTPChunkDataStream<T: HTTPChunkDataProtocol>: HTTPSocketWritable {
+public struct AsyncHTTPChunkDataStream<T: HTTPChunkDataProtocol>: AsyncHTTPSocketWritable {
     public let chunkSize:Int
     public let stream:ReusableAsyncThrowingStream<T, Error> // TODO: fix
 
@@ -37,7 +37,7 @@ public struct AsyncHTTPChunkDataStream<T: HTTPChunkDataProtocol>: HTTPSocketWrit
 
     @inlinable
     public func write(
-        to socket: borrowing some HTTPSocketProtocol & ~Copyable
+        to socket: Int32
     ) async throws(SocketError) {
         // 20 = length in hexadecimal (16) + "\r\n".count * 2 (4)
         let buffer = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: 20 + chunkSize)
@@ -68,7 +68,7 @@ public struct AsyncHTTPChunkDataStream<T: HTTPChunkDataProtocol>: HTTPSocketWrit
                 i += 1
                 buffer[i] = .lineFeed
                 i += 1
-                try socket.writeBuffer(buffer.baseAddress!, length: i)
+                try socket.socketWriteBuffer(buffer.baseAddress!, length: i)
             }
             do throws(SocketError) {
                 buffer[0] = 48
@@ -76,7 +76,7 @@ public struct AsyncHTTPChunkDataStream<T: HTTPChunkDataProtocol>: HTTPSocketWrit
                 buffer[2] = .lineFeed
                 buffer[3] = .carriageReturn
                 buffer[4] = .lineFeed
-                try socket.writeBuffer(buffer.baseAddress!, length: 5)
+                try socket.socketWriteBuffer(buffer.baseAddress!, length: 5)
             } catch {
                 print("AsyncHTTPChunkDataStream;\(#function);error trying to send final chunk to stream") // TODO: use logger
                 err = error

--- a/Sources/DestinyDefaults/EpollProcessor.swift
+++ b/Sources/DestinyDefaults/EpollProcessor.swift
@@ -60,9 +60,10 @@ public struct EpollProcessor<let threads: Int, let maxEvents: Int, ConcreteSocke
         let cancelPipeFD = instance.pipeFileDescriptors[1]
         let logger = instance.logger
         let acceptClient = instance.acceptFunction(noTCPDelay: noTCPDelay)
+        var events = InlineArray<maxEvents, epoll_event>(repeating: .init())
         while !Task.isCancelled {
             do throws(EpollError) {
-                let (loaded, clients) = try instance.wait(timeout: timeout, acceptClient: acceptClient)
+                let (loaded, clients) = try instance.wait(timeout: timeout, acceptClient: acceptClient, events: &events)
                 var i = 0
                 while i < loaded {
                     let client = clients[i]

--- a/Sources/DestinyDefaults/HTTPResponseMessage.swift
+++ b/Sources/DestinyDefaults/HTTPResponseMessage.swift
@@ -269,12 +269,12 @@ extension HTTPResponseMessage {
 extension HTTPResponseMessage {
     @inlinable
     public func write(
-        to socket: borrowing some HTTPSocketProtocol & ~Copyable
-    ) async throws(SocketError) {
+        to socket: Int32
+    ) throws(SocketError) {
         var err:SocketError? = nil
         self.temporaryAllocation {
             do throws(SocketError) {
-                try socket.writeBuffer($0.baseAddress!, length: $0.count)
+                try socket.socketWriteBuffer($0.baseAddress!, length: $0.count)
             } catch {
                 err = error
             }

--- a/Sources/DestinyDefaults/HTTPResponseMessageHead.swift
+++ b/Sources/DestinyDefaults/HTTPResponseMessageHead.swift
@@ -37,11 +37,12 @@ public struct HTTPResponseMessageHead: Sendable {
     }
 
     @inlinable
-    public func cookieDescriptions<E: Error>(
-        _ closure: (inout InlineVLArray<String>) throws(E) -> Void
-    ) rethrows {
-        try InlineVLArray.create(amount: cookies.count, initialize: {
-            return "\(cookies[$0])"
-        }, closure)
+    public func cookieDescriptions() -> [String] {
+        var array = [String]()
+        array.reserveCapacity(cookies.count)
+        for cookie in cookies {
+            array.append("\(cookie)")
+        }
+        return array
     }
 }

--- a/Sources/DestinyDefaults/HTTPServer.swift
+++ b/Sources/DestinyDefaults/HTTPServer.swift
@@ -76,9 +76,7 @@ public final class HTTPServer<Router: HTTPRouterProtocol, ClientSocket: HTTPSock
 
     public func shutdown() {
         self.onShutdown?()
-        if let serverFD {
-            close(serverFD)
-        }
+        serverFD?.socketClose()
     }
 
     /// - Returns: The file descriptor of the created socket.
@@ -130,11 +128,11 @@ public final class HTTPServer<Router: HTTPRouterProtocol, ClientSocket: HTTPSock
             bind(serverFD, UnsafePointer<sockaddr>(OpaquePointer($0)), socklen_t(MemoryLayout<sockaddr_in6>.size))
         }
         if binded == -1 {
-            close(serverFD)
+            serverFD.socketClose()
             throw ServerError.bindFailed()
         }
         if listen(serverFD, backlog) == -1 {
-            close(serverFD)
+            serverFD.socketClose()
             throw ServerError.listenFailed()
         }
         logger.info("Listening for clients on http://\(address ?? "localhost"):\(port) [backlog=\(backlog), serverFD=\(serverFD)]")

--- a/Sources/DestinyDefaults/middleware/dynamic/DynamicCORSLogic.swift
+++ b/Sources/DestinyDefaults/middleware/dynamic/DynamicCORSLogic.swift
@@ -14,7 +14,7 @@ public enum DynamicCORSLogic: Sendable {
     @inlinable
     public func apply(
         to response: inout some DynamicResponseProtocol
-    ) async {
+    ) {
         switch self {
         case .allowCredentials_exposedHeaders_maxAge(let allowedHeaders, let allowedMethods, let exposedHeaders, let maxAge):
             DynamicCORSMiddleware.logic_allowCredentials_exposedHeaders_maxAge(&response, allowedHeaders, allowedMethods, exposedHeaders, maxAge)

--- a/Sources/DestinyDefaults/middleware/dynamic/DynamicCORSMiddleware.swift
+++ b/Sources/DestinyDefaults/middleware/dynamic/DynamicCORSMiddleware.swift
@@ -71,10 +71,10 @@ public struct DynamicCORSMiddleware: CORSMiddlewareProtocol, OpaqueDynamicMiddle
     public func handle(
         request: inout some HTTPRequestProtocol & ~Copyable,
         response: inout some DynamicResponseProtocol
-    ) async throws(MiddlewareError) -> Bool {
+    ) throws(MiddlewareError) -> Bool {
         guard request.header(forKey: "Origin") != nil else { return true }
         allowedOrigin.apply(request: &request, response: &response)
-        await logicKind.apply(to: &response)
+        logicKind.apply(to: &response)
         return true
     }
 }

--- a/Sources/DestinyDefaults/middleware/dynamic/DynamicDateMiddleware.swift
+++ b/Sources/DestinyDefaults/middleware/dynamic/DynamicDateMiddleware.swift
@@ -10,7 +10,7 @@ public struct DynamicDateMiddleware: OpaqueDynamicMiddlewareProtocol {
     public func handle(
         request: inout some HTTPRequestProtocol & ~Copyable,
         response: inout some DynamicResponseProtocol
-    ) async -> Bool {
+    ) -> Bool {
         response.setHeader(key: "Date", value: HTTPDateFormat.nowInlineArray.string())
         return true
     }

--- a/Sources/DestinyDefaults/middleware/dynamic/DynamicMiddleware.swift
+++ b/Sources/DestinyDefaults/middleware/dynamic/DynamicMiddleware.swift
@@ -3,11 +3,11 @@ import DestinyBlueprint
 
 /// Default Dynamic Middleware implementation which handles requests to dynamic routes.
 public struct DynamicMiddleware: ExistentialDynamicMiddlewareProtocol {
-    public let handleLogic:@Sendable (_ request: inout any HTTPRequestProtocol, _ response: inout any DynamicResponseProtocol) async throws(MiddlewareError) -> Void
+    public let handleLogic:@Sendable (_ request: inout any HTTPRequestProtocol, _ response: inout any DynamicResponseProtocol) throws(MiddlewareError) -> Void
     package var logic:String = "{ _, _ in }"
 
     public init(
-        _ handleLogic: @Sendable @escaping (_ request: inout any HTTPRequestProtocol, _ response: inout any DynamicResponseProtocol) async throws(MiddlewareError) -> Void
+        _ handleLogic: @Sendable @escaping (_ request: inout any HTTPRequestProtocol, _ response: inout any DynamicResponseProtocol) throws(MiddlewareError) -> Void
     ) {
         self.handleLogic = handleLogic
     }
@@ -16,8 +16,8 @@ public struct DynamicMiddleware: ExistentialDynamicMiddlewareProtocol {
     public func handle(
         request: inout any HTTPRequestProtocol,
         response: inout any DynamicResponseProtocol
-    ) async throws(MiddlewareError) -> Bool {
-        try await handleLogic(&request, &response)
+    ) throws(MiddlewareError) -> Bool {
+        try handleLogic(&request, &response)
         return true
     }
 

--- a/Sources/DestinyDefaults/middleware/dynamic/DynamicRateLimitMiddleware.swift
+++ b/Sources/DestinyDefaults/middleware/dynamic/DynamicRateLimitMiddleware.swift
@@ -13,7 +13,7 @@ public final class DynamicRateLimitMiddleware: RateLimitMiddlewareProtocol, Opaq
     public func handle(
         request: inout some HTTPRequestProtocol & ~Copyable,
         response: inout some DynamicResponseProtocol
-    ) async throws(MiddlewareError) -> Bool {
+    ) throws(MiddlewareError) -> Bool {
         return true
     }
 }

--- a/Sources/DestinyDefaults/middleware/dynamic/ExistentialDynamicMiddleware.swift
+++ b/Sources/DestinyDefaults/middleware/dynamic/ExistentialDynamicMiddleware.swift
@@ -3,11 +3,11 @@ import DestinyBlueprint
 
 /// Default Existential Dynamic Middleware implementation which handles requests to dynamic routes.
 public struct ExistentialDynamicMiddleware: ExistentialDynamicMiddlewareProtocol {
-    public let handleLogic:@Sendable (_ request: inout any HTTPRequestProtocol, _ response: inout any DynamicResponseProtocol) async throws(MiddlewareError) -> Void
+    public let handleLogic:@Sendable (_ request: inout any HTTPRequestProtocol, _ response: inout any DynamicResponseProtocol) throws(MiddlewareError) -> Void
     package var logic:String = "{ _, _ in }"
 
     public init(
-        _ handleLogic: @Sendable @escaping (_ request: inout any HTTPRequestProtocol, _ response: inout any DynamicResponseProtocol) async throws(MiddlewareError) -> Void
+        _ handleLogic: @Sendable @escaping (_ request: inout any HTTPRequestProtocol, _ response: inout any DynamicResponseProtocol) throws(MiddlewareError) -> Void
     ) {
         self.handleLogic = handleLogic
     }
@@ -16,8 +16,8 @@ public struct ExistentialDynamicMiddleware: ExistentialDynamicMiddlewareProtocol
     public func handle(
         request: inout any HTTPRequestProtocol,
         response: inout any DynamicResponseProtocol
-    ) async throws(MiddlewareError) -> Bool {
-        try await handleLogic(&request, &response)
+    ) throws(MiddlewareError) -> Bool {
+        try handleLogic(&request, &response)
         return true
     }
 

--- a/Sources/DestinyDefaults/router/CompiledHTTPRouter.swift
+++ b/Sources/DestinyDefaults/router/CompiledHTTPRouter.swift
@@ -2,12 +2,6 @@
 import DestinyBlueprint
 import Logging
 
-#if canImport(SwiftGlibc)
-import SwiftGlibc
-#elseif canImport(Foundation)
-import Foundation
-#endif
-
 /// Default HTTP Router implementation that optimally handles immutable and mutable middleware, routes and route groups.
 public final class CompiledHTTPRouter<
         ImmutableRouter: HTTPRouterProtocol,
@@ -53,12 +47,7 @@ extension CompiledHTTPRouter {
     ) {
         Task {
             defer {
-                #if canImport(SwiftGlibc) || canImport(Foundation)
-                shutdown(client, Int32(SHUT_RDWR)) // shutdown read and write (https://www.gnu.org/software/libc/manual/html_node/Closing-a-Socket.html)
-                close(client)
-                #else
-                #warning("Unable to shutdown and close client file descriptor!")
-                #endif
+                client.socketClose()
             }
             do throws(SocketError) {
                 var request = try socket.loadRequest()

--- a/Sources/DestinyDefaults/router/CompiledHTTPRouter.swift
+++ b/Sources/DestinyDefaults/router/CompiledHTTPRouter.swift
@@ -4,9 +4,9 @@ import Logging
 
 /// Default HTTP Router implementation that optimally handles immutable and mutable middleware, routes and route groups.
 public final class CompiledHTTPRouter<
-        ImmutableRouter: HTTPRouterProtocol,
-        MutableRouter: HTTPMutableRouterProtocol
-    >: HTTPMutableRouterProtocol {
+        ImmutableRouter: DestinyHTTPRouterProtocol,
+        MutableRouter: DestinyHTTPMutableRouterProtocol
+    >: DestinyHTTPMutableRouterProtocol {
     public let immutable:ImmutableRouter
     public let mutable:MutableRouter
     

--- a/Sources/DestinyDefaults/router/CompiledHTTPRouter.swift
+++ b/Sources/DestinyDefaults/router/CompiledHTTPRouter.swift
@@ -66,7 +66,7 @@ extension CompiledHTTPRouter {
                 logger.info("\(request.startLine.stringSIMD())")
                 #endif
                 do throws(ResponderError) {
-                    if !(try await respond(client: client, socket: socket, request: &request, logger: logger)) {
+                    if !(try await respond(socket: client, request: &request, logger: logger)) {
                         // TODO: not found
                     }
                 } catch {
@@ -83,15 +83,14 @@ extension CompiledHTTPRouter {
 extension CompiledHTTPRouter {
     @inlinable
     public func respond(
-        client: Int32,
-        socket: borrowing some HTTPSocketProtocol & ~Copyable,
+        socket: Int32,
         request: inout some HTTPRequestProtocol & ~Copyable,
         logger: Logger
     ) async throws(ResponderError) -> Bool {
-        if try await immutable.respond(client: client, socket: socket, request: &request, logger: logger) {
+        if try await immutable.respond(socket: socket, request: &request, logger: logger) {
             return true
         }
-        if try await mutable.respond(client: client, socket: socket, request: &request, logger: logger) {
+        if try await mutable.respond(socket: socket, request: &request, logger: logger) {
             return true
         }
         return false

--- a/Sources/DestinyDefaults/router/DestinyHTTPMutableRouterProtocol.swift
+++ b/Sources/DestinyDefaults/router/DestinyHTTPMutableRouterProtocol.swift
@@ -1,0 +1,5 @@
+
+import DestinyBlueprint
+
+public protocol DestinyHTTPMutableRouterProtocol: DestinyHTTPRouterProtocol, HTTPMutableRouterProtocol {
+}

--- a/Sources/DestinyDefaults/router/DestinyHTTPRouterProtocol.swift
+++ b/Sources/DestinyDefaults/router/DestinyHTTPRouterProtocol.swift
@@ -1,0 +1,81 @@
+
+import DestinyBlueprint
+import Logging
+
+public protocol DestinyHTTPRouterProtocol: HTTPRouterProtocol, ~Copyable {
+    /// Handle dynamic middleware for a given request and dynamic response.
+    func handleDynamicMiddleware(
+        for request: inout some HTTPRequestProtocol & ~Copyable,
+        with response: inout some DynamicResponseProtocol
+    ) throws(ResponderError)
+
+    /// Responds to a socket.
+    /// 
+    /// - Parameters:
+    ///   - socket: File descriptor assigned to the socket.
+    ///   - request: A loaded request for the socket.
+    ///   - logger: Logger of the socket acceptor that called this function.
+    /// 
+    /// - Returns: Whether or not a response was sent.
+    func respond(
+        socket: Int32,
+        request: inout some HTTPRequestProtocol & ~Copyable,
+        logger: Logger
+    ) throws(ResponderError) -> Bool
+}
+
+// MARK: Defaults
+extension DestinyHTTPRouterProtocol {
+    @inlinable
+    public func respondStatically(
+        socket: Int32,
+        responder: borrowing some StaticRouteResponderProtocol
+    ) throws(ResponderError) {
+        do throws(SocketError) {
+            try responder.write(to: socket)
+        } catch {
+            throw .socketError(error)
+        }
+    }
+
+    @inlinable
+    public func defaultDynamicResponse(
+        request: inout some HTTPRequestProtocol & ~Copyable,
+        responder: some DynamicRouteResponderProtocol
+    ) throws(ResponderError) -> some DynamicResponseProtocol {
+        var response = responder.defaultResponse()
+        var index = 0
+        let maximumParameters = responder.pathComponentsCount
+        responder.forEachPathComponentParameterIndex { parameterIndex in
+            request.path(at: parameterIndex).inlineVLArray {
+                response.setParameter(at: index, value: $0)
+            }
+            if responder.pathComponent(at: parameterIndex) == .catchall {
+                var i = parameterIndex+1
+                request.forEachPath(offset: i) { path in
+                    path.inlineVLArray {
+                        if i < maximumParameters {
+                            response.setParameter(at: i, value: $0)
+                        } else {
+                            response.appendParameter(value: $0)
+                        }
+                    }
+                    i += 1
+                }
+            }
+            index += 1
+        }
+        return response
+    }
+
+    @inlinable
+    public func respondDynamically(
+        socket: Int32,
+        request: inout some HTTPRequestProtocol & ~Copyable,
+        responder: some DynamicRouteResponderProtocol
+    ) throws(ResponderError) {
+        var response = try defaultDynamicResponse(request: &request, responder: responder)
+        try handleDynamicMiddleware(for: &request, with: &response)
+        try responder.respond(to: socket, request: &request, response: &response)
+    }
+}

--- a/Sources/DestinyDefaults/router/HTTPRouter.swift
+++ b/Sources/DestinyDefaults/router/HTTPRouter.swift
@@ -11,7 +11,7 @@ public final class HTTPRouter<
         ErrorResponder: ErrorResponderProtocol,
         DynamicNotFoundResponder: DynamicRouteResponderProtocol,
         StaticNotFoundResponder: StaticRouteResponderProtocol
-    >: HTTPMutableRouterProtocol {
+    >: DestinyHTTPMutableRouterProtocol {
     public let caseSensitiveResponders:CaseSensitiveRouterResponderStorage
     public let caseInsensitiveResponders:CaseInsensitiveRouterResponderStorage
 

--- a/Sources/DestinyDefaults/router/HTTPRouter.swift
+++ b/Sources/DestinyDefaults/router/HTTPRouter.swift
@@ -107,7 +107,7 @@ extension HTTPRouter {
                         try await dynamicNotFoundResponder.respond(to: socket, request: &request, response: &response)
                     } else if let staticNotFoundResponder {
                         do throws(SocketError) {
-                            try await staticNotFoundResponder.write(to: socket)
+                            try staticNotFoundResponder.write(to: socket)
                         } catch {
                             throw .socketError(error)
                         }

--- a/Sources/DestinyDefaults/router/HTTPRouter.swift
+++ b/Sources/DestinyDefaults/router/HTTPRouter.swift
@@ -58,10 +58,10 @@ extension HTTPRouter {
     public func handleDynamicMiddleware(
         for request: inout some HTTPRequestProtocol & ~Copyable,
         with response: inout some DynamicResponseProtocol
-    ) async throws(ResponderError) {
+    ) throws(ResponderError) {
         for middleware in opaqueDynamicMiddleware {
             do throws(MiddlewareError) {
-                if try await !middleware.handle(request: &request, response: &response) {
+                if try !middleware.handle(request: &request, response: &response) {
                     break
                 }
             } catch {
@@ -79,37 +79,32 @@ extension HTTPRouter {
         socket: consuming some HTTPSocketProtocol & ~Copyable,
         logger: Logger
     ) {
-        Task {
-            defer {
-                client.socketClose()
-            }
-            do throws(SocketError) {
-                var request = try socket.loadRequest()
-                #if DEBUG
-                logger.info("\(request.startLine.stringSIMD())")
-                #endif
-                do throws(ResponderError) {
-                    guard !(try await respond(socket: client, request: &request, logger: logger)) else { return }
-                    // not found
-                    if let dynamicNotFoundResponder {
-                        var response = try await defaultDynamicResponse(request: &request, responder: dynamicNotFoundResponder)
-                        try await dynamicNotFoundResponder.respond(to: client, request: &request, response: &response)
-                    } else if let staticNotFoundResponder {
-                        do throws(SocketError) {
-                            try staticNotFoundResponder.write(to: socket)
-                        } catch {
-                            throw .socketError(error)
-                        }
-                    }
-                } catch {
-                    logger.warning("Encountered error while processing client: \(error)")
-                    if let errorResponder {
-                        await errorResponder.respond(socket: socket, error: error, request: &request, logger: logger)
+        do throws(SocketError) {
+            var request = try socket.loadRequest()
+            #if DEBUG
+            logger.info("\(request.startLine.stringSIMD())")
+            #endif
+            do throws(ResponderError) {
+                guard !(try respond(socket: client, request: &request, logger: logger)) else { return }
+                // not found
+                if let dynamicNotFoundResponder {
+                    var response = try defaultDynamicResponse(request: &request, responder: dynamicNotFoundResponder)
+                    try dynamicNotFoundResponder.respond(to: client, request: &request, response: &response)
+                } else if let staticNotFoundResponder {
+                    do throws(SocketError) {
+                        try staticNotFoundResponder.write(to: socket)
+                    } catch {
+                        throw .socketError(error)
                     }
                 }
             } catch {
-                logger.warning("Encountered error while loading request: \(error)")
+                logger.warning("Encountered error while processing client: \(error)")
+                if let errorResponder {
+                    errorResponder.respond(socket: socket, error: error, request: &request, logger: logger)
+                }
             }
+        } catch {
+            logger.warning("Encountered error while loading request: \(error)")
         }
     }
 }
@@ -121,13 +116,13 @@ extension HTTPRouter {
         socket: Int32,
         request: inout some HTTPRequestProtocol & ~Copyable,
         logger: Logger
-    ) async throws(ResponderError) -> Bool {
+    ) throws(ResponderError) -> Bool {
         if try caseSensitiveResponders.respondStatically(router: self, socket: socket, startLine: request.startLine) {
         } else if try caseInsensitiveResponders.respondStatically(router: self, socket: socket, startLine: request.startLineLowercased()) {
-        } else if try await caseSensitiveResponders.respondDynamically(router: self, socket: socket, request: &request) {
-        } else if try await caseInsensitiveResponders.respondDynamically(router: self, socket: socket, request: &request) { // TODO: support
+        } else if try caseSensitiveResponders.respondDynamically(router: self, socket: socket, request: &request) {
+        } else if try caseInsensitiveResponders.respondDynamically(router: self, socket: socket, request: &request) { // TODO: support
         } else {
-            return try await routeGroups.respond(router: self, socket: socket, request: &request)
+            return try routeGroups.respond(router: self, socket: socket, request: &request)
         }
         return true
     }

--- a/Sources/DestinyDefaults/router/ImmutableHTTPRouter.swift
+++ b/Sources/DestinyDefaults/router/ImmutableHTTPRouter.swift
@@ -96,11 +96,11 @@ extension ImmutableHTTPRouter {
                 logger.info("\(request.startLine.stringSIMD())")
                 #endif
                 do throws(ResponderError) {
-                    guard !(try await respond(client: client, socket: socket, request: &request, logger: logger)) else { return }
+                    guard !(try await respond(socket: client, request: &request, logger: logger)) else { return }
                     // not found
                     if let dynamicNotFoundResponder {
                         var response = try await defaultDynamicResponse(request: &request, responder: dynamicNotFoundResponder)
-                        try await dynamicNotFoundResponder.respond(to: socket, request: &request, response: &response)
+                        try await dynamicNotFoundResponder.respond(to: client, request: &request, response: &response)
                     } else if let staticNotFoundResponder {
                         do throws(SocketError) {
                             try staticNotFoundResponder.write(to: socket)
@@ -125,13 +125,16 @@ extension ImmutableHTTPRouter {
 extension ImmutableHTTPRouter {
     @inlinable
     public func respond(
-        client: Int32,
-        socket: borrowing some HTTPSocketProtocol & ~Copyable,
+        socket: Int32,
         request: inout some HTTPRequestProtocol & ~Copyable,
         logger: Logger
     ) async throws(ResponderError) -> Bool {
-        if try await caseSensitiveResponders.respondStatically(router: self, socket: socket, startLine: request.startLine) {
-        } else if try await caseInsensitiveResponders.respondStatically(router: self, socket: socket, startLine: request.startLineLowercased()) {
+        if try caseSensitiveResponders.respondStatically(router: self, socket: socket, startLine: request.startLine) {
+            socket.socketClose()
+            return true
+        } else if try caseInsensitiveResponders.respondStatically(router: self, socket: socket, startLine: request.startLineLowercased()) {
+            socket.socketClose()
+            return true
         } else if try await caseSensitiveResponders.respondDynamically(router: self, socket: socket, request: &request) {
         } else if try await caseInsensitiveResponders.respondDynamically(router: self, socket: socket, request: &request) { // TODO: support
         } else {

--- a/Sources/DestinyDefaults/router/ImmutableHTTPRouter.swift
+++ b/Sources/DestinyDefaults/router/ImmutableHTTPRouter.swift
@@ -10,7 +10,7 @@ public struct ImmutableHTTPRouter<
         ErrorResponder: ErrorResponderProtocol,
         DynamicNotFoundResponder: DynamicRouteResponderProtocol,
         StaticNotFoundResponder: StaticRouteResponderProtocol
-    >: HTTPRouterProtocol {
+    >: DestinyHTTPRouterProtocol {
     public let caseSensitiveResponders:CaseSensitiveRouterResponderStorage
     public let caseInsensitiveResponders:CaseInsensitiveRouterResponderStorage
 

--- a/Sources/DestinyDefaults/router/ImmutableHTTPRouter.swift
+++ b/Sources/DestinyDefaults/router/ImmutableHTTPRouter.swift
@@ -103,7 +103,7 @@ extension ImmutableHTTPRouter {
                         try await dynamicNotFoundResponder.respond(to: socket, request: &request, response: &response)
                     } else if let staticNotFoundResponder {
                         do throws(SocketError) {
-                            try await staticNotFoundResponder.write(to: socket)
+                            try staticNotFoundResponder.write(to: socket)
                         } catch {
                             throw .socketError(error)
                         }

--- a/Sources/DestinyDefaults/routes/ConditionalRouteResponder.swift
+++ b/Sources/DestinyDefaults/routes/ConditionalRouteResponder.swift
@@ -41,7 +41,7 @@ public struct ConditionalRouteResponder: ConditionalRouteResponderProtocol {
         router: some HTTPRouterProtocol,
         socket: Int32,
         request: inout some HTTPRequestProtocol & ~Copyable
-    ) async throws(ResponderError) -> Bool {
+    ) throws(ResponderError) -> Bool {
         // TODO: fix
         /*
         var request:any HTTPRequestProtocol = request

--- a/Sources/DestinyDefaults/routes/ConditionalRouteResponder.swift
+++ b/Sources/DestinyDefaults/routes/ConditionalRouteResponder.swift
@@ -39,7 +39,7 @@ public struct ConditionalRouteResponder: ConditionalRouteResponderProtocol {
     @inlinable
     public func respond(
         router: some HTTPRouterProtocol,
-        socket: borrowing some HTTPSocketProtocol & ~Copyable,
+        socket: Int32,
         request: inout some HTTPRequestProtocol & ~Copyable
     ) async throws(ResponderError) -> Bool {
         // TODO: fix

--- a/Sources/DestinyDefaults/routes/DynamicResponse.swift
+++ b/Sources/DestinyDefaults/routes/DynamicResponse.swift
@@ -65,8 +65,8 @@ extension DynamicResponse {
 
     @inlinable
     public func write(
-        to socket: borrowing some HTTPSocketProtocol & ~Copyable
-    ) async throws(SocketError) {
-        try await message.write(to: socket)
+        to socket: Int32
+    ) throws(SocketError) {
+        try message.write(to: socket)
     }
 }

--- a/Sources/DestinyDefaults/routes/DynamicRouteResponder.swift
+++ b/Sources/DestinyDefaults/routes/DynamicRouteResponder.swift
@@ -59,13 +59,18 @@ public struct DynamicRouteResponder: DynamicRouteResponderProtocol, CustomDebugS
         to socket: Int32,
         request: inout some HTTPRequestProtocol & ~Copyable,
         response: inout some DynamicResponseProtocol
-    ) async throws(ResponderError) {
+    ) throws(ResponderError) {
         // TODO: fix
         //try await logic(&anyRequest, &anyResponse)
+        var err:ResponderError? = nil
         do throws(SocketError) {
             try response.write(to: socket)
         } catch {
-            throw .socketError(error)
+            err = .socketError(error)
+        }
+        socket.socketClose()
+        if let err {
+            throw err
         }
     }
 }

--- a/Sources/DestinyDefaults/routes/DynamicRouteResponder.swift
+++ b/Sources/DestinyDefaults/routes/DynamicRouteResponder.swift
@@ -56,7 +56,7 @@ public struct DynamicRouteResponder: DynamicRouteResponderProtocol, CustomDebugS
 
     @inlinable
     public func respond(
-        to socket: borrowing some HTTPSocketProtocol & ~Copyable,
+        to socket: Int32,
         request: inout some HTTPRequestProtocol & ~Copyable,
         response: inout some DynamicResponseProtocol
     ) async throws(ResponderError) {

--- a/Sources/DestinyDefaults/routes/DynamicRouteResponder.swift
+++ b/Sources/DestinyDefaults/routes/DynamicRouteResponder.swift
@@ -63,7 +63,7 @@ public struct DynamicRouteResponder: DynamicRouteResponderProtocol, CustomDebugS
         // TODO: fix
         //try await logic(&anyRequest, &anyResponse)
         do throws(SocketError) {
-            try await response.write(to: socket)
+            try response.write(to: socket)
         } catch {
             throw .socketError(error)
         }

--- a/Sources/DestinyDefaults/routes/RouteGroup.swift
+++ b/Sources/DestinyDefaults/routes/RouteGroup.swift
@@ -43,10 +43,10 @@ extension RouteGroup {
     @inlinable
     public func respond(
         router: some HTTPRouterProtocol,
-        socket: borrowing some HTTPSocketProtocol & ~Copyable,
+        socket: Int32,
         request: inout some HTTPRequestProtocol & ~Copyable
     ) async throws(ResponderError) -> Bool {
-        if try await staticResponses.respond(router: router, socket: socket, startLine: request.startLine) {
+        if try staticResponses.respond(router: router, socket: socket, startLine: request.startLine) {
             return true
         } else if let responder = dynamicResponses.responder(for: &request) {
             try await router.respondDynamically(socket: socket, request: &request, responder: responder)

--- a/Sources/DestinyDefaults/routes/RouteGroup.swift
+++ b/Sources/DestinyDefaults/routes/RouteGroup.swift
@@ -45,11 +45,11 @@ extension RouteGroup {
         router: some HTTPRouterProtocol,
         socket: Int32,
         request: inout some HTTPRequestProtocol & ~Copyable
-    ) async throws(ResponderError) -> Bool {
+    ) throws(ResponderError) -> Bool {
         if try staticResponses.respond(router: router, socket: socket, startLine: request.startLine) {
             return true
         } else if let responder = dynamicResponses.responder(for: &request) {
-            try await router.respondDynamically(socket: socket, request: &request, responder: responder)
+            try router.respondDynamically(socket: socket, request: &request, responder: responder)
             return true
         } else {
             return false

--- a/Sources/DestinyDefaults/routes/StaticErrorResponder.swift
+++ b/Sources/DestinyDefaults/routes/StaticErrorResponder.swift
@@ -21,7 +21,7 @@ public struct StaticErrorResponder: ErrorResponderProtocol {
         logger.warning("\(error)")
         #endif
         do throws(SocketError) {
-            try await logic(error).write(to: socket)
+            try logic(error).write(to: socket)
         } catch {
             // TODO: do something
         }

--- a/Sources/DestinyDefaults/routes/StaticErrorResponder.swift
+++ b/Sources/DestinyDefaults/routes/StaticErrorResponder.swift
@@ -16,7 +16,7 @@ public struct StaticErrorResponder: ErrorResponderProtocol {
         error: some Error,
         request: inout some HTTPRequestProtocol & ~Copyable,
         logger: Logger
-    ) async {
+    ) {
         #if DEBUG
         logger.warning("\(error)")
         #endif

--- a/Sources/DestinyDefaults/routes/compiled/CompiledRouteGroup.swift
+++ b/Sources/DestinyDefaults/routes/compiled/CompiledRouteGroup.swift
@@ -47,14 +47,14 @@ extension CompiledRouteGroup {
         router: some HTTPRouterProtocol,
         socket: Int32,
         request: inout some HTTPRequestProtocol & ~Copyable
-    ) async throws(ResponderError) -> Bool {
+    ) throws(ResponderError) -> Bool {
         if try immutableStaticResponders.respond(router: router, socket: socket, startLine: request.startLine) {
             return true
         } else if try mutableStaticResponders.respond(router: router, socket: socket, startLine: request.startLine) {
             return true
-        } else if try await immutableDynamicResponders.respond(router: router, socket: socket, request: &request) {
+        } else if try immutableDynamicResponders.respond(router: router, socket: socket, request: &request) {
             return true
-        } else if try await mutableDynamicResponders.respond(router: router, socket: socket, request: &request) {
+        } else if try mutableDynamicResponders.respond(router: router, socket: socket, request: &request) {
             return true
         } else {
             return false

--- a/Sources/DestinyDefaults/routes/compiled/CompiledRouteGroup.swift
+++ b/Sources/DestinyDefaults/routes/compiled/CompiledRouteGroup.swift
@@ -45,12 +45,12 @@ extension CompiledRouteGroup {
     @inlinable
     public func respond(
         router: some HTTPRouterProtocol,
-        socket: borrowing some HTTPSocketProtocol & ~Copyable,
+        socket: Int32,
         request: inout some HTTPRequestProtocol & ~Copyable
     ) async throws(ResponderError) -> Bool {
-        if try await immutableStaticResponders.respond(router: router, socket: socket, startLine: request.startLine) {
+        if try immutableStaticResponders.respond(router: router, socket: socket, startLine: request.startLine) {
             return true
-        } else if try await mutableStaticResponders.respond(router: router, socket: socket, startLine: request.startLine) {
+        } else if try mutableStaticResponders.respond(router: router, socket: socket, startLine: request.startLine) {
             return true
         } else if try await immutableDynamicResponders.respond(router: router, socket: socket, request: &request) {
             return true

--- a/Sources/DestinyDefaults/routes/responses/MacroExpansionWithDateHeader.swift
+++ b/Sources/DestinyDefaults/routes/responses/MacroExpansionWithDateHeader.swift
@@ -29,8 +29,8 @@ public struct MacroExpansionWithDateHeader {
 extension MacroExpansionWithDateHeader: StaticRouteResponderProtocol {
     @inlinable
     public func write(
-        to socket: borrowing some HTTPSocketProtocol & ~Copyable
-    ) async throws(SocketError) {
+        to socket: Int32
+    ) throws(SocketError) {
         var err:SocketError? = nil
         preDateValue.withUTF8Buffer { preDatePointer in
             HTTPDateFormat.nowInlineArray.span.withUnsafeBufferPointer { datePointer in
@@ -40,7 +40,7 @@ extension MacroExpansionWithDateHeader: StaticRouteResponderProtocol {
                         bodyCountSuffix.span.withUnsafeBufferPointer { bodyCountSuffixPointer in
                             body.withContiguousStorageIfAvailable { bodyPointer in
                                 do throws(SocketError) {
-                                    try socket.writeBuffers([
+                                    try socket.socketWriteBuffers([
                                         preDatePointer,
                                         datePointer,
                                         postDatePointer,

--- a/Sources/DestinyDefaults/routes/responses/MacroExpansionWithDateHeader.swift
+++ b/Sources/DestinyDefaults/routes/responses/MacroExpansionWithDateHeader.swift
@@ -57,6 +57,7 @@ extension MacroExpansionWithDateHeader: StaticRouteResponderProtocol {
                 }
             }
         }
+        socket.socketClose()
         if let err {
             throw err
         }

--- a/Sources/DestinyDefaults/routes/responses/RouteResponses+MacroExpansion.swift
+++ b/Sources/DestinyDefaults/routes/responses/RouteResponses+MacroExpansion.swift
@@ -15,8 +15,8 @@ extension RouteResponses {
 
         @inlinable
         public func write(
-            to socket: borrowing some HTTPSocketProtocol & ~Copyable
-        ) async throws(SocketError) {
+            to socket: Int32
+        ) throws(SocketError) {
             var err:SocketError? = nil
             value.withUTF8Buffer { valuePointer in
                 bodyCount.withContiguousStorageIfAvailable { bodyCountPointer in
@@ -24,7 +24,7 @@ extension RouteResponses {
                         let bodyCountSuffix:InlineArray<4, UInt8> = [.carriageReturn, .lineFeed, .carriageReturn, .lineFeed]
                         bodyCountSuffix.span.withUnsafeBufferPointer { bodyCountSuffixPointer in
                             do throws(SocketError) {
-                                try socket.writeBuffers([
+                                try socket.socketWriteBuffers([
                                     valuePointer,
                                     bodyCountPointer,
                                     bodyCountSuffixPointer,

--- a/Sources/DestinyDefaults/routes/responses/RouteResponses+MacroExpansion.swift
+++ b/Sources/DestinyDefaults/routes/responses/RouteResponses+MacroExpansion.swift
@@ -30,7 +30,6 @@ extension RouteResponses {
                                     bodyCountSuffixPointer,
                                     bodyPointer
                                 ])
-                                return
                             } catch {
                                 err = error
                             }
@@ -38,6 +37,7 @@ extension RouteResponses {
                     }
                 }
             }
+            socket.socketClose()
             if let err {
                 throw err
             }

--- a/Sources/DestinyDefaults/routes/results/ResponseBody+Bytes.swift
+++ b/Sources/DestinyDefaults/routes/results/ResponseBody+Bytes.swift
@@ -41,8 +41,8 @@ extension ResponseBody {
 extension ResponseBody.Bytes: StaticRouteResponderProtocol {
     @inlinable
     public func write(
-        to socket: borrowing some HTTPSocketProtocol & ~Copyable
-    ) async throws(SocketError) {
-        try await value.write(to: socket)
+        to socket: Int32
+    ) throws(SocketError) {
+        try value.write(to: socket)
     }
 }

--- a/Sources/DestinyDefaults/routes/results/ResponseBody+Bytes.swift
+++ b/Sources/DestinyDefaults/routes/results/ResponseBody+Bytes.swift
@@ -43,6 +43,15 @@ extension ResponseBody.Bytes: StaticRouteResponderProtocol {
     public func write(
         to socket: Int32
     ) throws(SocketError) {
-        try value.write(to: socket)
+        var err:SocketError? = nil
+        do throws(SocketError) {
+            try value.write(to: socket)
+        } catch {
+            err = error
+        }
+        socket.socketClose()
+        if let err {
+            throw err
+        }
     }
 }

--- a/Sources/DestinyDefaults/routes/results/ResponseBody+InlineBytes.swift
+++ b/Sources/DestinyDefaults/routes/results/ResponseBody+InlineBytes.swift
@@ -49,6 +49,15 @@ extension ResponseBody.InlineBytes: StaticRouteResponderProtocol {
     public func write(
         to socket: Int32
     ) throws(SocketError) {
-        try value.write(to: socket)
+        var err:SocketError? = nil
+        do throws(SocketError) {
+            try value.write(to: socket)
+        } catch {
+            err = error
+        }
+        socket.socketClose()
+        if let err {
+            throw err
+        }
     }
 }

--- a/Sources/DestinyDefaults/routes/results/ResponseBody+InlineBytes.swift
+++ b/Sources/DestinyDefaults/routes/results/ResponseBody+InlineBytes.swift
@@ -47,8 +47,8 @@ extension ResponseBody {
 extension ResponseBody.InlineBytes: StaticRouteResponderProtocol {
     @inlinable
     public func write(
-        to socket: borrowing some HTTPSocketProtocol & ~Copyable
-    ) async throws(SocketError) {
-        try await value.write(to: socket)
+        to socket: Int32
+    ) throws(SocketError) {
+        try value.write(to: socket)
     }
 }

--- a/Sources/DestinyDefaults/routes/results/StaticStringWithDateHeader.swift
+++ b/Sources/DestinyDefaults/routes/results/StaticStringWithDateHeader.swift
@@ -62,13 +62,13 @@ extension StaticStringWithDateHeader {
 // MARK: Write to socket
 extension StaticStringWithDateHeader: StaticRouteResponderProtocol {
     @inlinable
-    public func write(to socket: borrowing some HTTPSocketProtocol & ~Copyable) async throws(SocketError) {
+    public func write(to socket: Int32) throws(SocketError) {
         var err:SocketError? = nil
         preDateValue.withUTF8Buffer { preDatePointer in
             HTTPDateFormat.nowInlineArray.span.withUnsafeBufferPointer { datePointer in
                 postDateValue.withUTF8Buffer { postDatePointer in
                     do throws(SocketError) {
-                        try socket.writeBuffers([preDatePointer, datePointer, postDatePointer])
+                        try socket.socketWriteBuffers([preDatePointer, datePointer, postDatePointer])
                     } catch {
                         err = error
                     }

--- a/Sources/DestinyDefaults/routes/results/StaticStringWithDateHeader.swift
+++ b/Sources/DestinyDefaults/routes/results/StaticStringWithDateHeader.swift
@@ -75,6 +75,7 @@ extension StaticStringWithDateHeader: StaticRouteResponderProtocol {
                 }
             }
         }
+        socket.socketClose()
         if let err {
             throw err
         }

--- a/Sources/DestinyDefaults/routes/results/StringWithDateHeader.swift
+++ b/Sources/DestinyDefaults/routes/results/StringWithDateHeader.swift
@@ -100,6 +100,7 @@ extension StringWithDateHeader: StaticRouteResponderProtocol {
                 }
             }
         }
+        socket.socketClose()
         if let err {
             throw err
         }

--- a/Sources/DestinyDefaults/routes/results/StringWithDateHeader.swift
+++ b/Sources/DestinyDefaults/routes/results/StringWithDateHeader.swift
@@ -86,14 +86,14 @@ extension StringWithDateHeader {
 extension StringWithDateHeader: StaticRouteResponderProtocol {
     @inlinable
     public func write(
-        to socket: borrowing some HTTPSocketProtocol & ~Copyable
-    ) async throws(SocketError) {
+        to socket: Int32
+    ) throws(SocketError) {
         var err:SocketError? = nil
         preDateValue.withContiguousStorageIfAvailable { preDatePointer in
             HTTPDateFormat.nowInlineArray.span.withUnsafeBufferPointer { datePointer in
                 postDateValue.withContiguousStorageIfAvailable { postDatePointer in
                     do throws(SocketError) {
-                        try socket.writeBuffers([preDatePointer, datePointer, postDatePointer])
+                        try socket.socketWriteBuffers([preDatePointer, datePointer, postDatePointer])
                     } catch {
                         err = error
                     }

--- a/Sources/DestinyDefaults/storage/DynamicResponderStorage.swift
+++ b/Sources/DestinyDefaults/storage/DynamicResponderStorage.swift
@@ -29,9 +29,9 @@ extension DynamicResponderStorage {
         router: some HTTPRouterProtocol,
         socket: Int32,
         request: inout some HTTPRequestProtocol & ~Copyable
-    ) async throws(ResponderError) -> Bool {
+    ) throws(ResponderError) -> Bool {
         guard let responder = responder(for: &request) else { return false }
-        try await router.respondDynamically(socket: socket, request: &request, responder: responder)
+        try router.respondDynamically(socket: socket, request: &request, responder: responder)
         return true
     }
 

--- a/Sources/DestinyDefaults/storage/DynamicResponderStorage.swift
+++ b/Sources/DestinyDefaults/storage/DynamicResponderStorage.swift
@@ -27,7 +27,7 @@ extension DynamicResponderStorage {
     @inlinable
     public func respond(
         router: some HTTPRouterProtocol,
-        socket: borrowing some HTTPSocketProtocol & ~Copyable,
+        socket: Int32,
         request: inout some HTTPRequestProtocol & ~Copyable
     ) async throws(ResponderError) -> Bool {
         guard let responder = responder(for: &request) else { return false }

--- a/Sources/DestinyDefaults/storage/RouteGroupStorage.swift
+++ b/Sources/DestinyDefaults/storage/RouteGroupStorage.swift
@@ -15,7 +15,7 @@ extension RouteGroupStorage {
     @inlinable
     public func respond(
         router: some HTTPRouterProtocol,
-        socket: borrowing some HTTPSocketProtocol & ~Copyable,
+        socket: Int32,
         request: inout some HTTPRequestProtocol & ~Copyable
     ) async throws(ResponderError) -> Bool {
         for group in groups {

--- a/Sources/DestinyDefaults/storage/RouteGroupStorage.swift
+++ b/Sources/DestinyDefaults/storage/RouteGroupStorage.swift
@@ -17,9 +17,9 @@ extension RouteGroupStorage {
         router: some HTTPRouterProtocol,
         socket: Int32,
         request: inout some HTTPRequestProtocol & ~Copyable
-    ) async throws(ResponderError) -> Bool {
+    ) throws(ResponderError) -> Bool {
         for group in groups {
-            if try await group.respond(router: router, socket: socket, request: &request) {
+            if try group.respond(router: router, socket: socket, request: &request) {
                 return true
             }
         }

--- a/Sources/DestinyDefaults/storage/RouterResponderStorage.swift
+++ b/Sources/DestinyDefaults/storage/RouterResponderStorage.swift
@@ -27,10 +27,10 @@ extension RouterResponderStorage {
     @inlinable
     public func respond(
         router: some HTTPRouterProtocol,
-        socket: borrowing some HTTPSocketProtocol & ~Copyable,
+        socket: Int32,
         request: inout some HTTPRequestProtocol & ~Copyable
     ) async throws(ResponderError) -> Bool {
-        if try await respondStatically(router: router, socket: socket, startLine: request.startLine) {
+        if try respondStatically(router: router, socket: socket, startLine: request.startLine) {
             return true
         }
         if try await respondDynamically(router: router, socket: socket, request: &request) {
@@ -45,16 +45,16 @@ extension RouterResponderStorage {
     @inlinable
     public func respondStatically(
         router: some HTTPRouterProtocol,
-        socket: borrowing some HTTPSocketProtocol & ~Copyable,
+        socket: Int32,
         startLine: SIMD64<UInt8>
-    ) async throws(ResponderError) -> Bool {
-        return try await `static`.respond(router: router, socket: socket, startLine: startLine)
+    ) throws(ResponderError) -> Bool {
+        return try `static`.respond(router: router, socket: socket, startLine: startLine)
     }
 
     @inlinable
     public func respondDynamically(
         router: some HTTPRouterProtocol,
-        socket: borrowing some HTTPSocketProtocol & ~Copyable,
+        socket: Int32,
         request: inout some HTTPRequestProtocol & ~Copyable,
     ) async throws(ResponderError) -> Bool {
         return try await dynamic.respond(router: router, socket: socket, request: &request)

--- a/Sources/DestinyDefaults/storage/RouterResponderStorage.swift
+++ b/Sources/DestinyDefaults/storage/RouterResponderStorage.swift
@@ -29,15 +29,15 @@ extension RouterResponderStorage {
         router: some HTTPRouterProtocol,
         socket: Int32,
         request: inout some HTTPRequestProtocol & ~Copyable
-    ) async throws(ResponderError) -> Bool {
+    ) throws(ResponderError) -> Bool {
         if try respondStatically(router: router, socket: socket, startLine: request.startLine) {
             return true
         }
-        if try await respondDynamically(router: router, socket: socket, request: &request) {
+        if try respondDynamically(router: router, socket: socket, request: &request) {
             return true
         }
         if let responder = conditional[request.startLine] {
-            return try await responder.respond(router: router, socket: socket, request: &request)
+            return try responder.respond(router: router, socket: socket, request: &request)
         }
         return false
     }

--- a/Sources/DestinyDefaults/storage/RouterResponderStorage.swift
+++ b/Sources/DestinyDefaults/storage/RouterResponderStorage.swift
@@ -56,8 +56,8 @@ extension RouterResponderStorage {
         router: some HTTPRouterProtocol,
         socket: Int32,
         request: inout some HTTPRequestProtocol & ~Copyable,
-    ) async throws(ResponderError) -> Bool {
-        return try await dynamic.respond(router: router, socket: socket, request: &request)
+    ) throws(ResponderError) -> Bool {
+        return try dynamic.respond(router: router, socket: socket, request: &request)
     }
 }
 

--- a/Sources/DestinyDefaults/storage/StaticResponderStorage.swift
+++ b/Sources/DestinyDefaults/storage/StaticResponderStorage.swift
@@ -36,23 +36,23 @@ extension StaticResponderStorage {
     @inlinable
     public func respond(
         router: some HTTPRouterProtocol,
-        socket: borrowing some HTTPSocketProtocol & ~Copyable,
+        socket: Int32,
         startLine: DestinyRoutePathType
-    ) async throws(ResponderError) -> Bool {
+    ) throws(ResponderError) -> Bool {
         if let r = macroExpansions[startLine] {
-            try await router.respondStatically(socket: socket, responder: r)
+            try router.respondStatically(socket: socket, responder: r)
         } else if let r = macroExpansionsWithDateHeader[startLine] {
-            try await router.respondStatically(socket: socket, responder: r)
+            try router.respondStatically(socket: socket, responder: r)
         } else if let r = staticStrings[startLine] {
-            try await router.respondStatically(socket: socket, responder: r)
+            try router.respondStatically(socket: socket, responder: r)
         } else if let r = staticStringsWithDateHeader[startLine] {
-            try await router.respondStatically(socket: socket, responder: r)
+            try router.respondStatically(socket: socket, responder: r)
         } else if let r = stringsWithDateHeader[startLine] {
-            try await router.respondStatically(socket: socket, responder: r)
+            try router.respondStatically(socket: socket, responder: r)
         } else if let r = strings[startLine] {
-            try await router.respondStatically(socket: socket, responder: r)
+            try router.respondStatically(socket: socket, responder: r)
         } else if let r = bytes[startLine] {
-            try await router.respondStatically(socket: socket, responder: r)
+            try router.respondStatically(socket: socket, responder: r)
         } else {
             return false
         }

--- a/Sources/DestinyDefaults/storage/compiled/CompiledDynamicResponderStorage.swift
+++ b/Sources/DestinyDefaults/storage/compiled/CompiledDynamicResponderStorage.swift
@@ -12,7 +12,7 @@ public struct CompiledDynamicResponderStorage<each ConcreteRoute: CompiledDynami
     @inlinable
     public func respond(
         router: some HTTPRouterProtocol,
-        socket: borrowing some HTTPSocketProtocol & ~Copyable,
+        socket: Int32,
         request: inout some HTTPRequestProtocol & ~Copyable
     ) async throws(ResponderError) -> Bool {
         let requestPathCount = request.pathCount()

--- a/Sources/DestinyDefaults/storage/compiled/CompiledDynamicResponderStorage.swift
+++ b/Sources/DestinyDefaults/storage/compiled/CompiledDynamicResponderStorage.swift
@@ -14,11 +14,11 @@ public struct CompiledDynamicResponderStorage<each ConcreteRoute: CompiledDynami
         router: some HTTPRouterProtocol,
         socket: Int32,
         request: inout some HTTPRequestProtocol & ~Copyable
-    ) async throws(ResponderError) -> Bool {
+    ) throws(ResponderError) -> Bool {
         let requestPathCount = request.pathCount()
         for route in repeat each routes {
             if route.path == request.startLine { // parameterless
-                try await router.respondDynamically(socket: socket, request: &request, responder: route.responder)
+                try router.respondDynamically(socket: socket, request: &request, responder: route.responder)
                 return true
             } else { // parameterized and catchall
                 let pathComponentsCount = route.responder.pathComponentsCount
@@ -45,7 +45,7 @@ public struct CompiledDynamicResponderStorage<each ConcreteRoute: CompiledDynami
                     }
                 }
                 if found && (lastIsCatchall || lastIsParameter && requestPathCount == pathComponentsCount) {
-                    try await router.respondDynamically(socket: socket, request: &request, responder: route.responder)
+                    try router.respondDynamically(socket: socket, request: &request, responder: route.responder)
                     return true
                 }
             }

--- a/Sources/DestinyDefaults/storage/compiled/CompiledRouteGroupStorage.swift
+++ b/Sources/DestinyDefaults/storage/compiled/CompiledRouteGroupStorage.swift
@@ -16,9 +16,9 @@ extension CompiledRouteGroupStorage {
         router: some HTTPRouterProtocol,
         socket: Int32,
         request: inout some HTTPRequestProtocol & ~Copyable
-    ) async throws(ResponderError) -> Bool {
+    ) throws(ResponderError) -> Bool {
         for group in repeat each groups {
-            if try await group.respond(router: router, socket: socket, request: &request) {
+            if try group.respond(router: router, socket: socket, request: &request) {
                 return true
             }
         }

--- a/Sources/DestinyDefaults/storage/compiled/CompiledRouteGroupStorage.swift
+++ b/Sources/DestinyDefaults/storage/compiled/CompiledRouteGroupStorage.swift
@@ -14,7 +14,7 @@ extension CompiledRouteGroupStorage {
     @inlinable
     public func respond(
         router: some HTTPRouterProtocol,
-        socket: borrowing some HTTPSocketProtocol & ~Copyable,
+        socket: Int32,
         request: inout some HTTPRequestProtocol & ~Copyable
     ) async throws(ResponderError) -> Bool {
         for group in repeat each groups {

--- a/Sources/DestinyDefaults/storage/compiled/CompiledRouterResponderStorage.swift
+++ b/Sources/DestinyDefaults/storage/compiled/CompiledRouterResponderStorage.swift
@@ -29,7 +29,7 @@ extension CompiledRouterResponderStorage {
         router: some HTTPRouterProtocol,
         socket: Int32,
         request: inout some HTTPRequestProtocol & ~Copyable
-    ) async throws(ResponderError) -> Bool {
+    ) throws(ResponderError) -> Bool {
         if try respondStatically(router: router, socket: socket, startLine: request.startLine) {
             return true
         }
@@ -37,7 +37,7 @@ extension CompiledRouterResponderStorage {
             return true
         }
         if let responder = conditional[request.startLine] {
-            return try await responder.respond(router: router, socket: socket, request: &request)
+            return try responder.respond(router: router, socket: socket, request: &request)
         }
         return false
     }

--- a/Sources/DestinyDefaults/storage/compiled/CompiledRouterResponderStorage.swift
+++ b/Sources/DestinyDefaults/storage/compiled/CompiledRouterResponderStorage.swift
@@ -27,10 +27,10 @@ extension CompiledRouterResponderStorage {
     @inlinable
     public func respond(
         router: some HTTPRouterProtocol,
-        socket: borrowing some HTTPSocketProtocol & ~Copyable,
+        socket: Int32,
         request: inout some HTTPRequestProtocol & ~Copyable
     ) async throws(ResponderError) -> Bool {
-        if try await respondStatically(router: router, socket: socket, startLine: request.startLine) {
+        if try respondStatically(router: router, socket: socket, startLine: request.startLine) {
             return true
         }
         if try await respondDynamically(router: router, socket: socket, request: &request) {
@@ -45,16 +45,16 @@ extension CompiledRouterResponderStorage {
     @inlinable
     public func respondStatically(
         router: some HTTPRouterProtocol,
-        socket: borrowing some HTTPSocketProtocol & ~Copyable,
+        socket: Int32,
         startLine: SIMD64<UInt8>
-    ) async throws(ResponderError) -> Bool {
-        return try await `static`.respond(router: router, socket: socket, startLine: startLine)
+    ) throws(ResponderError) -> Bool {
+        return try `static`.respond(router: router, socket: socket, startLine: startLine)
     }
 
     @inlinable
     public func respondDynamically(
         router: some HTTPRouterProtocol,
-        socket: borrowing some HTTPSocketProtocol & ~Copyable,
+        socket: Int32,
         request: inout some HTTPRequestProtocol & ~Copyable,
     ) async throws(ResponderError) -> Bool {
         return try await dynamic.respond(router: router, socket: socket, request: &request)

--- a/Sources/DestinyDefaults/storage/compiled/CompiledRouterResponderStorage.swift
+++ b/Sources/DestinyDefaults/storage/compiled/CompiledRouterResponderStorage.swift
@@ -33,7 +33,7 @@ extension CompiledRouterResponderStorage {
         if try respondStatically(router: router, socket: socket, startLine: request.startLine) {
             return true
         }
-        if try await respondDynamically(router: router, socket: socket, request: &request) {
+        if try respondDynamically(router: router, socket: socket, request: &request) {
             return true
         }
         if let responder = conditional[request.startLine] {
@@ -56,7 +56,7 @@ extension CompiledRouterResponderStorage {
         router: some HTTPRouterProtocol,
         socket: Int32,
         request: inout some HTTPRequestProtocol & ~Copyable,
-    ) async throws(ResponderError) -> Bool {
-        return try await dynamic.respond(router: router, socket: socket, request: &request)
+    ) throws(ResponderError) -> Bool {
+        return try dynamic.respond(router: router, socket: socket, request: &request)
     }
 }

--- a/Sources/DestinyDefaults/storage/compiled/CompiledStaticResponderStorage.swift
+++ b/Sources/DestinyDefaults/storage/compiled/CompiledStaticResponderStorage.swift
@@ -12,12 +12,12 @@ public struct CompiledStaticResponderStorage<each ConcreteRoute: CompiledStaticR
     @inlinable
     public func respond(
         router: some HTTPRouterProtocol,
-        socket: borrowing some HTTPSocketProtocol & ~Copyable,
+        socket: Int32,
         startLine: DestinyRoutePathType
-    ) async throws(ResponderError) -> Bool {
+    ) throws(ResponderError) -> Bool {
         for route in repeat each routes {
             if route.path == startLine {
-                try await router.respondStatically(socket: socket, responder: route.responder)
+                try router.respondStatically(socket: socket, responder: route.responder)
                 return true
             }
         }

--- a/Sources/DestinyMacros/Router+Routes+Dynamic.swift
+++ b/Sources/DestinyMacros/Router+Routes+Dynamic.swift
@@ -148,10 +148,10 @@ extension RouterStorage {
                     to socket: Int32,
                     request: inout some HTTPRequestProtocol & ~Copyable,
                     response: inout some DynamicResponseProtocol
-                ) async throws(ResponderError) {
+                ) throws(ResponderError) {
                     \(responder)
                     do throws(SocketError) {
-                        try await response.write(to: socket)
+                        try response.write(to: socket)
                     } catch {
                         throw .socketError(error)
                     }

--- a/Sources/DestinyMacros/Router+Routes+Dynamic.swift
+++ b/Sources/DestinyMacros/Router+Routes+Dynamic.swift
@@ -145,7 +145,7 @@ extension RouterStorage {
 
                 @inlinable
                 func respond(
-                    to socket: borrowing some HTTPSocketProtocol & ~Copyable,
+                    to socket: Int32,
                     request: inout some HTTPRequestProtocol & ~Copyable,
                     response: inout some DynamicResponseProtocol
                 ) async throws(ResponderError) {

--- a/Sources/DestinyMacros/RouterStorage.swift
+++ b/Sources/DestinyMacros/RouterStorage.swift
@@ -49,7 +49,7 @@ public struct RouterStorage {
                 func customLogic(
                     request: inout some HTTPRequestProtocol & ~Copyable,
                     response: inout some DynamicResponseProtocol
-                ) async throws(MiddlewareError) {
+                ) throws(MiddlewareError) {
                     \(functionString)
                 }
 
@@ -57,7 +57,7 @@ public struct RouterStorage {
                 func handle(
                     request: inout some HTTPRequestProtocol & ~Copyable,
                     response: inout some DynamicResponseProtocol
-                ) async throws(MiddlewareError) -> Bool {
+                ) throws(MiddlewareError) -> Bool {
                     try await customLogic(request: &request, response: &response)
                     return true
                 }


### PR DESCRIPTION
this PR does the following:
- refactor `HTTPSocketWritable` and make it synchronous
  - adds `AsyncHTTPSocketWritable` for asynchronous work
- makes `DynamicMiddlewareProtocol` synchronous
  - makes all types conforming to it synchronous as well
  - I will introduce `AsyncDynamicMiddlewareProtocol` later
- makes static, dynamic and conditional route responders synchronous
  - I will introduce async protocols for dynamic and conditional route responders later
- relaxed `HTTPRouterProtocol` requirements
- minor performance improvement to epoll
- fixes a crash in release mode relating to `InlineVLArray`