### PR TITLE
remove inline package traits

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -107,8 +107,6 @@ defaultTraits.formUnion([
     "StringRouteResponder",
     "UnwrapArithmetic",
     "Protocols",
-    //"Inlinable", // disabled by default because it is shown to hurt performance
-    //"InlineAlways" // disabled by default because it is shown to hurt performance
 
     "Logging",
     "OpenAPI"
@@ -386,14 +384,6 @@ let traits:Set<Trait> = [
     .trait(
         name: "Protocols",
         description: "Enables the design protocols and the DestinyBlueprint target."
-    ),
-    .trait( // useful when benchmarking/profiling raw performance
-        name: "Inlinable",
-        description: "Enables the `@inlinable` annotation where annotated."
-    ),
-    .trait( // useful when benchmarking/profiling raw performance
-        name: "InlineAlways",
-        description: "Enables the `@inline(__always)` annotation where annotated."
     ),
 
     .trait(

--- a/Package.swift
+++ b/Package.swift
@@ -107,7 +107,7 @@ defaultTraits.formUnion([
     "StringRouteResponder",
     "UnwrapArithmetic",
     "Protocols",
-    "Inlinable",
+    //"Inlinable", // disabled by default because it is shown to hurt performance
     //"InlineAlways" // disabled by default because it is shown to hurt performance
 
     "Logging",

--- a/Sources/CodeGeneration/Sources/CodeGeneration/HTTPRequestHeaders.swift
+++ b/Sources/CodeGeneration/Sources/CodeGeneration/HTTPRequestHeaders.swift
@@ -35,9 +35,6 @@ extension HTTPRequestHeaders {
         \(cases.joined(separator: "\n"))
 
             /// Lowercased canonical name of the header used for comparison.
-            #if Inlinable
-            @inlinable
-            #endif
             public var canonicalName: String {
                 switch self {
         \(canonicalNames.joined(separator: "\n"))
@@ -47,9 +44,6 @@ extension HTTPRequestHeaders {
 
         #if \(name)RawNames
         extension \(name) {
-            #if Inlinable
-            @inlinable
-            #endif
             public var rawName: String {
                 switch self {
         \(rawNames.joined(separator: "\n"))
@@ -67,9 +61,6 @@ extension HTTPRequestHeaders {
         extension \(name): RawRepresentable {
             public typealias RawValue = String
 
-            #if Inlinable
-            @inlinable
-            #endif
             public init?(rawValue: RawValue) {
                 switch rawValue {
         \(rawValueInitCases.joined(separator: "\n"))
@@ -77,9 +68,6 @@ extension HTTPRequestHeaders {
                 }
             }
 
-            #if Inlinable
-            @inlinable
-            #endif
             public var rawValue: RawValue {
                 switch self {
         \(rawValueCases.joined(separator: "\n"))

--- a/Sources/CodeGeneration/Sources/CodeGeneration/HTTPRequestMethods.swift
+++ b/Sources/CodeGeneration/Sources/CodeGeneration/HTTPRequestMethods.swift
@@ -38,9 +38,6 @@ extension HTTPRequestMethods {
         public enum \(name): HTTPRequestMethodProtocol {
         \(cases.joined(separator: "\n"))
 
-            #if Inlinable
-            @inlinable
-            #endif
             public func rawNameString() -> String {
                 switch self {
         \(rawNameCaseValues.joined(separator: "\n"))
@@ -52,9 +49,6 @@ extension HTTPRequestMethods {
         extension \(name): RawRepresentable {
             public typealias RawValue = String
 
-            #if Inlinable
-            @inlinable
-            #endif
             public init?(rawValue: String) {
                 switch rawValue {
         \(rawValueInitCases.joined(separator: "\n"))
@@ -62,9 +56,6 @@ extension HTTPRequestMethods {
                 }
             }
 
-            #if Inlinable
-            @inlinable
-            #endif
             public var rawValue: String {
                 switch self {
         \(rawValueCases.joined(separator: "\n"))

--- a/Sources/CodeGeneration/Sources/CodeGeneration/HTTPResponseHeaders.swift
+++ b/Sources/CodeGeneration/Sources/CodeGeneration/HTTPResponseHeaders.swift
@@ -35,9 +35,6 @@ extension HTTPResponseHeaders {
         \(cases.joined(separator: "\n"))
 
             /// Lowercased canonical name of the header used for comparison.
-            #if Inlinable
-            @inlinable
-            #endif
             public var canonicalName: String {
                 switch self {
         \(canonicalNames.joined(separator: "\n"))
@@ -47,9 +44,6 @@ extension HTTPResponseHeaders {
 
         #if \(name)RawNames
         extension \(name) {
-            #if Inlinable
-            @inlinable
-            #endif
             public var rawName: String {
                 switch self {
         \(rawNames.joined(separator: "\n"))
@@ -67,9 +61,6 @@ extension HTTPResponseHeaders {
         extension \(name): RawRepresentable {
             public typealias RawValue = String
 
-            #if Inlinable
-            @inlinable
-            #endif
             public init?(rawValue: RawValue) {
                 switch rawValue {
         \(rawValueInitCases.joined(separator: "\n"))
@@ -77,9 +68,6 @@ extension HTTPResponseHeaders {
                 }
             }
 
-            #if Inlinable
-            @inlinable
-            #endif
             public var rawValue: RawValue {
                 switch self {
         \(rawValueCases.joined(separator: "\n"))

--- a/Sources/CodeGeneration/Sources/CodeGeneration/HTTPResponseStatuses.swift
+++ b/Sources/CodeGeneration/Sources/CodeGeneration/HTTPResponseStatuses.swift
@@ -45,9 +45,6 @@ extension HTTPResponseStatuses {
         public enum \(name): HTTPResponseStatus.StorageProtocol {
         \(cases.joined(separator: "\n"))
 
-            #if Inlinable
-            @inlinable
-            #endif
             public var code: UInt16 {
                 switch self {
         \(codeCases.joined(separator: "\n"))
@@ -59,9 +56,6 @@ extension HTTPResponseStatuses {
         extension \(name): RawRepresentable {
             public typealias RawValue = String
 
-            #if Inlinable
-            @inlinable
-            #endif
             public init?(rawValue: RawValue) {
                 switch rawValue {
         \(rawValueInits.joined(separator: "\n"))
@@ -69,9 +63,6 @@ extension HTTPResponseStatuses {
                 }
             }
 
-            #if Inlinable
-            @inlinable
-            #endif
             public var rawValue: RawValue {
                 switch self {
         \(rawValueCases.joined(separator: "\n"))

--- a/Sources/DestinyBlueprint/PathComponent.swift
+++ b/Sources/DestinyBlueprint/PathComponent.swift
@@ -15,18 +15,12 @@ public enum PathComponent: Equatable, Sendable { // TODO: remove `Equatable` con
     indirect case components(PathComponent, PathComponent?)
 
     /// Whether or not this component is a literal.
-    #if Inlinable
-    @inlinable
-    #endif
     public var isLiteral: Bool {
         guard case .literal = self else { return false }
         return true
     }
 
     /// Whether or not this component does any route path matching.
-    #if Inlinable
-    @inlinable
-    #endif
     public var isParameter: Bool {
         switch self {
         case .literal:   false
@@ -39,9 +33,6 @@ public enum PathComponent: Equatable, Sendable { // TODO: remove `Equatable` con
     /// String representation of this component including the delimiter, if it is a parameter.
     /// 
     /// Used to determine where parameters are located in a route's path at compile time.
-    #if Inlinable
-    @inlinable
-    #endif
     public var slug: String {
         switch self {
         case .literal(let value): value
@@ -52,9 +43,6 @@ public enum PathComponent: Equatable, Sendable { // TODO: remove `Equatable` con
     }
 
     /// String representation of this component where the delimiter is omitted (only the name of the path is present).
-    #if Inlinable
-    @inlinable
-    #endif
     public var value: String {
         switch self {
         case .literal(let s): s

--- a/Sources/DestinyBlueprint/extensions/StringExtensions.swift
+++ b/Sources/DestinyBlueprint/extensions/StringExtensions.swift
@@ -2,9 +2,6 @@
 import VariableLengthArray
 
 extension String {
-    #if Inlinable
-    @inlinable
-    #endif
     public func inlineVLArray<E: Error>(_ closure: (consuming VLArray<UInt8>) throws(E) -> Void) rethrows {
         try VLArray<UInt8>.create(string: self, closure)
     }

--- a/Sources/DestinyBlueprint/extensions/embedded/HTTPCookieExtensions.swift
+++ b/Sources/DestinyBlueprint/extensions/embedded/HTTPCookieExtensions.swift
@@ -2,9 +2,6 @@
 #if HTTPCookie
 
 extension HTTPCookie {
-    #if Inlinable
-    @inlinable
-    #endif
     public init(unchecked cookie: HTTPCookie) {
         self.init(
             name: cookie._name,

--- a/Sources/DestinyBlueprint/extensions/embedded/HTTPHeadersExtensions.swift
+++ b/Sources/DestinyBlueprint/extensions/embedded/HTTPHeadersExtensions.swift
@@ -2,9 +2,6 @@
 extension HTTPHeaders: ExpressibleByDictionaryLiteral {
     /// Creates an instance initialized with the given key-value pairs.
     /// - Warning: Keys are case-sensitive!
-    #if Inlinable
-    @inlinable
-    #endif
     public init(dictionaryLiteral elements: (String, String)...) {
         var _storage = [(Key, Value)]()
         _storage.reserveCapacity(elements.count)

--- a/Sources/DestinyBlueprint/extensions/embedded/HTTPRequestMethodExtensions.swift
+++ b/Sources/DestinyBlueprint/extensions/embedded/HTTPRequestMethodExtensions.swift
@@ -1,8 +1,5 @@
 
 extension HTTPRequestMethod: HTTPRequestMethodProtocol {
-    #if Inlinable
-    @inlinable
-    #endif
     public init(_ method: some HTTPRequestMethodProtocol) {
         self.init(name: method.rawNameString())
     }

--- a/Sources/DestinyBlueprint/extensions/simd/StackStrings.swift
+++ b/Sources/DestinyBlueprint/extensions/simd/StackStrings.swift
@@ -1,9 +1,6 @@
 
 extension SIMD64<UInt8> {
     /// - Complexity: O(*n*) if `string` is non-contiguous, O(1) if already contiguous.
-    #if Inlinable
-    @inlinable
-    #endif
     public init(_ string: inout String) {
         var item = Self()
         string.withUTF8 { p in
@@ -15,18 +12,12 @@ extension SIMD64<UInt8> {
     }
 
     /// - Complexity: O(*n*) if `string` is non-contiguous, O(1) if already contiguous.
-    #if Inlinable
-    @inlinable
-    #endif
     public init(_ string: String) {
         var s = string
         self = .init(&s)
     }
 
     /// - Complexity: O(1)
-    #if Inlinable
-    @inlinable
-    #endif
     public var leadingNonzeroByteCountSIMD: Int {
         for i in 0..<scalarCount {
             if self[i] == 0 {
@@ -37,9 +28,6 @@ extension SIMD64<UInt8> {
     }
 
     /// - Complexity: O(1)
-    #if Inlinable
-    @inlinable
-    #endif
     public func stringSIMD() -> String {
         let amount = leadingNonzeroByteCountSIMD
         var characters = [Character](repeating: Character(Unicode.Scalar(0)), count: amount)

--- a/Sources/DestinyBlueprint/http/AsyncHTTPSocketWritable.swift
+++ b/Sources/DestinyBlueprint/http/AsyncHTTPSocketWritable.swift
@@ -19,9 +19,6 @@ extension AsyncHTTPSocketWritable {
     ///   - socket: some noncopyable `FileDescriptor`.
     /// 
     /// - Throws: `SocketError`
-    #if Inlinable
-    @inlinable
-    #endif
     public func write(
         to socket: borrowing some FileDescriptor & ~Copyable
     ) async throws(SocketError) {
@@ -31,9 +28,6 @@ extension AsyncHTTPSocketWritable {
 
 // MARK: Default conformances
 extension String: AsyncHTTPSocketWritable {
-    #if Inlinable
-    @inlinable
-    #endif
     public func write(
         to socket: some FileDescriptor
     ) async throws(SocketError) {
@@ -42,9 +36,6 @@ extension String: AsyncHTTPSocketWritable {
 }
 
 extension StaticString: AsyncHTTPSocketWritable {
-    #if Inlinable
-    @inlinable
-    #endif
     public func write(
         to socket: some FileDescriptor
     ) async throws(SocketError) {
@@ -53,9 +44,6 @@ extension StaticString: AsyncHTTPSocketWritable {
 }
 
 extension [UInt8]: AsyncHTTPSocketWritable {
-    #if Inlinable
-    @inlinable
-    #endif
     public func write(
         to socket: some FileDescriptor
     ) async throws(SocketError) {

--- a/Sources/DestinyBlueprint/http/HTTPChunkDataProtocol.swift
+++ b/Sources/DestinyBlueprint/http/HTTPChunkDataProtocol.swift
@@ -7,18 +7,12 @@ public protocol HTTPChunkDataProtocol: BufferWritable, HTTPSocketWritable, ~Copy
 
 // MARK: Default conformance logic
 extension String {
-    #if Inlinable
-    @inlinable
-    #endif
     public var chunkDataCount: Int {
         count
     }
 }
 
 extension StaticString {
-    #if Inlinable
-    @inlinable
-    #endif
     public var chunkDataCount: Int {
         utf8CodeUnitCount
     }

--- a/Sources/DestinyBlueprint/middleware/CORSMiddlewareAllowedOrigin.swift
+++ b/Sources/DestinyBlueprint/middleware/CORSMiddlewareAllowedOrigin.swift
@@ -7,9 +7,6 @@ extension CORSMiddlewareAllowedOrigin {
     /// Applies CORS headers to a dynamic response.
     /// 
     /// - Throws: `SocketError`
-    #if Inlinable
-    @inlinable
-    #endif
     public func apply(
         request: inout HTTPRequest,
         response: inout some DynamicResponseProtocol
@@ -28,18 +25,12 @@ extension CORSMiddlewareAllowedOrigin {
         }
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     static func applyAll(
         response: inout some DynamicResponseProtocol
     ) {
         response.setHeader(key: "access-control-allow-origin", value: "*")
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     static func applyAny(
         request: inout HTTPRequest,
         response: inout some DynamicResponseProtocol,
@@ -50,9 +41,6 @@ extension CORSMiddlewareAllowedOrigin {
         }
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     static func applyCustom(
         response: inout some DynamicResponseProtocol,
         string: String
@@ -60,9 +48,6 @@ extension CORSMiddlewareAllowedOrigin {
         response.setHeader(key: "access-control-allow-origin", value: string)
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     static func applyOriginBased(
         request: inout HTTPRequest,
         response: inout some DynamicResponseProtocol
@@ -78,9 +63,6 @@ extension CORSMiddlewareAllowedOrigin {
     /// Applies CORS headers to a `HTTPHeaders`.
     /// 
     /// - Throws: `SocketError`
-    #if Inlinable
-    @inlinable
-    #endif
     public func apply(
         request: inout HTTPRequest,
         headers: inout HTTPHeaders
@@ -99,18 +81,12 @@ extension CORSMiddlewareAllowedOrigin {
         }
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     static func applyAll(
         headers: inout HTTPHeaders
     ) {
         headers["access-control-allow-origin"] = "*"
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     static func applyAny(
         request: inout HTTPRequest,
         headers: inout HTTPHeaders,
@@ -121,9 +97,6 @@ extension CORSMiddlewareAllowedOrigin {
         }
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     static func applyCustom(
         headers: inout HTTPHeaders,
         string: String
@@ -131,9 +104,6 @@ extension CORSMiddlewareAllowedOrigin {
         headers["access-control-allow-origin"] = string
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     static func applyOriginBased(
         request: inout HTTPRequest,
         headers: inout HTTPHeaders

--- a/Sources/DestinyBlueprint/middleware/StaticMiddleware.swift
+++ b/Sources/DestinyBlueprint/middleware/StaticMiddleware.swift
@@ -154,9 +154,6 @@ public final class StaticMiddleware: @unchecked Sendable {
 
 // MARK: Handles
 extension StaticMiddleware {
-    #if Inlinable
-    @inlinable
-    #endif
     public func handles(
         version: HTTPVersion,
         path: String,
@@ -171,16 +168,10 @@ extension StaticMiddleware {
             && handlesStatus(status)
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func handlesVersion(_ version: HTTPVersion) -> Bool {
         handlesVersions?.contains(version) ?? true
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func handlesMethod(_ method: some HTTPRequestMethodProtocol) -> Bool {
         guard let handlesMethods else { return true }
         let methodName = method.rawNameString()
@@ -192,16 +183,10 @@ extension StaticMiddleware {
         return false
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func handlesStatus(_ code: HTTPResponseStatus.Code) -> Bool {
         handlesStatuses?.contains(code) ?? true
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func handlesContentType(_ contentType: String?) -> Bool {
         guard let handlesContentTypes else { return true }
         if let contentType {
@@ -215,9 +200,6 @@ extension StaticMiddleware {
 // MARK: Apply
 extension StaticMiddleware {
     #if HTTPCookie
-    #if Inlinable
-    @inlinable
-    #endif
     public func apply(
         version: inout HTTPVersion,
         contentType: inout String?,
@@ -241,9 +223,6 @@ extension StaticMiddleware {
         cookies.append(contentsOf: appliesCookies)
     }
     #else
-    #if Inlinable
-    @inlinable
-    #endif
     public func apply(
         version: inout HTTPVersion,
         contentType: inout String?,
@@ -266,9 +245,6 @@ extension StaticMiddleware {
     }
     #endif
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func apply(
         contentType: inout String?,
         to response: inout some DynamicResponseProtocol

--- a/Sources/DestinyBlueprint/responders/DynamicRouteResponderProtocol.swift
+++ b/Sources/DestinyBlueprint/responders/DynamicRouteResponderProtocol.swift
@@ -37,9 +37,6 @@ public protocol DynamicRouteResponderProtocol: RouteResponderProtocol, ~Copyable
 
 // MARK: Defaults
 extension DynamicRouteResponderProtocol {
-    #if Inlinable
-    @inlinable
-    #endif
     public func respond(
         router: some HTTPRouterProtocol,
         socket: some FileDescriptor,

--- a/Sources/DestinyBlueprint/responders/RouteResponderProtocol.swift
+++ b/Sources/DestinyBlueprint/responders/RouteResponderProtocol.swift
@@ -10,9 +10,6 @@ public protocol RouteResponderProtocol: Sendable, ~Copyable {
     ///   - completionHandler: Closure that should be called when the socket should be released.
     /// 
     /// - Throws: `ResponderError`
-    #if Inlinable
-    @inlinable
-    #endif
     func respond(
         router: some HTTPRouterProtocol,
         socket: some FileDescriptor,
@@ -25,9 +22,6 @@ public protocol RouteResponderProtocol: Sendable, ~Copyable {
 
 #if StringRouteResponder
 extension String: RouteResponderProtocol {
-    #if Inlinable
-    @inlinable
-    #endif
     public func respond(
         router: some HTTPRouterProtocol,
         socket: some FileDescriptor,
@@ -45,9 +39,6 @@ extension String: RouteResponderProtocol {
 #endif
 
 extension StaticString: RouteResponderProtocol {
-    #if Inlinable
-    @inlinable
-    #endif
     public func respond(
         router: some HTTPRouterProtocol,
         socket: some FileDescriptor,
@@ -64,9 +55,6 @@ extension StaticString: RouteResponderProtocol {
 }
 
 extension [UInt8]: RouteResponderProtocol {
-    #if Inlinable
-    @inlinable
-    #endif
     public func respond(
         router: some HTTPRouterProtocol,
         socket: some FileDescriptor,

--- a/Sources/DestinyBlueprint/responders/noncopyable/NonCopyableDynamicRouteResponderProtocol.swift
+++ b/Sources/DestinyBlueprint/responders/noncopyable/NonCopyableDynamicRouteResponderProtocol.swift
@@ -39,9 +39,6 @@ public protocol NonCopyableDynamicRouteResponderProtocol: NonCopyableRouteRespon
 
 // MARK: Defaults
 extension NonCopyableDynamicRouteResponderProtocol where Self: ~Copyable {
-    #if Inlinable
-    @inlinable
-    #endif
     public func respond(
         router: borrowing some NonCopyableHTTPRouterProtocol & ~Copyable,
         socket: some FileDescriptor,

--- a/Sources/DestinyBlueprint/responders/noncopyable/NonCopyableRouteResponderProtocol.swift
+++ b/Sources/DestinyBlueprint/responders/noncopyable/NonCopyableRouteResponderProtocol.swift
@@ -12,9 +12,6 @@ public protocol NonCopyableRouteResponderProtocol: Sendable, ~Copyable {
     ///   - completionHandler: Closure that should be called when the socket should be released.
     /// 
     /// - Throws: `ResponderError`
-    #if Inlinable
-    @inlinable
-    #endif
     func respond(
         router: borrowing some NonCopyableHTTPRouterProtocol & ~Copyable,
         socket: some FileDescriptor,
@@ -27,9 +24,6 @@ public protocol NonCopyableRouteResponderProtocol: Sendable, ~Copyable {
 
 #if StringRouteResponder
 extension String: NonCopyableRouteResponderProtocol {
-    #if Inlinable
-    @inlinable
-    #endif
     public func respond(
         router: borrowing some NonCopyableHTTPRouterProtocol & ~Copyable,
         socket: some FileDescriptor,
@@ -47,9 +41,6 @@ extension String: NonCopyableRouteResponderProtocol {
 #endif
 
 extension StaticString: NonCopyableRouteResponderProtocol {
-    #if Inlinable
-    @inlinable
-    #endif
     public func respond(
         router: borrowing some NonCopyableHTTPRouterProtocol & ~Copyable,
         socket: some FileDescriptor,
@@ -66,9 +57,6 @@ extension StaticString: NonCopyableRouteResponderProtocol {
 }
 
 extension [UInt8]: NonCopyableRouteResponderProtocol {
-    #if Inlinable
-    @inlinable
-    #endif
     public func respond(
         router: borrowing some NonCopyableHTTPRouterProtocol & ~Copyable,
         socket: some FileDescriptor,

--- a/Sources/DestinyBlueprint/routes/RoutePathComponent.swift
+++ b/Sources/DestinyBlueprint/routes/RoutePathComponent.swift
@@ -7,31 +7,19 @@ public enum RoutePathComponent: RoutePathComponentProtocol {
     case parameter
     case query([SIMD64<UInt8>])
 
-    #if Inlinable
-    @inlinable
-    #endif
     public var isCatchall: Bool {
         self == .catchall
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public var isLiteral: Bool {
         guard case .literal = self else { return false }
         return true
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public var isParameter: Bool {
         self == .parameter
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public var isQuery: Bool {
         guard case .query = self else { return false }
         return true

--- a/Sources/DestinyBlueprint/routes/compiled/CompiledRoutePath.swift
+++ b/Sources/DestinyBlueprint/routes/compiled/CompiledRoutePath.swift
@@ -2,9 +2,6 @@
 #if RoutePath
 
 public struct CompiledRoutePath<each Component: RoutePathComponentProtocol>: Equatable, Sendable {
-    #if Inlinable
-    @inlinable
-    #endif
     public static func == (lhs: Self, rhs: Self) -> Bool {
         for (left, right) in repeat (each lhs.components, each rhs.components) {
             guard left == right else { return false }

--- a/Sources/DestinyDefaults/AsyncHTTPChunkDataStream.swift
+++ b/Sources/DestinyDefaults/AsyncHTTPChunkDataStream.swift
@@ -40,9 +40,6 @@ public struct AsyncHTTPChunkDataStream<T: HTTPChunkDataProtocol>: Sendable {
 
 // MARK: Write
 extension AsyncHTTPChunkDataStream {
-    #if Inlinable
-    @inlinable
-    #endif
     public func write(
         to socket: some FileDescriptor
     ) async throws(SocketError) {

--- a/Sources/DestinyDefaults/HTTPSocket.swift
+++ b/Sources/DestinyDefaults/HTTPSocket.swift
@@ -13,16 +13,10 @@ public struct HTTPSocket: Sendable, ~Copyable {
         Self.noSigPipe(fileDescriptor: fileDescriptor)
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func socketLocalAddress() -> String? {
         fileDescriptor.socketLocalAddress()
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func socketPeerAddress() -> String? {
         fileDescriptor.socketPeerAddress()
     }
@@ -31,9 +25,6 @@ public struct HTTPSocket: Sendable, ~Copyable {
 // MARK: Reading
 extension HTTPSocket {
     /// Reads multiple bytes and writes them into a buffer
-    #if Inlinable
-    @inlinable
-    #endif
     public func readBuffer(
         into buffer: UnsafeMutableBufferPointer<UInt8>,
         length: Int,
@@ -44,9 +35,6 @@ extension HTTPSocket {
     }
 
     /// Reads multiple bytes and writes them into a buffer
-    #if Inlinable
-    @inlinable
-    #endif
     public func readBuffer(
         into baseAddress: UnsafeMutablePointer<UInt8>,
         length: Int,
@@ -68,9 +56,6 @@ extension HTTPSocket {
     }
 
     /// Reads multiple bytes and writes them into a buffer
-    #if Inlinable
-    @inlinable
-    #endif
     public func readBuffer(
         into baseAddress: UnsafeMutableRawPointer,
         length: Int,
@@ -94,9 +79,6 @@ extension HTTPSocket {
     /// Reads multiple bytes and writes them into a buffer.
     /// 
     /// - Returns: Number of bytes received.
-    #if Inlinable
-    @inlinable
-    #endif
     public func readBuffer(
         into baseAddress: UnsafeMutableRawPointer,
         length: Int
@@ -107,9 +89,6 @@ extension HTTPSocket {
 
 // MARK: Writing
 extension HTTPSocket {
-    #if Inlinable
-    @inlinable
-    #endif
     public func writeBuffer(
         _ pointer: UnsafeRawPointer,
         length: Int
@@ -124,9 +103,6 @@ extension HTTPSocket {
         }
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func writeBuffers3(
         _ b1: (buffer: UnsafePointer<UInt8>, bufferCount: Int),
         _ b2: (buffer: UnsafePointer<UInt8>, bufferCount: Int),
@@ -135,9 +111,6 @@ extension HTTPSocket {
         try fileDescriptor.writeBuffers3(b1, b2, b3)
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func writeBuffers4(
         _ b1: UnsafeBufferPointer<UInt8>,
         _ b2: UnsafeBufferPointer<UInt8>,
@@ -147,9 +120,6 @@ extension HTTPSocket {
         try fileDescriptor.writeBuffers4(b1, b2, b3, b4)
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func writeBuffers6(
         _ b1: (buffer: UnsafePointer<UInt8>, bufferCount: Int),
         _ b2: (buffer: UnsafePointer<UInt8>, bufferCount: Int),
@@ -164,23 +134,14 @@ extension HTTPSocket {
 
 // MARK: Socket
 extension HTTPSocket {
-    #if Inlinable
-    @inlinable
-    #endif
     public func socketReceive(baseAddress: UnsafeMutablePointer<UInt8>, length: Int, flags: Int32) -> Int {
         return fileDescriptor.socketReceive(baseAddress: baseAddress, length: length, flags: flags)
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func socketReceive(baseAddress: UnsafeMutableRawPointer, length: Int, flags: Int32) -> Int {
         return fileDescriptor.socketReceive(baseAddress: baseAddress, length: length, flags: flags)
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func socketSendMultiplatform(pointer: UnsafeRawPointer, length: Int) -> Int {
         return fileDescriptor.socketSendMultiplatform(pointer: pointer, length: length)
     }

--- a/Sources/DestinyDefaults/_copyable/responders/Bytes.swift
+++ b/Sources/DestinyDefaults/_copyable/responders/Bytes.swift
@@ -6,31 +6,19 @@ import DestinyEmbedded
 public struct Bytes: Sendable {
     public let value:[UInt8]
 
-    #if Inlinable
-    @inlinable
-    #endif
     public init(_ value: [UInt8]) {
         self.value = value
     }
 
 
-    #if Inlinable
-    @inlinable
-    #endif
     public var count: Int {
         value.count
     }
     
-    #if Inlinable
-    @inlinable
-    #endif
     public func string() -> String {
         .init(decoding: value, as: UTF8.self)
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func write(
         to buffer: UnsafeMutableBufferPointer<UInt8>,
         at index: inout Int
@@ -44,9 +32,6 @@ extension Bytes {
     /// Writes a response to a file descriptor.
     /// 
     /// - Throws: `ResponderError`
-    #if Inlinable
-    @inlinable
-    #endif
     public func respond(
         socket: some FileDescriptor,
         completionHandler: @Sendable @escaping () -> Void
@@ -68,9 +53,6 @@ import DestinyBlueprint
 extension Bytes: ResponseBodyProtocol {}
 
 extension Bytes: RouteResponderProtocol {
-    #if Inlinable
-    @inlinable
-    #endif
     public func respond(
         router: some HTTPRouterProtocol,
         socket: some FileDescriptor,

--- a/Sources/DestinyDefaults/_copyable/responders/DateHeaderPayload.swift
+++ b/Sources/DestinyDefaults/_copyable/responders/DateHeaderPayload.swift
@@ -23,12 +23,6 @@ public struct DateHeaderPayload: @unchecked Sendable {
     /// Efficiently writes the `preDate` value, `date` header and `postDate` value to a file descriptor.
     /// 
     /// - Throws: `ResponderError`
-    #if Inlinable
-    @inlinable
-    #endif
-    #if InlineAlways
-    @inline(__always)
-    #endif
     public func write(to socket: some FileDescriptor) throws(ResponderError) {
         do throws(SocketError) {
             try socket.writeBuffers3(

--- a/Sources/DestinyDefaults/_copyable/responders/InlineBytes.swift
+++ b/Sources/DestinyDefaults/_copyable/responders/InlineBytes.swift
@@ -6,30 +6,18 @@ import DestinyEmbedded
 public struct InlineBytes<let count: Int>: Sendable {
     public let value:InlineArray<count, UInt8>
 
-    #if Inlinable
-    @inlinable
-    #endif
     public init(_ value: InlineArray<count, UInt8>) {
         self.value = value
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public var count: Int {
         value.count
     }
     
-    #if Inlinable
-    @inlinable
-    #endif
     public func string() -> String {
         value.unsafeString()
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func write(
         to buffer: UnsafeMutableBufferPointer<UInt8>,
         at index: inout Int
@@ -46,9 +34,6 @@ extension InlineBytes {
     ///   - completionHandler: Closure that should be called when the socket should be released.
     /// 
     /// - Throws: `ResponderError`
-    #if Inlinable
-    @inlinable
-    #endif
     public func respond(
         socket: some FileDescriptor,
         completionHandler: @Sendable @escaping () -> Void
@@ -70,9 +55,6 @@ import DestinyBlueprint
 extension InlineBytes: ResponseBodyProtocol {}
 
 extension InlineBytes: RouteResponderProtocol {
-    #if Inlinable
-    @inlinable
-    #endif
     public func respond(
         router: some HTTPRouterProtocol,
         socket: some FileDescriptor,

--- a/Sources/DestinyDefaults/_copyable/responders/MacroExpansionWithDateHeader.swift
+++ b/Sources/DestinyDefaults/_copyable/responders/MacroExpansionWithDateHeader.swift
@@ -28,9 +28,6 @@ public struct MacroExpansionWithDateHeader: Sendable {
 
 // MARK: Respond
 extension MacroExpansionWithDateHeader {
-    #if Inlinable
-    @inlinable
-    #endif
     public func respond(
         router: some HTTPRouterProtocol,
         socket: some FileDescriptor,

--- a/Sources/DestinyDefaults/_copyable/responders/ResponseBody+MacroExpansion.swift
+++ b/Sources/DestinyDefaults/_copyable/responders/ResponseBody+MacroExpansion.swift
@@ -7,30 +7,18 @@ extension ResponseBody {
     public struct MacroExpansion<Value: ResponseBodyValueProtocol>: Sendable {
         public var value:Value
 
-        #if Inlinable
-        @inlinable
-        #endif
         public init(_ value: Value) {
             self.value = value
         }
 
-        #if Inlinable
-        @inlinable
-        #endif
         public var count: Int {
             value.count
         }
         
-        #if Inlinable
-        @inlinable
-        #endif
         public func string() -> String {
             value.string()
         }
 
-        #if Inlinable
-        @inlinable
-        #endif
         public mutating func write(
             to buffer: UnsafeMutableBufferPointer<UInt8>,
             at index: inout Int

--- a/Sources/DestinyDefaults/_copyable/responders/ResponseBody+MacroExpansionWithDateHeader.swift
+++ b/Sources/DestinyDefaults/_copyable/responders/ResponseBody+MacroExpansionWithDateHeader.swift
@@ -7,30 +7,18 @@ extension ResponseBody {
     public struct MacroExpansionWithDateHeader<Value: ResponseBodyValueProtocol>: Sendable {
         public var value:Value
 
-        #if Inlinable
-        @inlinable
-        #endif
         public init(_ value: Value) {
             self.value = value
         }
 
-        #if Inlinable
-        @inlinable
-        #endif
         public var count: Int {
             value.count
         }
         
-        #if Inlinable
-        @inlinable
-        #endif
         public func string() -> String {
             value.string()
         }
 
-        #if Inlinable
-        @inlinable
-        #endif
         public mutating func write(
             to buffer: UnsafeMutableBufferPointer<UInt8>,
             at index: inout Int
@@ -38,9 +26,6 @@ extension ResponseBody {
             try value.write(to: buffer, at: &index)
         }
 
-        #if Inlinable
-        @inlinable
-        #endif
         public var hasDateHeader: Bool {
             true
         }

--- a/Sources/DestinyDefaults/_copyable/responders/RouteResponses+MacroExpansion.swift
+++ b/Sources/DestinyDefaults/_copyable/responders/RouteResponses+MacroExpansion.swift
@@ -25,9 +25,6 @@ extension RouteResponses.MacroExpansion {
     ///   - completionHandler: Closure that should be called when the socket should be released.
     /// 
     /// - Throws: `ResponderError`
-    #if Inlinable
-    @inlinable
-    #endif
     public func respond(
         socket: some FileDescriptor,
         completionHandler: @Sendable @escaping () -> Void
@@ -65,9 +62,6 @@ import DestinyBlueprint
 
 // MARK: Conformances
 extension RouteResponses.MacroExpansion: RouteResponderProtocol {
-    #if Inlinable
-    @inlinable
-    #endif
     public func respond(
         router: some HTTPRouterProtocol,
         socket: some FileDescriptor,

--- a/Sources/DestinyDefaults/_copyable/responders/StaticStringWithDateHeader.swift
+++ b/Sources/DestinyDefaults/_copyable/responders/StaticStringWithDateHeader.swift
@@ -24,23 +24,14 @@ public struct StaticStringWithDateHeader: Sendable {
         )
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public var count: Int {
         payload.preDatePointerCount +! HTTPDateFormat.InlineArrayResult.count +! payload.postDatePointerCount
     }
     
-    #if Inlinable
-    @inlinable
-    #endif
     public func string() -> String {
         "\(String(cString: payload.preDatePointer))\(HTTPDateFormat.placeholder)\(String(cString: payload.postDatePointer))"
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public var hasDateHeader: Bool {
         true
     }
@@ -48,9 +39,6 @@ public struct StaticStringWithDateHeader: Sendable {
 
 // MARK: Write to buffer
 extension StaticStringWithDateHeader {
-    #if Inlinable
-    @inlinable
-    #endif
     public func write(to buffer: UnsafeMutableBufferPointer<UInt8>, at index: inout Int) {
         index = 0
         buffer.copyBuffer(baseAddress: payload.preDatePointer, count: payload.preDatePointerCount, at: &index)
@@ -61,12 +49,6 @@ extension StaticStringWithDateHeader {
 
 // MARK: Respond
 extension StaticStringWithDateHeader {
-    #if Inlinable
-    @inlinable
-    #endif
-    #if InlineAlways
-    @inline(__always)
-    #endif
     public func respond(
         router: some HTTPRouterProtocol,
         socket: some FileDescriptor,

--- a/Sources/DestinyDefaults/_copyable/responders/StreamWithDateHeader.swift
+++ b/Sources/DestinyDefaults/_copyable/responders/StreamWithDateHeader.swift
@@ -29,30 +29,18 @@ public struct StreamWithDateHeader<Body: AsyncHTTPSocketWritable>: Sendable {
         )
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public var count: Int {
         payload.preDatePointerCount +! HTTPDateFormat.InlineArrayResult.count +! payload.postDatePointerCount
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func string() -> String {
         "\(String(cString: payload.preDatePointer))\(HTTPDateFormat.placeholder)\(String(cString: payload.postDatePointer))"
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public var hasDateHeader: Bool {
         true
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public var hasContentLength: Bool {
         false
     }
@@ -60,9 +48,6 @@ public struct StreamWithDateHeader<Body: AsyncHTTPSocketWritable>: Sendable {
 
 // MARK: Write to buffer
 extension StreamWithDateHeader {
-    #if Inlinable
-    @inlinable
-    #endif
     public func write(to buffer: UnsafeMutableBufferPointer<UInt8>, at index: inout Int) {
         // TODO: support?
     }
@@ -70,9 +55,6 @@ extension StreamWithDateHeader {
 
 // MARK: Respond
 extension StreamWithDateHeader {
-    #if Inlinable
-    @inlinable
-    #endif
     public func respond(
         router: some HTTPRouterProtocol,
         socket: some FileDescriptor,

--- a/Sources/DestinyDefaults/_copyable/responders/StringWithDateHeader.swift
+++ b/Sources/DestinyDefaults/_copyable/responders/StringWithDateHeader.swift
@@ -24,23 +24,14 @@ public struct StringWithDateHeader: Sendable {
         self.value = value.utf8
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public var count: Int {
         preDateValue.count +! HTTPDateFormat.InlineArrayResult.count +! postDateValue.count +! value.count
     }
     
-    #if Inlinable
-    @inlinable
-    #endif
     public func string() -> String {
         String(preDateValue) + HTTPDateFormat.placeholder + String(postDateValue) + String(value)
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public var hasDateHeader: Bool {
         true
     }
@@ -48,9 +39,6 @@ public struct StringWithDateHeader: Sendable {
 
 // MARK: Write to buffer
 extension StringWithDateHeader {
-    #if Inlinable
-    @inlinable
-    #endif
     public func write(to buffer: UnsafeMutableBufferPointer<UInt8>, at index: inout Int) {
         index = 0
         preDateValue.withContiguousStorageIfAvailable {
@@ -74,9 +62,6 @@ extension StringWithDateHeader {
     ///   - completionHandler: Closure that should be called when the socket should be released.
     /// 
     /// - Throws: `ResponderError`
-    #if Inlinable
-    @inlinable
-    #endif
     public func respond(
         socket: some FileDescriptor,
         completionHandler: @Sendable @escaping () -> Void
@@ -113,9 +98,6 @@ import DestinyBlueprint
 extension StringWithDateHeader: ResponseBodyProtocol {}
 
 extension StringWithDateHeader: RouteResponderProtocol {
-    #if Inlinable
-    @inlinable
-    #endif
     public func respond(
         router: some HTTPRouterProtocol,
         socket: some FileDescriptor,
@@ -127,9 +109,6 @@ extension StringWithDateHeader: RouteResponderProtocol {
 }
 
 extension StringWithDateHeader: NonCopyableRouteResponderProtocol {
-    #if Inlinable
-    @inlinable
-    #endif
     public func respond(
         router: borrowing some NonCopyableHTTPRouterProtocol & ~Copyable,
         socket: some FileDescriptor,

--- a/Sources/DestinyDefaults/_copyable/storage/CaseInsensitiveStaticResponderStorage.swift
+++ b/Sources/DestinyDefaults/_copyable/storage/CaseInsensitiveStaticResponderStorage.swift
@@ -5,9 +5,6 @@ import DestinyEmbedded
 
 /// Default mutable storage that handles case insensitive static routes.
 public final class CaseInsensitiveStaticResponderStorage: @unchecked Sendable {
-    #if Inlinable
-    @inlinable
-    #endif
     public override func respond(
         router: some HTTPRouterProtocol,
         socket: some FileDescriptor,

--- a/Sources/DestinyDefaults/_copyable/storage/StaticResponderStorage.swift
+++ b/Sources/DestinyDefaults/_copyable/storage/StaticResponderStorage.swift
@@ -62,9 +62,6 @@ public class StaticResponderStorage: @unchecked Sendable {
         #endif
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func respond(
         router: some HTTPRouterProtocol,
         socket: some FileDescriptor,
@@ -132,9 +129,6 @@ public class StaticResponderStorage: @unchecked Sendable {
 // MARK: Register
 extension StaticResponderStorage {
     /// Registers a static route responder to the given route path.
-    #if Inlinable
-    @inlinable
-    #endif
     public func register(
         path: SIMD64<UInt8>,
         responder: some RouteResponderProtocol
@@ -188,61 +182,40 @@ extension StaticResponderStorage {
     }
 
     #if CopyableMacroExpansion
-    #if Inlinable
-    @inlinable
-    #endif
     public func register(path: SIMD64<UInt8>, _ responder: RouteResponses.MacroExpansion) {
         macroExpansions[path] = responder
     }
     #endif
 
     #if CopyableMacroExpansionWithDateHeader
-    #if Inlinable
-    @inlinable
-    #endif
     public func register(path: SIMD64<UInt8>, _ responder: MacroExpansionWithDateHeader) {
         macroExpansionsWithDateHeader[path] = responder
     }
     #endif
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func register(path: SIMD64<UInt8>, _ responder: StaticString) {
         staticStrings[path] = responder
     }
 
     #if CopyableStaticStringWithDateHeader
-    #if Inlinable
-    @inlinable
-    #endif
     public func register(path: SIMD64<UInt8>, _ responder: StaticStringWithDateHeader) {
         staticStringsWithDateHeader[path] = responder
     }
     #endif
 
     #if StringRouteResponder
-    #if Inlinable
-    @inlinable
-    #endif
     public func register(path: SIMD64<UInt8>, _ responder: String) {
         strings[path] = responder
     }
     #endif
 
     #if CopyableStringWithDateHeader
-    #if Inlinable
-    @inlinable
-    #endif
     public func register(path: SIMD64<UInt8>, _ responder: StringWithDateHeader) {
         stringsWithDateHeader[path] = responder
     }
     #endif
 
     #if CopyableBytes
-    #if Inlinable
-    @inlinable
-    #endif
     public func register(path: SIMD64<UInt8>, _ responder: Bytes) {
         bytes[path] = responder
     }

--- a/Sources/DestinyDefaults/_generics/GenericRouteGroup.swift
+++ b/Sources/DestinyDefaults/_generics/GenericRouteGroup.swift
@@ -26,9 +26,6 @@ public struct GenericRouteGroup<
 
 // MARK: Respond
 extension GenericRouteGroup {
-    #if Inlinable
-    @inlinable
-    #endif
     public func respond(
         router: some HTTPRouterProtocol,
         socket: some FileDescriptor,

--- a/Sources/DestinyDefaults/_noncopyable/NonCopyableHTTPServer.swift
+++ b/Sources/DestinyDefaults/_noncopyable/NonCopyableHTTPServer.swift
@@ -187,9 +187,6 @@ extension NonCopyableHTTPServer where Router: ~Copyable, ClientSocket: ~Copyable
         case reuseAddress = 2
         case reusePort    = 4
 
-        #if Inlinable
-        @inlinable
-        #endif
         static func pack(
             noTCPDelay: Bool,
             reuseAddress: Bool,
@@ -201,30 +198,18 @@ extension NonCopyableHTTPServer where Router: ~Copyable, ClientSocket: ~Copyable
         }
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     func isFlag(_ flag: Flag) -> Bool {
         flags & flag.rawValue != 0
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public var noTCPDelay: Bool {
         isFlag(.noTCPDelay)
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public var reuseAddress: Bool {
         isFlag(.reuseAddress)
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public var reusePort: Bool {
         isFlag(.reusePort)
     }
@@ -232,9 +217,6 @@ extension NonCopyableHTTPServer where Router: ~Copyable, ClientSocket: ~Copyable
 
 // MARK: Process clients
 extension NonCopyableHTTPServer where Router: ~Copyable, ClientSocket: ~Copyable {
-    #if Inlinable
-    @inlinable
-    #endif
     func setNonBlocking(socket: Int32) {
         let flags = fcntl(socket, F_GETFL, 0)
         guard flags != -1 else {
@@ -246,9 +228,6 @@ extension NonCopyableHTTPServer where Router: ~Copyable, ClientSocket: ~Copyable
         }
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     func processClients() async throws(ServerError) {
         #if Epoll
         let _:InlineArray<64, Bool>? = processClientsEpoll(port: port, router: router)
@@ -262,16 +241,10 @@ extension NonCopyableHTTPServer where Router: ~Copyable, ClientSocket: ~Copyable
 #if !Epoll && !Liburing
 
 extension NonCopyableHTTPServer where Router: ~Copyable, ClientSocket: ~Copyable {
-    #if Inlinable
-    @inlinable
-    #endif
     public func acceptFunction(noTCPDelay: Bool) -> @Sendable (Int32?) throws(SocketError) -> Int32? {
         noTCPDelay ? Self.acceptClientNoTCPDelay : Self.acceptClient
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     @Sendable
     static func acceptClient(server: Int32?) throws(SocketError) -> Int32? {
         guard let serverFD = server else { return nil }
@@ -286,9 +259,6 @@ extension NonCopyableHTTPServer where Router: ~Copyable, ClientSocket: ~Copyable
         return client
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     @Sendable
     static func acceptClientNoTCPDelay(server: Int32?) throws(SocketError) -> Int32? {
         guard let serverFD = server else { return nil }
@@ -305,9 +275,6 @@ extension NonCopyableHTTPServer where Router: ~Copyable, ClientSocket: ~Copyable
         return client
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     func processClientsOLD(serverFD: Int32) async {
         let acceptClient = acceptFunction(noTCPDelay: noTCPDelay)
         while !Task.isCancelled {
@@ -339,9 +306,6 @@ extension NonCopyableHTTPServer where Router: ~Copyable, ClientSocket: ~Copyable
 // MARK: Epoll
 extension NonCopyableHTTPServer where Router: ~Copyable, ClientSocket: ~Copyable {
     @discardableResult
-    #if Inlinable
-    @inlinable
-    #endif
     func processClientsEpoll<let maxEvents: Int>(
         port: UInt16,
         router: borrowing Router

--- a/Sources/DestinyDefaults/_noncopyable/responders/NonCopyableBytes.swift
+++ b/Sources/DestinyDefaults/_noncopyable/responders/NonCopyableBytes.swift
@@ -6,30 +6,18 @@ import DestinyEmbedded
 public struct NonCopyableBytes: Sendable, ~Copyable {
     public let value:[UInt8]
 
-    #if Inlinable
-    @inlinable
-    #endif
     public init(_ value: [UInt8]) {
         self.value = value
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public var count: Int {
         value.count
     }
     
-    #if Inlinable
-    @inlinable
-    #endif
     public func string() -> String {
         .init(decoding: value, as: UTF8.self)
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func write(
         to buffer: UnsafeMutableBufferPointer<UInt8>,
         at index: inout Int
@@ -46,9 +34,6 @@ extension NonCopyableBytes {
     ///   - completionHandler: Closure that should be called when the socket should be released.
     /// 
     /// - Throws: `ResponderError`
-    #if Inlinable
-    @inlinable
-    #endif
     public func respond(
         socket: some FileDescriptor,
         completionHandler: @Sendable @escaping () -> Void
@@ -70,9 +55,6 @@ import DestinyBlueprint
 extension NonCopyableBytes: ResponseBodyProtocol {}
 
 extension NonCopyableBytes: NonCopyableRouteResponderProtocol {
-    #if Inlinable
-    @inlinable
-    #endif
     public func respond(
         router: borrowing some NonCopyableHTTPRouterProtocol & ~Copyable,
         socket: some FileDescriptor,

--- a/Sources/DestinyDefaults/_noncopyable/responders/NonCopyableDateHeaderPayload.swift
+++ b/Sources/DestinyDefaults/_noncopyable/responders/NonCopyableDateHeaderPayload.swift
@@ -32,12 +32,6 @@ public struct NonCopyableDateHeaderPayload: @unchecked Sendable, ~Copyable {
     /// Efficiently writes the `preDate` value, `date` header and `postDate` value to a file descriptor.
     /// 
     /// - Throws: `ResponderError`
-    #if Inlinable
-    @inlinable
-    #endif
-    #if InlineAlways
-    @inline(__always)
-    #endif
     public func write(to socket: some FileDescriptor) throws(ResponderError) {
         do throws(SocketError) {
             try socket.writeBuffers3(

--- a/Sources/DestinyDefaults/_noncopyable/responders/NonCopyableInlineBytes.swift
+++ b/Sources/DestinyDefaults/_noncopyable/responders/NonCopyableInlineBytes.swift
@@ -6,30 +6,18 @@ import DestinyEmbedded
 public struct NonCopyableInlineBytes<let count: Int>: Sendable, ~Copyable {
     public let value:InlineArray<count, UInt8>
 
-    #if Inlinable
-    @inlinable
-    #endif
     public init(_ value: InlineArray<count, UInt8>) {
         self.value = value
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public var count: Int {
         value.count
     }
     
-    #if Inlinable
-    @inlinable
-    #endif
     public func string() -> String {
         value.unsafeString()
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func write(
         to buffer: UnsafeMutableBufferPointer<UInt8>,
         at index: inout Int
@@ -46,9 +34,6 @@ extension NonCopyableInlineBytes {
     ///   - completionHandler: Closure that should be called when the socket should be released.
     /// 
     /// - Throws: `ResponderError`
-    #if Inlinable
-    @inlinable
-    #endif
     public func respond(
         socket: some FileDescriptor,
         completionHandler: @Sendable @escaping () -> Void
@@ -70,9 +55,6 @@ import DestinyBlueprint
 extension NonCopyableInlineBytes: ResponseBodyProtocol {}
 
 extension NonCopyableInlineBytes: NonCopyableRouteResponderProtocol {
-    #if Inlinable
-    @inlinable
-    #endif
     public func respond(
         router: borrowing some NonCopyableHTTPRouterProtocol & ~Copyable,
         socket: some FileDescriptor,

--- a/Sources/DestinyDefaults/_noncopyable/responders/NonCopyableMacroExpansionWithDateHeader.swift
+++ b/Sources/DestinyDefaults/_noncopyable/responders/NonCopyableMacroExpansionWithDateHeader.swift
@@ -34,9 +34,6 @@ extension NonCopyableMacroExpansionWithDateHeader {
     ///   - completionHandler: Closure that should be called when the socket should be released.
     /// 
     /// - Throws: `ResponderError`
-    #if Inlinable
-    @inlinable
-    #endif
     public func respond(
         socket: some FileDescriptor,
         completionHandler: @Sendable @escaping () -> Void
@@ -71,9 +68,6 @@ import DestinyBlueprint
 
 // MARK: Conformances
 extension NonCopyableMacroExpansionWithDateHeader: NonCopyableRouteResponderProtocol {
-    #if Inlinable
-    @inlinable
-    #endif
     public func respond(
         router: borrowing some NonCopyableHTTPRouterProtocol & ~Copyable,
         socket: some FileDescriptor,

--- a/Sources/DestinyDefaults/_noncopyable/responders/NonCopyableStaticStringWithDateHeader.swift
+++ b/Sources/DestinyDefaults/_noncopyable/responders/NonCopyableStaticStringWithDateHeader.swift
@@ -30,23 +30,14 @@ public struct NonCopyableStaticStringWithDateHeader: Sendable, ~Copyable {
         self.payload = .init(payload)
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public var count: Int {
         payload.preDatePointerCount +! HTTPDateFormat.InlineArrayResult.count +! payload.postDatePointerCount
     }
     
-    #if Inlinable
-    @inlinable
-    #endif
     public func string() -> String {
         "\(String(cString: payload.preDatePointer))\(HTTPDateFormat.placeholder)\(String(cString: payload.postDatePointer))"
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public var hasDateHeader: Bool {
         true
     }
@@ -54,9 +45,6 @@ public struct NonCopyableStaticStringWithDateHeader: Sendable, ~Copyable {
 
 // MARK: Write to buffer
 extension NonCopyableStaticStringWithDateHeader {
-    #if Inlinable
-    @inlinable
-    #endif
     public func write(to buffer: UnsafeMutableBufferPointer<UInt8>, at index: inout Int) {
         index = 0
         buffer.copyBuffer(baseAddress: payload.preDatePointer, count: payload.preDatePointerCount, at: &index)
@@ -67,12 +55,6 @@ extension NonCopyableStaticStringWithDateHeader {
 
 // MARK: Respond
 extension NonCopyableStaticStringWithDateHeader {
-    #if Inlinable
-    @inlinable
-    #endif
-    #if InlineAlways
-    @inline(__always)
-    #endif
     public func respond(
         router: borrowing some NonCopyableHTTPRouterProtocol & ~Copyable,
         socket: some FileDescriptor,

--- a/Sources/DestinyDefaults/_noncopyable/responders/NonCopyableStreamWithDateHeader.swift
+++ b/Sources/DestinyDefaults/_noncopyable/responders/NonCopyableStreamWithDateHeader.swift
@@ -29,38 +29,23 @@ public struct NonCopyableStreamWithDateHeader<Body: AsyncHTTPSocketWritable & ~C
         )
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public var count: Int {
         payload.preDatePointerCount +! HTTPDateFormat.InlineArrayResult.count +! payload.postDatePointerCount
     }
     
-    #if Inlinable
-    @inlinable
-    #endif
     public func string() -> String {
         "\(String(cString: payload.preDatePointer))\(HTTPDateFormat.placeholder)\(String(cString: payload.postDatePointer))"
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public var hasDateHeader: Bool {
         true
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public var hasContentLength: Bool {
         false
     }
 
     // MARK: Write to buffer
-    #if Inlinable
-    @inlinable
-    #endif
     public mutating func write(to buffer: UnsafeMutableBufferPointer<UInt8>, at index: inout Int) throws(BufferWriteError) {
         // TODO: support?
     }
@@ -68,9 +53,6 @@ public struct NonCopyableStreamWithDateHeader<Body: AsyncHTTPSocketWritable & ~C
 
 // MARK: Respond
 extension NonCopyableStreamWithDateHeader {
-    #if Inlinable
-    @inlinable
-    #endif
     public func respond(
         router: borrowing some NonCopyableHTTPRouterProtocol & ~Copyable,
         socket: some FileDescriptor,

--- a/Sources/DestinyDefaults/_noncopyable/responders/ResponseBody+NonCopyableMacroExpansionWithDateHeader.swift
+++ b/Sources/DestinyDefaults/_noncopyable/responders/ResponseBody+NonCopyableMacroExpansionWithDateHeader.swift
@@ -4,9 +4,6 @@
 import DestinyEmbedded
 
 extension ResponseBody {
-    #if Inlinable
-    @inlinable
-    #endif
     public static func nonCopyableMacroExpansionWithDateHeader<Value: ResponseBodyValueProtocol>(_ value: Value) -> NonCopyableMacroExpansionWithDateHeader<Value> {
         .init(value)
     }
@@ -14,30 +11,18 @@ extension ResponseBody {
     public struct NonCopyableMacroExpansionWithDateHeader<Value: ResponseBodyValueProtocol>: Sendable, ~Copyable {
         public var value:Value
 
-        #if Inlinable
-        @inlinable
-        #endif
         public init(_ value: Value) {
             self.value = value
         }
 
-        #if Inlinable
-        @inlinable
-        #endif
         public var count: Int {
             value.count
         }
         
-        #if Inlinable
-        @inlinable
-        #endif
         public func string() -> String {
             value.string()
         }
 
-        #if Inlinable
-        @inlinable
-        #endif
         public mutating func write(
             to buffer: UnsafeMutableBufferPointer<UInt8>,
             at index: inout Int
@@ -45,9 +30,6 @@ extension ResponseBody {
             try value.write(to: buffer, at: &index)
         }
 
-        #if Inlinable
-        @inlinable
-        #endif
         public var hasDateHeader: Bool {
             true
         }

--- a/Sources/DestinyDefaults/extensions/AbstractHTTPRequestExtensions.swift
+++ b/Sources/DestinyDefaults/extensions/AbstractHTTPRequestExtensions.swift
@@ -6,12 +6,6 @@ import DestinyBlueprint
 // MARK: Conformance logic
 extension AbstractHTTPRequest {
     /// - Throws: `SocketError`
-    #if Inlinable
-    @inlinable
-    #endif
-    #if InlineAlways
-    @inline(__always)
-    #endif
     mutating func isMethod(fileDescriptor: some FileDescriptor, _ method: some HTTPRequestMethodProtocol) throws(SocketError) -> Bool {
         if initialBuffer == nil {
             try loadStorage(fileDescriptor: fileDescriptor)

--- a/Sources/DestinyDefaults/extensions/HTTPRequestExtensions.swift
+++ b/Sources/DestinyDefaults/extensions/HTTPRequestExtensions.swift
@@ -5,9 +5,6 @@ import DestinyBlueprint
 
 // MARK: Conformances
 extension HTTPRequest {
-    #if Inlinable
-    @inlinable
-    #endif
     public mutating func isMethod(_ method: some HTTPRequestMethodProtocol) throws(SocketError) -> Bool {
         try abstractRequest.isMethod(fileDescriptor: fileDescriptor, method)
     }

--- a/Sources/DestinyDefaults/generated/headers/HTTPNonStandardRequestHeader.swift
+++ b/Sources/DestinyDefaults/generated/headers/HTTPNonStandardRequestHeader.swift
@@ -22,9 +22,6 @@ public enum HTTPNonStandardRequestHeader {
     case xWapProfile
 
     /// Lowercased canonical name of the header used for comparison.
-    #if Inlinable
-    @inlinable
-    #endif
     public var canonicalName: String {
         switch self {
         case .correlationID: "correlation-id"
@@ -51,9 +48,6 @@ public enum HTTPNonStandardRequestHeader {
 
 #if HTTPNonStandardRequestHeaderRawNames
 extension HTTPNonStandardRequestHeader {
-    #if Inlinable
-    @inlinable
-    #endif
     public var rawName: String {
         switch self {
         case .correlationID: "Correlation-ID"
@@ -88,9 +82,6 @@ extension HTTPNonStandardRequestHeader: Hashable {
 extension HTTPNonStandardRequestHeader: RawRepresentable {
     public typealias RawValue = String
 
-    #if Inlinable
-    @inlinable
-    #endif
     public init?(rawValue: RawValue) {
         switch rawValue {
         case "correlationID": self = .correlationID
@@ -115,9 +106,6 @@ extension HTTPNonStandardRequestHeader: RawRepresentable {
         }
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public var rawValue: RawValue {
         switch self {
         case .correlationID: "correlationID"

--- a/Sources/DestinyDefaults/generated/headers/HTTPNonStandardResponseHeader.swift
+++ b/Sources/DestinyDefaults/generated/headers/HTTPNonStandardResponseHeader.swift
@@ -21,9 +21,6 @@ public enum HTTPNonStandardResponseHeader {
     case xXSSProtection
 
     /// Lowercased canonical name of the header used for comparison.
-    #if Inlinable
-    @inlinable
-    #endif
     public var canonicalName: String {
         switch self {
         case .contentSecurityPolicy: "content-security-policy"
@@ -49,9 +46,6 @@ public enum HTTPNonStandardResponseHeader {
 
 #if HTTPNonStandardResponseHeaderRawNames
 extension HTTPNonStandardResponseHeader {
-    #if Inlinable
-    @inlinable
-    #endif
     public var rawName: String {
         switch self {
         case .contentSecurityPolicy: "Content-Security-Policy"
@@ -85,9 +79,6 @@ extension HTTPNonStandardResponseHeader: Hashable {
 extension HTTPNonStandardResponseHeader: RawRepresentable {
     public typealias RawValue = String
 
-    #if Inlinable
-    @inlinable
-    #endif
     public init?(rawValue: RawValue) {
         switch rawValue {
         case "contentSecurityPolicy": self = .contentSecurityPolicy
@@ -111,9 +102,6 @@ extension HTTPNonStandardResponseHeader: RawRepresentable {
         }
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public var rawValue: RawValue {
         switch self {
         case .contentSecurityPolicy: "contentSecurityPolicy"

--- a/Sources/DestinyDefaults/generated/headers/HTTPStandardRequestHeader.swift
+++ b/Sources/DestinyDefaults/generated/headers/HTTPStandardRequestHeader.swift
@@ -43,9 +43,6 @@ public enum HTTPStandardRequestHeader {
     case via
 
     /// Lowercased canonical name of the header used for comparison.
-    #if Inlinable
-    @inlinable
-    #endif
     public var canonicalName: String {
         switch self {
         case .aim: "a-im"
@@ -92,9 +89,6 @@ public enum HTTPStandardRequestHeader {
 
 #if HTTPStandardRequestHeaderRawNames
 extension HTTPStandardRequestHeader {
-    #if Inlinable
-    @inlinable
-    #endif
     public var rawName: String {
         switch self {
         case .aim: "A-IM"
@@ -149,9 +143,6 @@ extension HTTPStandardRequestHeader: Hashable {
 extension HTTPStandardRequestHeader: RawRepresentable {
     public typealias RawValue = String
 
-    #if Inlinable
-    @inlinable
-    #endif
     public init?(rawValue: RawValue) {
         switch rawValue {
         case "aim": self = .aim
@@ -196,9 +187,6 @@ extension HTTPStandardRequestHeader: RawRepresentable {
         }
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public var rawValue: RawValue {
         switch self {
         case .aim: "aim"

--- a/Sources/DestinyDefaults/generated/headers/HTTPStandardResponseHeader.swift
+++ b/Sources/DestinyDefaults/generated/headers/HTTPStandardResponseHeader.swift
@@ -49,9 +49,6 @@ public enum HTTPStandardResponseHeader {
     case wwwAuthenticate
 
     /// Lowercased canonical name of the header used for comparison.
-    #if Inlinable
-    @inlinable
-    #endif
     public var canonicalName: String {
         switch self {
         case .acceptPatch: "accept-patch"
@@ -104,9 +101,6 @@ public enum HTTPStandardResponseHeader {
 
 #if HTTPStandardResponseHeaderRawNames
 extension HTTPStandardResponseHeader {
-    #if Inlinable
-    @inlinable
-    #endif
     public var rawName: String {
         switch self {
         case .acceptPatch: "Accept-Patch"
@@ -167,9 +161,6 @@ extension HTTPStandardResponseHeader: Hashable {
 extension HTTPStandardResponseHeader: RawRepresentable {
     public typealias RawValue = String
 
-    #if Inlinable
-    @inlinable
-    #endif
     public init?(rawValue: RawValue) {
         switch rawValue {
         case "acceptPatch": self = .acceptPatch
@@ -220,9 +211,6 @@ extension HTTPStandardResponseHeader: RawRepresentable {
         }
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public var rawValue: RawValue {
         switch self {
         case .acceptPatch: "acceptPatch"

--- a/Sources/DestinyDefaults/generated/requestMethods/HTTPNonStandardRequestMethods.swift
+++ b/Sources/DestinyDefaults/generated/requestMethods/HTTPNonStandardRequestMethods.swift
@@ -107,9 +107,6 @@ public enum HTTPNonStandardRequestMethod: HTTPRequestMethodProtocol {
     case validate
     case verify
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func rawNameString() -> String {
         switch self {
         case .announce: "ANNOUNCE"
@@ -222,9 +219,6 @@ public enum HTTPNonStandardRequestMethod: HTTPRequestMethodProtocol {
 extension HTTPNonStandardRequestMethod: RawRepresentable {
     public typealias RawValue = String
 
-    #if Inlinable
-    @inlinable
-    #endif
     public init?(rawValue: String) {
         switch rawValue {
         case "announce": self = .announce
@@ -333,9 +327,6 @@ extension HTTPNonStandardRequestMethod: RawRepresentable {
         }
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public var rawValue: String {
         switch self {
         case .announce: "announce"

--- a/Sources/DestinyDefaults/generated/requestMethods/HTTPStandardRequestMethods.swift
+++ b/Sources/DestinyDefaults/generated/requestMethods/HTTPStandardRequestMethods.swift
@@ -41,9 +41,6 @@ public enum HTTPStandardRequestMethod: Sendable {
     case updateredirectref
     case versionControl
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func rawNameString() -> String {
         switch self {
         case .connect: "CONNECT"
@@ -92,9 +89,6 @@ public enum HTTPStandardRequestMethod: Sendable {
 extension HTTPStandardRequestMethod: RawRepresentable {
     public typealias RawValue = String
 
-    #if Inlinable
-    @inlinable
-    #endif
     public init?(rawValue: String) {
         switch rawValue {
         case "connect": self = .connect
@@ -139,9 +133,6 @@ extension HTTPStandardRequestMethod: RawRepresentable {
         }
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public var rawValue: String {
         switch self {
         case .connect: "connect"

--- a/Sources/DestinyDefaults/generated/responseStatuses/HTTPNonStandardResponseStatus.swift
+++ b/Sources/DestinyDefaults/generated/responseStatuses/HTTPNonStandardResponseStatus.swift
@@ -42,9 +42,6 @@ public enum HTTPNonStandardResponseStatus: Sendable {
     case _464
     case _561
 
-    #if Inlinable
-    @inlinable
-    #endif
     public var code: UInt16 {
         switch self {
         case .thisIsFine: 218
@@ -94,9 +91,6 @@ public enum HTTPNonStandardResponseStatus: Sendable {
 extension HTTPNonStandardResponseStatus: RawRepresentable {
     public typealias RawValue = String
 
-    #if Inlinable
-    @inlinable
-    #endif
     public init?(rawValue: RawValue) {
         switch rawValue {
         case "thisIsFine": self = .thisIsFine
@@ -142,9 +136,6 @@ extension HTTPNonStandardResponseStatus: RawRepresentable {
         }
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public var rawValue: RawValue {
         switch self {
         case .thisIsFine: "thisIsFine"

--- a/Sources/DestinyDefaults/generated/responseStatuses/HTTPStandardResponseStatus.swift
+++ b/Sources/DestinyDefaults/generated/responseStatuses/HTTPStandardResponseStatus.swift
@@ -127,9 +127,6 @@ public enum HTTPStandardResponseStatus: Sendable {
     /// https://www.rfc-editor.org/rfc/rfc9110.html#status.511
     case networkAuthenticationRequired
 
-    #if Inlinable
-    @inlinable
-    #endif
     public var code: UInt16 {
         switch self {
         case .`continue`: 100
@@ -202,9 +199,6 @@ public enum HTTPStandardResponseStatus: Sendable {
 extension HTTPStandardResponseStatus: RawRepresentable {
     public typealias RawValue = String
 
-    #if Inlinable
-    @inlinable
-    #endif
     public init?(rawValue: RawValue) {
         switch rawValue {
         case "`continue`", "continue": self = .`continue`
@@ -273,9 +267,6 @@ extension HTTPStandardResponseStatus: RawRepresentable {
         }
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public var rawValue: RawValue {
         switch self {
         case .`continue`: "continue"

--- a/Sources/DestinyDefaults/middleware/CORSLogic.swift
+++ b/Sources/DestinyDefaults/middleware/CORSLogic.swift
@@ -20,9 +20,6 @@ import DestinyBlueprint
 // MARK: Apply to response
 extension CORSLogic {
     /// Applies CORS headers to a dynamic response.
-    #if Inlinable
-    @inlinable
-    #endif
     public func apply(
         to response: inout some DynamicResponseProtocol
     ) {
@@ -50,9 +47,6 @@ extension CORSLogic {
 // MARK: Apply to headers
 extension CORSLogic {
     /// Applies CORS headers to a `HTTPHeaders`.
-    #if Inlinable
-    @inlinable
-    #endif
     public func apply(
         to headers: inout HTTPHeaders
     ) {

--- a/Sources/DestinyDefaults/middleware/CORSMiddleware.swift
+++ b/Sources/DestinyDefaults/middleware/CORSMiddleware.swift
@@ -19,9 +19,6 @@ public struct CORSMiddleware: Sendable {
         self.logicKind = logicKind
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     package static func maxAgeString(_ input: Int?) -> String? {
         guard let input else { return nil }
         return "\(input)"
@@ -31,9 +28,6 @@ public struct CORSMiddleware: Sendable {
 // MARK: Handle
 extension CORSMiddleware {
     /// - Throws: `MiddlewareError`
-    #if Inlinable
-    @inlinable
-    #endif
     public func handle(
         request: inout HTTPRequest,
         headers: inout HTTPHeaders
@@ -56,9 +50,6 @@ extension CORSMiddleware {
     /// 
     /// - Returns: Whether or not to continue processing the request.
     /// - Throws: `MiddlewareError`
-    #if Inlinable
-    @inlinable
-    #endif
     public func handle(
         request: inout HTTPRequest,
         response: inout some DynamicResponseProtocol
@@ -177,9 +168,6 @@ extension CORSMiddleware {
 import DestinyBlueprint
 
 extension CORSMiddleware {
-    #if Inlinable
-    @inlinable
-    #endif
     static func handleSharedLogic(
         _ response: inout some DynamicResponseProtocol,
         _ allowedHeaders: String,
@@ -191,9 +179,6 @@ extension CORSMiddleware {
 }
 
 extension CORSMiddleware {
-    #if Inlinable
-    @inlinable
-    #endif
     static func logic_allowCredentials_exposedHeaders_maxAge(
         _ response: inout some DynamicResponseProtocol,
         _ allowedHeaders: String,
@@ -205,9 +190,6 @@ extension CORSMiddleware {
         response.setHeader(key: "access-control-allow-credentials", value: "true")
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     static func logic_allowCredentials_exposedHeaders(
         _ response: inout some DynamicResponseProtocol,
         _ allowedHeaders: String,
@@ -218,9 +200,6 @@ extension CORSMiddleware {
         response.setHeader(key: "access-control-allow-credentials", value: "true")
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     static func logic_allowCredentials_maxAge(
         _ response: inout some DynamicResponseProtocol,
         _ allowedHeaders: String,
@@ -231,9 +210,6 @@ extension CORSMiddleware {
         response.setHeader(key: "access-control-max-age", value: maxAgeString)
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     static func logic_allowCredentials(
         _ response: inout some DynamicResponseProtocol,
         _ allowedHeaders: String,
@@ -245,9 +221,6 @@ extension CORSMiddleware {
 }
 
 extension CORSMiddleware {
-    #if Inlinable
-    @inlinable
-    #endif
     static func logic_exposedHeaders_maxAge(
         _ response: inout some DynamicResponseProtocol,
         _ allowedHeaders: String,
@@ -259,9 +232,6 @@ extension CORSMiddleware {
         response.setHeader(key: "access-control-max-age", value: maxAgeString)
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     static func logic_exposedHeaders(
         _ response: inout some DynamicResponseProtocol,
         _ allowedHeaders: String,
@@ -274,9 +244,6 @@ extension CORSMiddleware {
 }
 
 extension CORSMiddleware {
-    #if Inlinable
-    @inlinable
-    #endif
     static func logic_maxAge(
         _ response: inout some DynamicResponseProtocol,
         _ allowedHeaders: String,
@@ -290,9 +257,6 @@ extension CORSMiddleware {
 
 // MARK: HTTPHeaders
 extension CORSMiddleware {
-    #if Inlinable
-    @inlinable
-    #endif
     static func handleSharedLogic(
         _ headers: inout HTTPHeaders,
         _ allowedHeaders: String,
@@ -304,9 +268,6 @@ extension CORSMiddleware {
 }
 
 extension CORSMiddleware {
-    #if Inlinable
-    @inlinable
-    #endif
     static func logic_allowCredentials_exposedHeaders_maxAge(
         _ headers: inout HTTPHeaders,
         _ allowedHeaders: String,
@@ -318,9 +279,6 @@ extension CORSMiddleware {
         headers["access-control-allow-credentials"] = "true"
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     static func logic_allowCredentials_exposedHeaders(
         _ headers: inout HTTPHeaders,
         _ allowedHeaders: String,
@@ -331,9 +289,6 @@ extension CORSMiddleware {
         headers["access-control-allow-credentials"] = "true"
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     static func logic_allowCredentials_maxAge(
         _ headers: inout HTTPHeaders,
         _ allowedHeaders: String,
@@ -344,9 +299,6 @@ extension CORSMiddleware {
         headers["access-control-max-age"] = maxAgeString
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     static func logic_allowCredentials(
         _ headers: inout HTTPHeaders,
         _ allowedHeaders: String,
@@ -358,9 +310,6 @@ extension CORSMiddleware {
 }
 
 extension CORSMiddleware {
-    #if Inlinable
-    @inlinable
-    #endif
     static func logic_exposedHeaders_maxAge(
         _ headers: inout HTTPHeaders,
         _ allowedHeaders: String,
@@ -372,9 +321,6 @@ extension CORSMiddleware {
         headers["access-control-max-age"] = maxAgeString
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     static func logic_exposedHeaders(
         _ headers: inout HTTPHeaders,
         _ allowedHeaders: String,
@@ -387,9 +333,6 @@ extension CORSMiddleware {
 }
 
 extension CORSMiddleware {
-    #if Inlinable
-    @inlinable
-    #endif
     static func logic_maxAge(
         _ headers: inout HTTPHeaders,
         _ allowedHeaders: String,

--- a/Sources/DestinyDefaults/middleware/dynamic/DynamicDateMiddleware.swift
+++ b/Sources/DestinyDefaults/middleware/dynamic/DynamicDateMiddleware.swift
@@ -14,9 +14,6 @@ public struct DynamicDateMiddleware: Sendable {
     /// 
     /// - Returns: Whether or not to continue processing the request.
     /// - Throws: `MiddlewareError`
-    #if Inlinable
-    @inlinable
-    #endif
     public func handle(
         request: inout HTTPRequest,
         response: inout some DynamicResponseProtocol

--- a/Sources/DestinyDefaults/middleware/dynamic/DynamicRateLimitMiddleware.swift
+++ b/Sources/DestinyDefaults/middleware/dynamic/DynamicRateLimitMiddleware.swift
@@ -25,9 +25,6 @@ extension DynamicRateLimitMiddleware {
     /// 
     /// - Returns: Whether or not to continue processing the request.
     /// - Throws: `MiddlewareError`
-    #if Inlinable
-    @inlinable
-    #endif
     public func handle(
         request: inout HTTPRequest,
         response: inout some DynamicResponseProtocol

--- a/Sources/DestinyDefaults/responders/ResponseBodyValueProtocol.swift
+++ b/Sources/DestinyDefaults/responders/ResponseBodyValueProtocol.swift
@@ -10,25 +10,16 @@ public protocol ResponseBodyValueProtocol: BufferWritable, ~Copyable {
 
 // MARK: Default conformances
 extension String: ResponseBodyValueProtocol {
-    #if Inlinable
-    @inlinable
-    #endif
     public func string() -> String {
         self
     }
 }
 
 extension StaticString: ResponseBodyValueProtocol {
-    #if Inlinable
-    @inlinable
-    #endif
     public var count: Int {
         self.utf8CodeUnitCount
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func string() -> String {
         description
     }

--- a/Sources/DestinyDefaults/routes/StaticRedirectionRoute.swift
+++ b/Sources/DestinyDefaults/routes/StaticRedirectionRoute.swift
@@ -22,9 +22,6 @@ public struct StaticRedirectionRoute: Sendable {
     public let version:HTTPVersion
 
     /// The http start line this route redirects from.
-    #if Inlinable
-    @inlinable
-    #endif
     public func fromStartLine() -> String {
         return "\(method.rawNameString()) /\(from.joined(separator: "/")) \(version.string)"
     }

--- a/Sources/DestinyDefaultsNonEmbedded/HTTPResponseMessage+Convenience+NonEmbedded.swift
+++ b/Sources/DestinyDefaultsNonEmbedded/HTTPResponseMessage+Convenience+NonEmbedded.swift
@@ -24,9 +24,6 @@ extension HTTPResponseMessage {
         self.init(head: head, body: body, contentType: mediaType?.template, charset: charset)
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public static func create(
         escapeLineBreak: Bool,
         version: HTTPVersion,
@@ -40,9 +37,6 @@ extension HTTPResponseMessage {
         return create(suffix: suffix, version: version, status: status, headers: Self.headers(suffix: suffix, headers: headers), body: body, mediaType: mediaType, charset: charset)
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public static func create(
         suffix: String,
         version: HTTPVersion,

--- a/Sources/DestinyDefaultsNonEmbedded/extensions/PathComponentExtensions+NonEmbedded.swift
+++ b/Sources/DestinyDefaultsNonEmbedded/extensions/PathComponentExtensions+NonEmbedded.swift
@@ -3,9 +3,6 @@ import DestinyBlueprint
 
 // MARK: CustomStringConvertible
 extension PathComponent: CustomStringConvertible {
-    #if Inlinable
-    @inlinable
-    #endif
     public var description: String {
         "\"\(slug)\""
     }

--- a/Sources/DestinyDefaultsNonEmbedded/middleware/DynamicMiddleware.swift
+++ b/Sources/DestinyDefaultsNonEmbedded/middleware/DynamicMiddleware.swift
@@ -22,9 +22,6 @@ public struct DynamicMiddleware: Sendable {
     /// 
     /// - Returns: Whether or not to continue processing the request.
     /// - Throws: `MiddlewareError`
-    #if Inlinable
-    @inlinable
-    #endif
     public func handle(
         request: inout HTTPRequest,
         response: inout any DynamicResponseProtocol

--- a/Sources/DestinyDefaultsNonEmbedded/request/AbstractHTTPRequest+NonEmbedded.swift
+++ b/Sources/DestinyDefaultsNonEmbedded/request/AbstractHTTPRequest+NonEmbedded.swift
@@ -7,12 +7,6 @@ import DestinyDefaults
 // MARK: Body
 extension AbstractHTTPRequest {
     /// - Throws: `any Error`
-    #if Inlinable
-    @inlinable
-    #endif
-    #if InlineAlways
-    @inline(__always)
-    #endif
     package mutating func bodyStream<let count: Int>(
         fileDescriptor: some FileDescriptor,
         _ yield: (consuming InlineByteBuffer<count>) async throws -> Void

--- a/Sources/DestinyDefaultsNonEmbedded/request/AbstractHTTPRequest+_Storage+NonEmbedded.swift
+++ b/Sources/DestinyDefaultsNonEmbedded/request/AbstractHTTPRequest+_Storage+NonEmbedded.swift
@@ -10,9 +10,6 @@ extension AbstractHTTPRequest._Storage {
     /// - Warning: `_headers` **MUST NOT** be `nil`!
     /// 
     /// - Throws: `any Error`
-    #if Inlinable
-    @inlinable
-    #endif
     mutating func bodyStream<let initialBufferCount: Int, let bufferCount: Int>(
         fileDescriptor: some FileDescriptor,
         initialBuffer: borrowing InlineByteBuffer<initialBufferCount>,
@@ -52,12 +49,6 @@ extension AbstractHTTPRequest._Storage {
         try await _body!.stream(fileDescriptor: fileDescriptor, yield)
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
-    #if InlineAlways
-    @inline(__always)
-    #endif
     mutating func loadBufferSlice<let initialBufferCount: Int, let bufferCount: Int>(
         initialBuffer: borrowing InlineByteBuffer<initialBufferCount>,
         buffer: inout InlineArray<bufferCount, UInt8>,

--- a/Sources/DestinyDefaultsNonEmbedded/request/CopyableInlineBuffer.swift
+++ b/Sources/DestinyDefaultsNonEmbedded/request/CopyableInlineBuffer.swift
@@ -12,23 +12,11 @@ struct CopyableInlineBuffer<let count: Int>: Sendable {
     @usableFromInline
     let endIndex:Int
 
-    #if Inlinable
-    @inlinable
-    #endif
-    #if InlineAlways
-    @inline(__always)
-    #endif
     init(buffer: InlineArray<count, UInt8>, endIndex: Int) {
         self.buffer = buffer
         self.endIndex = endIndex
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
-    #if InlineAlways
-    @inline(__always)
-    #endif
     func noncopyable() -> InlineByteBuffer<count> {
         .init(buffer: buffer, endIndex: endIndex)
     }

--- a/Sources/DestinyDefaultsNonEmbedded/request/HTTPRequest+NonEmbedded.swift
+++ b/Sources/DestinyDefaultsNonEmbedded/request/HTTPRequest+NonEmbedded.swift
@@ -6,18 +6,12 @@ import DestinyDefaults
 
 extension HTTPRequest {
     /// - Throws: `any Error`
-    #if Inlinable
-    @inlinable
-    #endif
     public mutating func bodyStream(
         _ yield: (consuming InitialBuffer) async throws -> Void
     ) async throws {
         try await abstractRequest.bodyStream(fileDescriptor: fileDescriptor, yield)
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public mutating func bodyStream<let count: Int>(
         _ yield: (consuming InlineByteBuffer<count>) async throws -> Void
     ) async throws {

--- a/Sources/DestinyDefaultsNonEmbedded/request/RequestBody+NonEmbedded.swift
+++ b/Sources/DestinyDefaultsNonEmbedded/request/RequestBody+NonEmbedded.swift
@@ -9,9 +9,6 @@ extension RequestBody {
     /// Streams data from a file descriptor.
     /// 
     /// - Throws: `any Error`
-    #if Inlinable
-    @inlinable
-    #endif
     public mutating func stream<let chunkSize: Int>(
         fileDescriptor: some FileDescriptor,
         //maximumSize: Int = 500_000,
@@ -24,9 +21,6 @@ extension RequestBody {
     /// Streams data from a file descriptor and writes it into a buffer.
     /// 
     /// - Throws: `any Error`
-    #if Inlinable
-    @inlinable
-    #endif
     public mutating func stream<let chunkSize: Int>(
         fileDescriptor: some FileDescriptor,
         buffer: inout InlineArray<chunkSize, UInt8>,

--- a/Sources/DestinyDefaultsNonEmbedded/responders/DynamicRouteResponder.swift
+++ b/Sources/DestinyDefaultsNonEmbedded/responders/DynamicRouteResponder.swift
@@ -24,30 +24,18 @@ public struct DynamicRouteResponder: Sendable {
         self.logicDebugDescription = logicDebugDescription
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func defaultResponse() -> DynamicResponse {
         return _defaultResponse
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public var pathComponentsCount: Int {
         path.count
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func pathComponent(at index: Int) -> PathComponent {
         path[index]
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func forEachPathComponentParameterIndex(_ yield: (Int) -> Void) {
         for index in parameterPathIndexes {
             yield(index)
@@ -57,9 +45,6 @@ public struct DynamicRouteResponder: Sendable {
 
 // MARK: Respond
 extension DynamicRouteResponder {
-    #if Inlinable
-    @inlinable
-    #endif
     public func respond(
         router: some HTTPRouterProtocol,
         socket: some FileDescriptor,

--- a/Sources/DestinyDefaultsNonEmbedded/routes/Route+Copyable+MediaTypes.swift
+++ b/Sources/DestinyDefaultsNonEmbedded/routes/Route+Copyable+MediaTypes.swift
@@ -5,9 +5,6 @@ import DestinyBlueprint
 import MediaTypes
 
 extension Route {
-    #if Inlinable
-    @inlinable
-    #endif
     public static func on(
         head: HTTPResponseMessageHead = .default,
         method: some HTTPRequestMethodProtocol,
@@ -28,9 +25,6 @@ extension Route {
         )
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public static func get(
         head: HTTPResponseMessageHead = .default,
         path: [PathComponent],
@@ -50,9 +44,6 @@ extension Route {
         )
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public static func head(
         head: HTTPResponseMessageHead = .default,
         path: [PathComponent],
@@ -72,9 +63,6 @@ extension Route {
         )
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public static func post(
         head: HTTPResponseMessageHead = .default,
         path: [PathComponent],
@@ -93,9 +81,6 @@ extension Route {
         )
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public static func put(
         head: HTTPResponseMessageHead = .default,
         path: [PathComponent],
@@ -115,9 +100,6 @@ extension Route {
         )
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public static func delete(
         head: HTTPResponseMessageHead = .default,
         path: [PathComponent],
@@ -137,9 +119,6 @@ extension Route {
         )
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public static func connect(
         head: HTTPResponseMessageHead = .default,
         path: [PathComponent],
@@ -159,9 +138,6 @@ extension Route {
         )
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public static func options(
         head: HTTPResponseMessageHead = .default,
         path: [PathComponent],
@@ -181,9 +157,6 @@ extension Route {
         )
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public static func trace(
         head: HTTPResponseMessageHead = .default,
         path: [PathComponent],
@@ -203,9 +176,6 @@ extension Route {
         )
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public static func patch(
         head: HTTPResponseMessageHead = .default,
         path: [PathComponent],

--- a/Sources/DestinyDefaultsNonEmbedded/routes/Route+Copyable.swift
+++ b/Sources/DestinyDefaultsNonEmbedded/routes/Route+Copyable.swift
@@ -4,9 +4,6 @@
 import DestinyBlueprint
 
 extension Route {
-    #if Inlinable
-    @inlinable
-    #endif
     public static func on(
         head: HTTPResponseMessageHead = .default,
         method: some HTTPRequestMethodProtocol,
@@ -29,9 +26,6 @@ extension Route {
         )
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public static func get(
         head: HTTPResponseMessageHead = .default,
         path: [PathComponent],
@@ -53,9 +47,6 @@ extension Route {
         )
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public static func head(
         head: HTTPResponseMessageHead = .default,
         path: [PathComponent],
@@ -77,9 +68,6 @@ extension Route {
         )
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public static func post(
         head: HTTPResponseMessageHead = .default,
         path: [PathComponent],
@@ -101,9 +89,6 @@ extension Route {
         )
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public static func put(
         head: HTTPResponseMessageHead = .default,
         path: [PathComponent],
@@ -125,9 +110,6 @@ extension Route {
         )
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public static func delete(
         head: HTTPResponseMessageHead = .default,
         path: [PathComponent],
@@ -149,9 +131,6 @@ extension Route {
         )
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public static func connect(
         head: HTTPResponseMessageHead = .default,
         path: [PathComponent],
@@ -173,9 +152,6 @@ extension Route {
         )
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public static func options(
         head: HTTPResponseMessageHead = .default,
         path: [PathComponent],
@@ -197,9 +173,6 @@ extension Route {
         )
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public static func trace(
         head: HTTPResponseMessageHead = .default,
         path: [PathComponent],
@@ -221,9 +194,6 @@ extension Route {
         )
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public static func patch(
         head: HTTPResponseMessageHead = .default,
         path: [PathComponent],

--- a/Sources/DestinyDefaultsNonEmbedded/routes/RouteGroup.swift
+++ b/Sources/DestinyDefaultsNonEmbedded/routes/RouteGroup.swift
@@ -72,9 +72,6 @@ public struct RouteGroup: Sendable { // TODO: avoid existentials / support embed
 
 // MARK: Respond
 extension RouteGroup {
-    #if Inlinable
-    @inlinable
-    #endif
     public func respond(
         router: some HTTPRouterProtocol,
         socket: some FileDescriptor,

--- a/Sources/DestinyDefaultsNonEmbedded/routes/storage/DynamicResponderStorage.swift
+++ b/Sources/DestinyDefaultsNonEmbedded/routes/storage/DynamicResponderStorage.swift
@@ -29,9 +29,6 @@ public final class DynamicResponderStorage: @unchecked Sendable {
 
 // MARK: Respond
 extension DynamicResponderStorage {
-    #if Inlinable
-    @inlinable
-    #endif
     public func respond(
         router: some HTTPRouterProtocol,
         socket: some FileDescriptor,
@@ -43,9 +40,6 @@ extension DynamicResponderStorage {
         return true
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     package func responder(for request: inout HTTPRequest) throws(ResponderError) -> (any DynamicRouteResponderProtocol)? {
         let requestStartLine:SIMD64<UInt8>
         do throws(SocketError) {
@@ -84,9 +78,6 @@ extension DynamicResponderStorage {
         return try catchallResponder(for: &request)
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     func catchallResponder(for request: inout HTTPRequest) throws(ResponderError) -> (any DynamicRouteResponderProtocol)? {
         var responderIndex = 0
         loop: while responderIndex < catchall.count {
@@ -120,9 +111,6 @@ extension DynamicResponderStorage {
 // MARK: Register
 extension DynamicResponderStorage {
     /// Registers a dynamic route responder to the given route path.
-    #if Inlinable
-    @inlinable
-    #endif
     public func register(
         route: some DynamicRouteProtocol,
         responder: some DynamicRouteResponderProtocol,

--- a/Sources/DestinyDefaultsNonEmbedded/routes/storage/RouteGroupStorage.swift
+++ b/Sources/DestinyDefaultsNonEmbedded/routes/storage/RouteGroupStorage.swift
@@ -21,9 +21,6 @@ extension RouteGroupStorage {
     /// 
     /// - Returns: Whether or not a response was sent.
     /// - Throws: `ResponderError`
-    #if Inlinable
-    @inlinable
-    #endif
     public func respond(
         router: some HTTPRouterProtocol,
         socket: some FileDescriptor,

--- a/Sources/DestinyEmbedded/BufferWritable.swift
+++ b/Sources/DestinyEmbedded/BufferWritable.swift
@@ -12,9 +12,6 @@ public protocol BufferWritable: Sendable, ~Copyable {
 
 // MARK: Default conformances
 extension String: BufferWritable {
-    #if Inlinable
-    @inlinable
-    #endif
     public mutating func write(
         to buffer: UnsafeMutableBufferPointer<UInt8>,
         at index: inout Int
@@ -26,9 +23,6 @@ extension String: BufferWritable {
 }
 
 extension StaticString: BufferWritable {
-    #if Inlinable
-    @inlinable
-    #endif
     public func write(
         to buffer: UnsafeMutableBufferPointer<UInt8>,
         at index: inout Int
@@ -38,9 +32,6 @@ extension StaticString: BufferWritable {
 }
 
 extension [UInt8]: BufferWritable {
-    #if Inlinable
-    @inlinable
-    #endif
     public func write(
         to buffer: UnsafeMutableBufferPointer<UInt8>,
         at index: inout Int

--- a/Sources/DestinyEmbedded/Charset.swift
+++ b/Sources/DestinyEmbedded/Charset.swift
@@ -15,9 +15,6 @@ public enum Charset: Sendable {
     case utf32
 
     // MARK: Raw name
-    #if Inlinable
-    @inlinable
-    #endif
     public var rawName: String {
         switch self {
         case .any: "*"

--- a/Sources/DestinyEmbedded/FileDescriptor.swift
+++ b/Sources/DestinyEmbedded/FileDescriptor.swift
@@ -87,9 +87,6 @@ public protocol FileDescriptor: NetworkAddressable, ~Copyable {
 
 // MARK: Write
 extension FileDescriptor where Self: ~Copyable {
-    #if Inlinable
-    @inlinable
-    #endif
     public static func noSigPipe(fileDescriptor: Int32) {
         #if canImport(Darwin)
         var no_sig_pipe:Int32 = 0
@@ -97,9 +94,6 @@ extension FileDescriptor where Self: ~Copyable {
         #endif
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func socketWriteBuffer(
         _ pointer: UnsafeRawPointer,
         length: Int
@@ -114,9 +108,6 @@ extension FileDescriptor where Self: ~Copyable {
         }
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func socketWriteString(
         _ string: String
     ) throws(SocketError) {
@@ -136,9 +127,6 @@ extension FileDescriptor where Self: ~Copyable {
 
 // MARK: Close
 extension FileDescriptor {
-    #if Inlinable
-    @inlinable
-    #endif
     package func socketClose() {
         #if canImport(SwiftGlibc) || canImport(Foundation)
         shutdown(fileDescriptor, Int32(SHUT_RDWR)) // shutdown read and write (https://www.gnu.org/software/libc/manual/html_node/Closing-a-Socket.html)

--- a/Sources/DestinyEmbedded/InlineByteBuffer.swift
+++ b/Sources/DestinyEmbedded/InlineByteBuffer.swift
@@ -7,23 +7,11 @@ public struct InlineByteBuffer<let count: Int>: Sendable, ~Copyable {
     /// The actual "end" of the byte buffer data.
     public let endIndex:Int
 
-    #if Inlinable
-    @inlinable
-    #endif
-    #if InlineAlways
-    @inline(__always)
-    #endif
     package init(buffer: InlineArray<count, UInt8>, endIndex: Int) {
         self.buffer = buffer
         self.endIndex = endIndex
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
-    #if InlineAlways
-    @inline(__always)
-    #endif
     func copy() -> Self {
         Self(buffer: buffer, endIndex: endIndex)
     }

--- a/Sources/DestinyEmbedded/PercentEncoding.swift
+++ b/Sources/DestinyEmbedded/PercentEncoding.swift
@@ -117,9 +117,6 @@ extension String {
     /// Encodes `self` using url percent encoding.
     /// 
     /// - Complexity: O(_n_).
-    #if Inlinable
-    @inlinable
-    #endif
     public func urlPercentEncoded() -> String {
         let percent = Character("%")
         var string = ""
@@ -153,9 +150,6 @@ extension String {
     /// Encodes `self` as an HTTP Cookie Value (percent encoded).
     /// 
     /// - Complexity: O(_n_).
-    #if Inlinable
-    @inlinable
-    #endif
     public func httpCookiePercentEncoded() -> String {
         let percent = Character("%")
         var string = ""

--- a/Sources/DestinyEmbedded/ResponseBodyProtocol.swift
+++ b/Sources/DestinyEmbedded/ResponseBodyProtocol.swift
@@ -16,31 +16,19 @@ public protocol ResponseBodyProtocol: BufferWritable, ~Copyable {
 
 // MARK: Defaults
 extension ResponseBodyProtocol {
-    #if Inlinable
-    @inlinable
-    #endif
     public var hasDateHeader: Bool {
         false
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public var hasContentLength: Bool {
         true
     }
 }
 
 extension ResponseBodyProtocol where Self: ~Copyable {
-    #if Inlinable
-    @inlinable
-    #endif
     public var hasDateHeader: Bool {
         false
     }
-    #if Inlinable
-    @inlinable
-    #endif
     public var hasContentLength: Bool {
         true
     }
@@ -48,25 +36,16 @@ extension ResponseBodyProtocol where Self: ~Copyable {
 
 // MARK: Default conformances
 extension String: ResponseBodyProtocol {
-    #if Inlinable
-    @inlinable
-    #endif
     public func string() -> String {
         self
     }
 }
 
 extension StaticString: ResponseBodyProtocol {
-    #if Inlinable
-    @inlinable
-    #endif
     public var count: Int {
         utf8CodeUnitCount
     }
     
-    #if Inlinable
-    @inlinable
-    #endif
     public func string() -> String {
         description
     }

--- a/Sources/DestinyEmbedded/ReusableAsyncStream.swift
+++ b/Sources/DestinyEmbedded/ReusableAsyncStream.swift
@@ -11,9 +11,6 @@ public struct ReusableAsyncStream<Element>: AsyncSequence, Sendable {
         self.source = source
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func makeAsyncIterator() -> AsyncIterator {
         source().makeAsyncIterator()
     }

--- a/Sources/DestinyEmbedded/RouterSettings.swift
+++ b/Sources/DestinyEmbedded/RouterSettings.swift
@@ -37,9 +37,6 @@ public struct RouterSettings: Sendable {
     /// If `true`: you can register middleware, routes, route groups, and route responders at runtime.
     /// 
     /// Default is `false`.
-    #if Inlinable
-    @inlinable
-    #endif
     public var isMutable: Bool {
         get { isFlag(.mutable) }
         set { setFlag(.mutable, newValue) }
@@ -48,9 +45,6 @@ public struct RouterSettings: Sendable {
     /// Whether the expanded route responders should be computed properties instead of static constants.
     /// 
     /// Default is `false`.
-    #if Inlinable
-    @inlinable
-    #endif
     public var respondersAreComputedProperties: Bool {
         get { isFlag(.respondersAreComputedProperties) }
         set { setFlag(.respondersAreComputedProperties, newValue) }
@@ -59,9 +53,6 @@ public struct RouterSettings: Sendable {
     /// Whether or not the default response for Dynamic Route Responders should be `GenericDynamicResponse`.
     /// 
     /// Default is `true`.
-    #if Inlinable
-    @inlinable
-    #endif
     public var dynamicResponsesAreGeneric: Bool {
         get { isFlag(.dynamicResponsesAreGeneric) }
         set { setFlag(.dynamicResponsesAreGeneric, newValue) }
@@ -71,9 +62,6 @@ public struct RouterSettings: Sendable {
     /// Can reduce binary size if disabled and handled properly.
     /// 
     /// Default is `true`.
-    #if Inlinable
-    @inlinable
-    #endif
     public var hasProtocolConformances: Bool {
         get { isFlag(.protocolConformances) }
         set { setFlag(.protocolConformances, newValue) }
@@ -82,9 +70,6 @@ public struct RouterSettings: Sendable {
     /// Whether or not the expanded data should include logging logic.
     /// 
     /// Default is `true`.
-    #if Inlinable
-    @inlinable
-    #endif
     public var hasLogging: Bool {
         get { isFlag(.logging) }
         set { setFlag(.logging, newValue) }
@@ -116,16 +101,10 @@ extension RouterSettings {
         }
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     func isFlag(_ flag: Flags) -> Bool {
         flags & flag.rawValue != 0
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     mutating func setFlag(_ flag: Flags, _ value: Bool) {
         if value {
             flags |= flag.rawValue

--- a/Sources/DestinyEmbedded/epoll/Epoll.swift
+++ b/Sources/DestinyEmbedded/epoll/Epoll.swift
@@ -51,9 +51,6 @@ public struct Epoll<let maxEvents: Int>: Sendable {
     }
 
     /// Flags a file descriptor as non-blocking.
-    #if Inlinable
-    @inlinable
-    #endif
     public func setNonBlocking(socket: Int32) {
         let flags = fcntl(socket, F_GETFL, 0)
         guard flags != -1 else {
@@ -66,9 +63,6 @@ public struct Epoll<let maxEvents: Int>: Sendable {
     }
 
     /// Closes all file descriptors managed by epoll.
-    #if Inlinable
-    @inlinable
-    #endif
     public func closeAll() {
         close(pipeFileDescriptors.read)
         close(pipeFileDescriptors.write)
@@ -81,9 +75,6 @@ extension Epoll {
     /// Adds a file descriptor to epoll.
     /// 
     /// - Throws: `EpollError`
-    #if Inlinable
-    @inlinable
-    #endif
     public func add(client: Int32, events: UInt32) throws(EpollError) {
         var e = epoll_event()
         e.events = events
@@ -102,9 +93,6 @@ extension Epoll {
     /// Modifies a file descriptor from epoll.
     /// 
     /// - Throws: `EpollError`
-    #if Inlinable
-    @inlinable
-    #endif
     public func mod(fd: Int32, events: UInt32) throws(EpollError) {
         var ev = epoll_event()
         ev.events = events
@@ -123,9 +111,6 @@ extension Epoll {
     /// Deletes a file descriptor from epoll.
     /// 
     /// - Throws: `EpollError`
-    #if Inlinable
-    @inlinable
-    #endif
     public func remove(client: Int32) throws(EpollError) {
         if epoll_ctl(fileDescriptor, EPOLL_CTL_DEL, client, nil) == -1 {
             throw .epollCtlFailed(errno: cError())
@@ -142,9 +127,6 @@ extension Epoll {
     /// 
     /// - Returns: Number of loaded clients. Guaranteed to be greater than -1.
     /// - Throws: `EpollError`
-    #if Inlinable
-    @inlinable
-    #endif
     public func wait(
         timeout: Int32 = -1,
         events: inout MutableSpan<epoll_event>

--- a/Sources/DestinyEmbedded/epoll/EpollWorker.swift
+++ b/Sources/DestinyEmbedded/epoll/EpollWorker.swift
@@ -9,12 +9,6 @@ import Logging
 #endif
 
 @_silgen_name("accept4")
-#if Inlinable
-@inlinable
-#endif
-#if InlineAlways
-@inline(__always)
-#endif
 func accept4_fd(
     _ sockfd: Int32,
     _ addr: UnsafeMutablePointer<sockaddr>?,
@@ -93,9 +87,6 @@ public struct EpollWorker<let maxEvents: Int>: Sendable, ~Copyable {
     }
 
     /// Pin this worker to a core to improve cache locality.
-    #if Inlinable
-    @inlinable
-    #endif
     public func pinToCore(_ core: Int32) {
         /*var cpuset = cpu_set_t()
         CPU_ZERO(&cpuset)
@@ -105,9 +96,6 @@ public struct EpollWorker<let maxEvents: Int>: Sendable, ~Copyable {
     }
 
     /// - Returns: Accepted nonblocking file descriptor
-    #if Inlinable
-    @inlinable
-    #endif
     func acceptNewConnection() -> Int32? {
         var addr = sockaddr_storage()
         var len = socklen_t(MemoryLayout<sockaddr_storage>.size)
@@ -135,9 +123,6 @@ public struct EpollWorker<let maxEvents: Int>: Sendable, ~Copyable {
     }
 
     /// Shuts down the worker.
-    #if Inlinable
-    @inlinable
-    #endif
     public mutating func shutdown() {
         running = false
         var c:UInt8 = 1
@@ -153,9 +138,6 @@ extension EpollWorker {
     ///   - pinToCore: Which core to run this on.
     ///   - timeout: Milliseconds to wait until we time-out.
     ///   - handleClient: Handle logic for a file descriptor.
-    #if Inlinable
-    @inlinable
-    #endif
     public mutating func run(
         pinToCore: Int32? = nil,
         timeout: Int32 = -1,
@@ -225,9 +207,6 @@ extension EpollWorker {
 // MARK: Bind and listen
 extension EpollWorker {
     /// Opens, binds and listens to a socket with the given port and backlog.
-    #if Inlinable
-    @inlinable
-    #endif
     static func bindAndListen(
         port: UInt16,
         backlog: Int32
@@ -272,9 +251,6 @@ extension EpollWorker {
         return fd
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     static func setNonBlockingFD(_ fd: Int32) {
         let flags = fcntl(fd, F_GETFL, 0)
         guard flags != -1 else { fatalError("fcntl F_GETFL failed") }

--- a/Sources/DestinyEmbedded/extensions/GlobalExtensions.swift
+++ b/Sources/DestinyEmbedded/extensions/GlobalExtensions.swift
@@ -22,12 +22,6 @@ import WinSDK
 ///   - __dest: Destination pointer.
 ///   - __src: Source pointer.
 ///   - __n: Number of bytes to copy.
-#if Inlinable
-@inlinable
-#endif
-#if InlineAlways
-@inline(__always)
-#endif
 package func copyMemory(
     _ __dest: UnsafeMutableRawPointer,
     _ __src: UnsafeRawPointer,

--- a/Sources/DestinyEmbedded/extensions/InlineArrayExtensions.swift
+++ b/Sources/DestinyEmbedded/extensions/InlineArrayExtensions.swift
@@ -6,9 +6,6 @@ import VariableLengthArray
 extension VLArray where Element == UInt8 {
     /// - Returns: A case-literal `String` initialized from `storage`.
     /// - Warning: The returned `String` is the exact size of this `VLArray`! This function doesn't look for a null-terminator!
-    #if Inlinable
-    @inlinable
-    #endif
     public func unsafeString() -> String {
         return String.init(unsafeUninitializedCapacity: storage.count, initializingUTF8With: {
             return $0.initialize(from: storage).index
@@ -19,9 +16,6 @@ extension VLArray where Element == UInt8 {
     /// 
     /// - Returns: A case-literal `String` initialized from `storage` with start and end indexes.
     /// - Warning: `endIndex` MUST be greater than `startIndex`.
-    #if Inlinable
-    @inlinable
-    #endif
     public func unsafeString(startIndex: Int, endIndex: Int) -> String {
         let count = endIndex -! startIndex
         let slice = storage[startIndex..<endIndex]
@@ -43,12 +37,6 @@ extension VLArray where Element == UInt8 {
 
 // MARK: Write to file descriptor
 extension InlineArray {
-    #if Inlinable
-    @inlinable
-    #endif
-    #if InlineAlways
-    @inline(__always)
-    #endif
     public func write(to socket: some FileDescriptor) throws(SocketError) {
         var err:SocketError? = nil
         withUnsafePointer(to: self, {
@@ -66,12 +54,6 @@ extension InlineArray {
 
 // MARK: BufferWritable
 extension InlineArray where Element == UInt8 { 
-    #if Inlinable
-    @inlinable
-    #endif
-    #if InlineAlways
-    @inline(__always)
-    #endif
     public func write(
         to buffer: UnsafeMutableBufferPointer<UInt8>,
         at index: inout Int
@@ -89,9 +71,6 @@ extension InlineArray where Element == UInt8 {
     /// 
     /// - Returns: A case-literal `String` initialized from `span`.
     /// - Warning: The returned `String` is the exact size of this `InlineArray`! This function doesn't look for a null-terminator!
-    #if Inlinable
-    @inlinable
-    #endif
     public func unsafeString() -> String {
         return self.span.withUnsafeBufferPointer { pointer in
             return String.init(unsafeUninitializedCapacity: pointer.count, initializingUTF8With: {
@@ -104,9 +83,6 @@ extension InlineArray where Element == UInt8 {
     /// 
     /// - Returns: A case-literal `String` initialized from `span` with start and end indexes.
     /// - Warning: `endIndex` MUST be greater than `startIndex`.
-    #if Inlinable
-    @inlinable
-    #endif
     public func unsafeString(startIndex: Int, endIndex: Int) -> String {
         return self.span.withUnsafeBufferPointer {
             let count = endIndex -! startIndex

--- a/Sources/DestinyEmbedded/extensions/Int32Extensions.swift
+++ b/Sources/DestinyEmbedded/extensions/Int32Extensions.swift
@@ -21,16 +21,10 @@ import UnwrapArithmeticOperators
 
 // MARK: Int32
 extension Int32 {
-    #if Inlinable
-    @inlinable
-    #endif
     public var fileDescriptor: Int32 {
         self
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func readBuffer(
         into baseAddress: UnsafeMutableRawPointer,
         length: Int,
@@ -43,9 +37,6 @@ extension Int32 {
         return read
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     package func handleReadError() throws(SocketError) {
         #if canImport(Glibc)
         if errno == EAGAIN || errno == EWOULDBLOCK {
@@ -55,9 +46,6 @@ extension Int32 {
         throw .readBufferFailed(errno: errno)
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func writeBuffer(
         _ pointer: UnsafeRawPointer,
         length: Int
@@ -72,9 +60,6 @@ extension Int32 {
         }
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func writeBuffers3(
         _ b1: (buffer: UnsafePointer<UInt8>, bufferCount: Int),
         _ b2: (buffer: UnsafePointer<UInt8>, bufferCount: Int),
@@ -93,9 +78,6 @@ extension Int32 {
         }
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func writeBuffers4(
         _ b1: UnsafeBufferPointer<UInt8>,
         _ b2: UnsafeBufferPointer<UInt8>,
@@ -116,9 +98,6 @@ extension Int32 {
         }
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func writeBuffers6(
         _ b1: (buffer: UnsafePointer<UInt8>, bufferCount: Int),
         _ b2: (buffer: UnsafePointer<UInt8>, bufferCount: Int),
@@ -146,9 +125,6 @@ extension Int32 {
 
 // MARK: Address
 extension Int32 {
-    #if Inlinable
-    @inlinable
-    #endif
     public func socketLocalAddress() -> String? {
         var addr = sockaddr_storage()
         var len = socklen_t(MemoryLayout<sockaddr_storage>.size)
@@ -160,9 +136,6 @@ extension Int32 {
         return socketAddress(addr: &addr, result: result)
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func socketPeerAddress() -> String? {
         var addr = sockaddr_storage()
         var len = socklen_t(MemoryLayout<sockaddr_storage>.size)
@@ -174,9 +147,6 @@ extension Int32 {
         return socketAddress(addr: &addr, result: result)
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     func socketAddress(addr: inout sockaddr_storage, result: Int32) -> String? {
         if result != 0 {
             return nil
@@ -208,15 +178,9 @@ extension Int32 {
 
 // MARK: Receive
 extension Int32 {
-    #if Inlinable
-    @inlinable
-    #endif
     public func socketReceive(baseAddress: UnsafeMutablePointer<UInt8>, length: Int, flags: Int32 = 0) -> Int {
         return recv(fileDescriptor, baseAddress, length, flags)
     }
-    #if Inlinable
-    @inlinable
-    #endif
     public func socketReceive(baseAddress: UnsafeMutableRawPointer, length: Int, flags: Int32 = 0) -> Int {
         return recv(fileDescriptor, baseAddress, length, flags)
     }
@@ -224,9 +188,6 @@ extension Int32 {
 
 // MARK: Send
 extension Int32 {
-    #if Inlinable
-    @inlinable
-    #endif
     public func socketSendMultiplatform(pointer: UnsafeRawPointer, length: Int) -> Int {
         #if canImport(Android) || canImport(Bionic) || canImport(Darwin) || canImport(Glibc) || canImport(Musl) || canImport(WASILibc) || canImport(Windows) || canImport(WinSDK)
         return send(fileDescriptor, pointer, length, Int32(MSG_NOSIGNAL))

--- a/Sources/DestinyEmbedded/extensions/SIMDExtensions+Lowercased.swift
+++ b/Sources/DestinyEmbedded/extensions/SIMDExtensions+Lowercased.swift
@@ -2,9 +2,6 @@
 extension SIMD64<UInt8> {
     /// - Returns: A UTF-8 lowercased version of `self`.
     /// - Complexity: O(1).
-    #if Inlinable
-    @inlinable
-    #endif
     public func lowercased() -> Self {
         var upperCase = self .>= 65
         upperCase .&= self .<= 90

--- a/Sources/DestinyEmbedded/extensions/UnsafePointerExtensions.swift
+++ b/Sources/DestinyEmbedded/extensions/UnsafePointerExtensions.swift
@@ -3,24 +3,12 @@ import UnwrapArithmeticOperators
 
 extension UnsafeMutableBufferPointer where Element == UInt8 {
     /// Copies the given buffer to `self` at the given index.
-    #if Inlinable
-    @inlinable
-    #endif
-    #if InlineAlways
-    @inline(__always)
-    #endif
     public func copyBuffer(_ buffer: UnsafeBufferPointer<Element>, at index: Int) {
         var index = index
         copyBuffer(buffer, at: &index)
     }
 
     /// Copies the given buffer to `self` at the given index.
-    #if Inlinable
-    @inlinable
-    #endif
-    #if InlineAlways
-    @inline(__always)
-    #endif
     public func copyBuffer(_ buffer: UnsafeMutableBufferPointer<Element>, at index: Int) {
         var index = index
         copyBuffer(buffer, at: &index)
@@ -29,24 +17,12 @@ extension UnsafeMutableBufferPointer where Element == UInt8 {
 
 extension UnsafeMutableBufferPointer where Element == UInt8 {
     /// Copies the given buffer to `self` at the given index.
-    #if Inlinable
-    @inlinable
-    #endif
-    #if InlineAlways
-    @inline(__always)
-    #endif
     public func copyBuffer(_ buffer: UnsafeBufferPointer<Element>, at index: inout Int) {
         copyMemory(baseAddress! + index, buffer.baseAddress!, buffer.count)
         index +=! buffer.count
     }
 
     /// Copies the given buffer to `self` at the given index.
-    #if Inlinable
-    @inlinable
-    #endif
-    #if InlineAlways
-    @inline(__always)
-    #endif
     public func copyBuffer(_ buffer: UnsafeMutableBufferPointer<Element>, at index: inout Int) {
         copyMemory(baseAddress! + index, buffer.baseAddress!, buffer.count)
         index +=! buffer.count
@@ -55,12 +31,6 @@ extension UnsafeMutableBufferPointer where Element == UInt8 {
 
 extension UnsafeMutableBufferPointer where Element == UInt8 {
     /// Copies the given buffer to `self` at the given index.
-    #if Inlinable
-    @inlinable
-    #endif
-    #if InlineAlways
-    @inline(__always)
-    #endif
     public func copyBuffer(baseAddress: UnsafePointer<UInt8>, count: Int, at index: inout Int) {
         copyMemory(self.baseAddress! + index, baseAddress, count)
         index +=! count

--- a/Sources/DestinyEmbedded/http/HTTPCookie.swift
+++ b/Sources/DestinyEmbedded/http/HTTPCookie.swift
@@ -22,25 +22,16 @@ public struct HTTPCookie: Sendable {
     public var sameSite:HTTPCookieFlag.SameSite?
 
     /// Name of the cookie.
-    #if Inlinable
-    @inlinable
-    #endif
     public func name() -> String {
         _name
     }
 
     /// Sets the name of the cookie.
-    #if Inlinable
-    @inlinable
-    #endif
     public mutating func setName(_ name: String) {
         _name = name
     }
 
     /// Value of the cookie.
-    #if Inlinable
-    @inlinable
-    #endif
     public func value() -> String {
         _value
     }
@@ -48,9 +39,6 @@ public struct HTTPCookie: Sendable {
     /// Sets the value of the cookie.
     /// 
     /// - Throws: `HTTPCookieError` if `value` contains an illegal character.
-    #if Inlinable
-    @inlinable
-    #endif
     public mutating func setValue(_ value: String) throws(HTTPCookieError) {
         try Self.validateValue(value)
         _value = value
@@ -62,9 +50,6 @@ extension HTTPCookie {
     #if PercentEncoding
 
     /// - Throws: `HTTPCookieError` if `encoding` contains an illegal character.
-    #if Inlinable
-    @inlinable
-    #endif
     public init(
         name: String,
         encoding: String,
@@ -94,9 +79,6 @@ extension HTTPCookie {
     #endif
 
     /// - Throws: `HTTPCookieError` if `value` contains an illegal character.
-    #if Inlinable
-    @inlinable
-    #endif
     public init(
         name: String,
         value: String,
@@ -124,9 +106,6 @@ extension HTTPCookie {
         )
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public init(
         name: String,
         uncheckedValue: String,
@@ -157,27 +136,18 @@ extension HTTPCookie {
     /// Validates the provided string is a valid HTTP Cookie Value.
     /// 
     /// - Throws: `HTTPCookieError` if it contains an illegal character.
-    #if Inlinable
-    @inlinable
-    #endif
     public static func validateValue(_ value: String) throws(HTTPCookieError) {
         guard let illegalChar = value.first(where: { !Self.isValidInValue($0) }) else { return }
         throw .illegalCharacter(illegalChar)
     }
 
     /// Returns: Whether the provided character is allowed in an HTTP Cookie Value.
-    #if Inlinable
-    @inlinable
-    #endif
     public static func isValidInValue(_ char: Character) -> Bool {
         guard let ascii = char.asciiValue else { return false }
         return isValidInValue(ascii)
     }
 
     /// Returns: Whether the provided byte is allowed in an HTTP Cookie Value.
-    #if Inlinable
-    @inlinable
-    #endif
     public static func isValidInValue(_ byte: UInt8) -> Bool {
         return !(
             byte <= 31
@@ -193,9 +163,6 @@ extension HTTPCookie {
 
 // MARK: CustomStringConvertible
 extension HTTPCookie: CustomStringConvertible {
-    #if Inlinable
-    @inlinable
-    #endif
     public var description: String {
         var string = "\(_name)=\(_value)"
         if maxAge > 0 {
@@ -252,18 +219,12 @@ extension HTTPCookie {
     }
 
     /// Whether or not the cookie is secure.
-    #if Inlinable
-    @inlinable
-    #endif
     public var isSecure: Bool {
         get { isFlag(.secure) }
         set { setFlag(.secure, newValue) }
     }
 
     /// Whether or not the cookie is http only.
-    #if Inlinable
-    @inlinable
-    #endif
     public var isHTTPOnly: Bool {
         get { isFlag(.httpOnly) }
         set { setFlag(.httpOnly, newValue) }
@@ -272,9 +233,6 @@ extension HTTPCookie {
     /// Whether or not the cookie is partitioned.
     /// 
     /// [Read more](https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/Privacy_sandbox/Partitioned_cookies).
-    #if Inlinable
-    @inlinable
-    #endif
     public var isPartitioned: Bool {
         get { isFlag(.partitioned) }
         set { setFlag(.partitioned, newValue) }

--- a/Sources/DestinyEmbedded/http/HTTPCookieFlag.swift
+++ b/Sources/DestinyEmbedded/http/HTTPCookieFlag.swift
@@ -11,9 +11,6 @@ extension HTTPCookieFlag {
         case lax
         case none
 
-        #if Inlinable
-        @inlinable
-        #endif
         public var httpValue: String {
             switch self {
             case .strict: "Strict"

--- a/Sources/DestinyEmbedded/http/HTTPDateFormat.swift
+++ b/Sources/DestinyEmbedded/http/HTTPDateFormat.swift
@@ -54,12 +54,6 @@ public struct HTTPDateFormat: Sendable {
     /// Last calculated date value in the HTTP Format as an `UnsafeBufferPointer<UInt8>`.
     /// 
     /// - Warning: Can have zero or more trailing null-termination bytes (0)!
-    #if Inlinable
-    @inlinable
-    #endif
-    #if InlineAlways
-    @inline(__always)
-    #endif
     public static var nowUnsafeBufferPointer: UnsafeBufferPointer<UInt8> {
         _read {
             yield UnsafeBufferPointer(_nowUnsafeBufferPointer)
@@ -67,20 +61,11 @@ public struct HTTPDateFormat: Sendable {
     }
 
     /// Last calculated date value in the HTTP Format as a `String`.
-    #if Inlinable
-    @inlinable
-    #endif
-    #if InlineAlways
-    @inline(__always)
-    #endif
     public static var nowString: String {
         _read { yield _nowString }
     }
 
     /// Current number of non-zero bytes in the `_nowUnsafeBufferPointer`.
-    #if Inlinable
-    @inlinable
-    #endif
     public static var count: Int {
         _read { yield _count }
     }
@@ -89,9 +74,6 @@ public struct HTTPDateFormat: Sendable {
     /// 
     /// - Returns: HTTP formatted result, at the time it was executed, as an `InlineArrayResult`.
     @discardableResult
-    #if Inlinable
-    @inlinable
-    #endif
     public static func now() -> InlineArrayResult? {
         #if canImport(Android) || canImport(Bionic) || canImport(Darwin) || canImport(SwiftGlibc) || canImport(Musl) || canImport(WASILibc) || canImport(Windows) || canImport(WinSDK)
         return nowGlibc()
@@ -105,9 +87,6 @@ public struct HTTPDateFormat: Sendable {
 extension HTTPDateFormat {
     #if Logging
     /// Begins the auto-updating of the current date in the HTTP Format.
-    #if Inlinable
-    @inlinable
-    #endif
     public static func load(logger: Logger) { // TODO: reduce binary size
         // TODO: make it update at the beginning of the second
         Task.detached(priority: .userInitiated) {
@@ -141,9 +120,6 @@ extension HTTPDateFormat {
     }
     #else
     /// Begins the auto-updating of the current date in the HTTP Format.
-    #if Inlinable
-    @inlinable
-    #endif
     public static func load() { // TODO: reduce binary size
         // TODO: make it update at the beginning of the second
         Task.detached(priority: .userInitiated) {
@@ -189,9 +165,6 @@ extension HTTPDateFormat {
     ///   - minute: Number of minutes after the hour, in the range 0 to 59.
     ///   - second: Number of seconds after the minute, normally in the range 0 to 59, but can be up to 60 to allow for leap seconds.
     /// - Returns: An `InlineArray<29, UInt8>` that represents a date and time in the HTTP preferred format, as defined by the [spec](https://www.rfc-editor.org/rfc/rfc2616#section-3.3).
-    #if Inlinable
-    @inlinable
-    #endif
     public static func get(
         year: Int32,
         month: UInt8,
@@ -264,9 +237,6 @@ extension HTTPDateFormat {
         return value
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     static func httpDayName(_ int: UInt8) -> (UInt8, UInt8, UInt8) {
         switch int {
         case 0:  (83, 117, 110) // Sun
@@ -281,9 +251,6 @@ extension HTTPDateFormat {
     }
 
     /// - Returns: The month's 3 byte representation to be used in the HTTP Format.
-    #if Inlinable
-    @inlinable
-    #endif
     static func httpMonthName(_ int: UInt8) -> (UInt8, UInt8, UInt8) {
         switch int {
         case 0:  (74, 97, 110)  // Jan
@@ -302,9 +269,6 @@ extension HTTPDateFormat {
         }
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     static func httpDateNumber(_ int: UInt8) -> InlineArray<2, UInt8> {
         // we don't use a switch here because it would bloat the binary
         if int < 10 {
@@ -320,9 +284,6 @@ extension HTTPDateFormat {
         }
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     static func httpNumber<let count: Int>(_ int: Int32) -> InlineArray<count, UInt8> {
         var value = InlineArray<count, UInt8>(repeating: 0)
         var i = 0
@@ -345,18 +306,12 @@ extension HTTPDateFormat {
 // MARK: SwiftGlibc
 extension HTTPDateFormat {
     /// https://linux.die.net/man/3/localtime
-    #if Inlinable
-    @inlinable
-    #endif
     public static func nowGlibc() -> InlineArrayResult? {
         var now = time(nil)
         guard let gmt = gmtime(&now) else { return nil }
         return httpDateGlibc(gmt.pointee)
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     static func httpDateGlibc(_ gmt: tm) -> InlineArrayResult {
         return HTTPDateFormat.get(
             year: 1900 +! gmt.tm_year,

--- a/Sources/DestinyEmbedded/http/HTTPHeaders.swift
+++ b/Sources/DestinyEmbedded/http/HTTPHeaders.swift
@@ -7,17 +7,11 @@ public struct HTTPHeaders: Sendable {
     package var _storage:[(key: String, value: String)]
 
     /// - Warning: Keys are case-sensitive!
-    #if Inlinable
-    @inlinable
-    #endif
     public init(_storage: [(String, String)] = []) {
         self._storage = _storage
     }
 
     /// - Warning: Keys are case-sensitive!
-    #if Inlinable
-    @inlinable
-    #endif
     public init(_ storage: [String:String]) {
         var array = [(String, String)]()
         array.reserveCapacity(storage.count)
@@ -28,9 +22,6 @@ public struct HTTPHeaders: Sendable {
     }
 
     /// Reserves enough space to store the specified number of elements.
-    #if Inlinable
-    @inlinable
-    #endif
     public mutating func reserveCapacity(_ minimumCapacity: Int) {
         _storage.reserveCapacity(minimumCapacity)
     }
@@ -39,9 +30,6 @@ public struct HTTPHeaders: Sendable {
 extension HTTPHeaders {
     /// - Complexity: On average, reading/writing an existing header is O(_n_) while removing a header is O(2*n*) if it exists and O(_n_) if it doesn't.
     /// - Warning: `header` is case-sensitive!
-    #if Inlinable
-    @inlinable
-    #endif
     public subscript(header: String) -> String? {
         get {
             _storage.first(where: { $0.key == header })?.value
@@ -63,18 +51,12 @@ extension HTTPHeaders {
     /// 
     /// - Complexity: O(_n_).
     /// - Warning: `header` is case-sensitive!
-    #if Inlinable
-    @inlinable
-    #endif
     public func has(_ header: String) -> Bool {
         _storage.firstIndex(where: { $0.key == header }) != nil
     }
 }
 
 extension HTTPHeaders: Sequence {
-    #if Inlinable
-    @inlinable
-    #endif
     public func makeIterator() -> HTTPHeadersIterator {
         HTTPHeadersIterator(headers: _storage)
     }

--- a/Sources/DestinyEmbedded/http/HTTPHeadersIterator.swift
+++ b/Sources/DestinyEmbedded/http/HTTPHeadersIterator.swift
@@ -20,9 +20,6 @@ public struct HTTPHeadersIterator: IteratorProtocol {
         maxIndex = UInt16(headers.count)
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public mutating func next() -> (key: String, value: String)? {
         if self.index == maxIndex {
             return nil

--- a/Sources/DestinyEmbedded/http/HTTPRequestMethod.swift
+++ b/Sources/DestinyEmbedded/http/HTTPRequestMethod.swift
@@ -8,9 +8,6 @@ public struct HTTPRequestMethod: Sendable {
         self.name = name
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func rawNameString() -> String {
         name
     }

--- a/Sources/DestinyEmbedded/http/HTTPResponseMessage+Write.swift
+++ b/Sources/DestinyEmbedded/http/HTTPResponseMessage+Write.swift
@@ -3,9 +3,6 @@ import UnwrapArithmeticOperators
 
 // MARK: Temp allocation
 extension HTTPResponseMessage {
-    #if Inlinable
-    @inlinable
-    #endif
     public func temporaryAllocation<E: Error>(_ closure: (UnsafeMutableBufferPointer<UInt8>) throws(E) -> Void) rethrows {
         var capacity = 14 // HTTP/x.x ###\r\n
         for (key, value) in head.headers {
@@ -68,9 +65,6 @@ extension HTTPResponseMessage {
         })
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     func writeString(_ string: String, to buffer: UnsafeMutableBufferPointer<UInt8>, at i: inout Int) {
         let span = string.utf8Span.span
         for j in span.indices {
@@ -80,9 +74,6 @@ extension HTTPResponseMessage {
     }
 
     /// Writes `\r` and `\n` to the buffer.
-    #if Inlinable
-    @inlinable
-    #endif
     func writeCRLF(to buffer: UnsafeMutableBufferPointer<UInt8>, at i: inout Int) {
         buffer[i] = .carriageReturn
         i +=! 1
@@ -90,9 +81,6 @@ extension HTTPResponseMessage {
         i +=! 1
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     func writeStartLine(to buffer: UnsafeMutableBufferPointer<UInt8>, at i: inout Int) {
         writeStaticString(head.version.staticString, to: buffer, at: &i)
         buffer[i] = .space
@@ -103,9 +91,6 @@ extension HTTPResponseMessage {
         writeCRLF(to: buffer, at: &i)
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     func writeHeader(to buffer: UnsafeMutableBufferPointer<UInt8>, at i: inout Int, key: String, value: String) {
         writeString(key, to: buffer, at: &i)
         buffer[i] = .colon
@@ -117,9 +102,6 @@ extension HTTPResponseMessage {
         writeCRLF(to: buffer, at: &i)
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     func writeCookie(_ cookie: String, to buffer: UnsafeMutableBufferPointer<UInt8>, at i: inout Int) {
         writeStaticString("set-cookie: ", to: buffer, at: &i)
         writeString(cookie, to: buffer, at: &i)
@@ -127,9 +109,6 @@ extension HTTPResponseMessage {
     }
 
     /// - Throws: `BufferWriteError`
-    #if Inlinable
-    @inlinable
-    #endif
     func writeResult(
         to buffer: UnsafeMutableBufferPointer<UInt8>,
         index i: inout Int,
@@ -155,9 +134,6 @@ extension HTTPResponseMessage {
         try body.write(to: buffer, at: &i)
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     func writeStaticString(
         _ string: StaticString,
         to buffer: UnsafeMutableBufferPointer<UInt8>,
@@ -172,9 +148,6 @@ extension HTTPResponseMessage {
 
 // MARK: Write
 extension HTTPResponseMessage {
-    #if Inlinable
-    @inlinable
-    #endif
     public func write(
         to socket: some FileDescriptor
     ) throws(SocketError) {

--- a/Sources/DestinyEmbedded/http/HTTPResponseMessage.swift
+++ b/Sources/DestinyEmbedded/http/HTTPResponseMessage.swift
@@ -26,9 +26,6 @@ public struct HTTPResponseMessage<
     /// 
     /// - Parameters:
     ///   - body: New body to set.
-    #if Inlinable
-    @inlinable
-    #endif
     public mutating func setBody(_ body: Body) {
         self.body = body
     }
@@ -37,9 +34,6 @@ public struct HTTPResponseMessage<
     /// 
     /// - Parameters:
     ///   - body: New body to set.
-    #if Inlinable
-    @inlinable
-    #endif
     public mutating func setBody(_ body: some ResponseBodyProtocol) {
         guard let body = body as? Body else { return }
         self.body = body
@@ -71,9 +65,6 @@ public struct HTTPResponseMessage: HTTPSocketWritable {
     /// 
     /// - Parameters:
     ///   - body: New body to set.
-    #if Inlinable
-    @inlinable
-    #endif
     public mutating func setBody(_ body: some ResponseBodyProtocol) {
         self.body = body
     }
@@ -83,18 +74,12 @@ public struct HTTPResponseMessage: HTTPSocketWritable {
 // MARK: Logic
 extension HTTPResponseMessage {
     /// Associated HTTP Version of this message.
-    #if Inlinable
-    @inlinable
-    #endif
     public var version: HTTPVersion {
         get { head.version }
         set { head.version = newValue }
     }
 
     /// - Returns: Current status code this message.
-    #if Inlinable
-    @inlinable
-    #endif
     public func statusCode() -> HTTPResponseStatus.Code {
         head.status
     }
@@ -103,9 +88,6 @@ extension HTTPResponseMessage {
     /// 
     /// - Parameters:
     ///   - code: New status code to set.
-    #if Inlinable
-    @inlinable
-    #endif
     public mutating func setStatusCode(_ code: HTTPResponseStatus.Code) {
         head.status = code
     }
@@ -115,9 +97,6 @@ extension HTTPResponseMessage {
     /// 
     /// - Returns: A string representing an HTTP Message with the given values.
     /// - Throws: `HTTPMessageError`
-    #if Inlinable
-    @inlinable
-    #endif
     public func string(
         escapeLineBreak: Bool
     ) -> String {
@@ -144,18 +123,12 @@ extension HTTPResponseMessage {
     /// - Parameters:
     ///   - key: Header you want to modify.
     ///   - value: New header value to set.
-    #if Inlinable
-    @inlinable
-    #endif
     public mutating func setHeader(key: String, value: String) {
         head.headers[key] = value
     }
 
     #if HTTPCookie
     /// - Throws: `HTTPCookieError`
-    #if Inlinable
-    @inlinable
-    #endif
     public mutating func appendCookie(_ cookie: HTTPCookie) throws(HTTPCookieError) {
         head.cookies.append(cookie)
     }
@@ -170,9 +143,6 @@ extension HTTPResponseMessage {
     ///   - version: HTTP Version of the message.
     ///   - status: HTTP response status of the message.
     /// - Returns: A complete `HTTPResponseMessage` that redirects to the target with the given configuration.
-    #if Inlinable
-    @inlinable
-    #endif
     public static func redirect(
         to target: String,
         version: HTTPVersion = .v1_1,
@@ -187,9 +157,6 @@ extension HTTPResponseMessage {
     ///   - version: HTTP Version of the message.
     ///   - status: HTTP response status of the message.
     /// - Returns: A complete `HTTPResponseMessage` that redirects to the target with the given configuration.
-    #if Inlinable
-    @inlinable
-    #endif
     public static func redirect(
         to target: String,
         version: HTTPVersion = .v1_1,
@@ -207,9 +174,6 @@ extension HTTPResponseMessage {
     ///   - status: HTTP response status of the message.
     ///   - headers: HTTP headers of the message.
     /// - Returns: A complete `HTTPResponseMessage` that redirects to the target with the given configuration.
-    #if Inlinable
-    @inlinable
-    #endif
     public static func redirect(
         to target: String,
         version: HTTPVersion = .v1_1,
@@ -240,9 +204,6 @@ extension HTTPResponseMessage {
     ///   - status: HTTP response status of the message.
     ///   - headers: HTTP headers of the message.
     /// - Returns: A complete `HTTPResponseMessage` that redirects to the target with the given configuration.
-    #if Inlinable
-    @inlinable
-    #endif
     public static func redirect(
         to target: String,
         version: HTTPVersion = .v1_1,
@@ -271,9 +232,6 @@ extension HTTPResponseMessage {
 
 // MARK: Create
 extension HTTPResponseMessage {
-    #if Inlinable
-    @inlinable
-    #endif
     public static func create(
         escapeLineBreak: Bool,
         version: HTTPVersion,
@@ -287,9 +245,6 @@ extension HTTPResponseMessage {
         return create(suffix: suffix, version: version, status: status, headers: Self.headers(suffix: suffix, headers: headers), body: body, contentType: contentType, charset: charset)
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public static func create(
         suffix: String,
         version: HTTPVersion,
@@ -311,9 +266,6 @@ extension HTTPResponseMessage {
     }
 
 
-    #if Inlinable
-    @inlinable
-    #endif
     public static func headers(
         suffix: String,
         headers: HTTPHeaders

--- a/Sources/DestinyEmbedded/http/HTTPResponseMessageHead.swift
+++ b/Sources/DestinyEmbedded/http/HTTPResponseMessageHead.swift
@@ -44,16 +44,10 @@ public struct HTTPResponseMessageHead: Sendable {
     }
     #endif
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func string(escapeLineBreak: Bool) -> String {
         return string(suffix: escapeLineBreak ? "\\r\\n" : "\r\n")
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func string(suffix: String) -> String {
         var string = "\(version.string) \(status)\(suffix)"
         for (header, value) in headers {
@@ -70,9 +64,6 @@ public struct HTTPResponseMessageHead: Sendable {
     }
 
     #if HTTPCookie
-    #if Inlinable
-    @inlinable
-    #endif
     public func cookieDescriptions() -> [String] {
         var array = [String]()
         array.reserveCapacity(cookies.count)

--- a/Sources/DestinyEmbedded/http/HTTPResponseStatus.swift
+++ b/Sources/DestinyEmbedded/http/HTTPResponseStatus.swift
@@ -21,16 +21,10 @@ extension HTTPResponseStatus {
 }
 
 extension HTTPResponseStatus.StorageProtocol {
-    #if Inlinable
-    @inlinable
-    #endif
     public static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.code == rhs.code
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public var category: HTTPResponseStatus.Category {
         switch code {
         case 100...199: .informational

--- a/Sources/DestinyEmbedded/http/HTTPSocketWritable.swift
+++ b/Sources/DestinyEmbedded/http/HTTPSocketWritable.swift
@@ -14,9 +14,6 @@ public protocol HTTPSocketWritable: Sendable, ~Copyable {
 
 // MARK: Default conformances
 extension String: HTTPSocketWritable {
-    #if Inlinable
-    @inlinable
-    #endif
     public func write(
         to socket: some FileDescriptor
     ) throws(SocketError) {
@@ -25,9 +22,6 @@ extension String: HTTPSocketWritable {
 }
 
 extension StaticString: HTTPSocketWritable {
-    #if Inlinable
-    @inlinable
-    #endif
     public func write(
         to socket: some FileDescriptor
     ) throws(SocketError) {
@@ -36,9 +30,6 @@ extension StaticString: HTTPSocketWritable {
 }
 
 extension [UInt8]: HTTPSocketWritable {
-    #if Inlinable
-    @inlinable
-    #endif
     public func write(
         to socket: some FileDescriptor
     ) throws(SocketError) {

--- a/Sources/DestinyEmbedded/http/HTTPVersion.swift
+++ b/Sources/DestinyEmbedded/http/HTTPVersion.swift
@@ -12,9 +12,6 @@ public enum HTTPVersion: Hashable, Sendable {
     /// 
     /// - Parameters:
     ///   - token: The `UInt64` in `bigEndian` representation.
-    #if Inlinable
-    @inlinable
-    #endif
     public init?(token: UInt64) {
         switch token {
         case 5211883372140310073: self = .v0_9
@@ -28,9 +25,6 @@ public enum HTTPVersion: Hashable, Sendable {
     }
 
     /// `String` representation of this HTTP Version (`HTTP/<major>.<minor>`).
-    #if Inlinable
-    @inlinable
-    #endif
     public var string: String {
         switch self {
         case .v0_9: "HTTP/0.9"
@@ -43,9 +37,6 @@ public enum HTTPVersion: Hashable, Sendable {
     }
 
     /// `StaticString` representation of this HTTP Version (`HTTP/<major>.<minor>`).
-    #if Inlinable
-    @inlinable
-    #endif
     public var staticString: StaticString {
         switch self {
         case .v0_9: "HTTP/0.9"

--- a/Sources/DestinyEmbedded/request/AbstractHTTPRequest+Headers.swift
+++ b/Sources/DestinyEmbedded/request/AbstractHTTPRequest+Headers.swift
@@ -16,19 +16,10 @@ extension AbstractHTTPRequest {
         @usableFromInline
         var headers:[Substring:Substring] = [:]
 
-        #if Inlinable
-        @inlinable
-        #endif
         init(startIndex: Int) {
             self.startIndex = startIndex
         }
 
-        #if Inlinable
-        @inlinable
-        #endif
-        #if InlineAlways
-        @inline(__always)
-        #endif
         subscript(key: Substring) -> Substring? {
             _read { yield headers[key] }
             _modify { yield &headers[key] }
@@ -39,9 +30,6 @@ extension AbstractHTTPRequest {
 // MARK: Load
 extension AbstractHTTPRequest.Headers {
     /// Loads `_endIndex` and headers from a buffer.
-    #if Inlinable
-    @inlinable
-    #endif
     package mutating func load<let count: Int>(
         buffer: borrowing InlineByteBuffer<count>
     ) {

--- a/Sources/DestinyEmbedded/request/AbstractHTTPRequest+_Storage.swift
+++ b/Sources/DestinyEmbedded/request/AbstractHTTPRequest+_Storage.swift
@@ -100,12 +100,6 @@ extension AbstractHTTPRequest._Storage {
     /// Loads `requestLine`, `_headers` and `_body`.
     /// 
     /// - Throws: `SocketError`
-    #if Inlinable
-    @inlinable
-    #endif
-    #if InlineAlways
-    @inline(__always)
-    #endif
     mutating func load<let count: Int>(
         buffer: borrowing InlineByteBuffer<count>
     ) throws(SocketError) {
@@ -126,12 +120,6 @@ extension AbstractHTTPRequest._Storage {
 // MARK: Start Line SIMD
 extension AbstractHTTPRequest._Storage {
     /// - Warning: `requestLine` **MUST NOT** be `nil`!
-    #if Inlinable
-    @inlinable
-    #endif
-    #if InlineAlways
-    @inline(__always)
-    #endif
     mutating func startLineSIMD<let count: Int>(buffer: borrowing InlineByteBuffer<count>) -> SIMD64<UInt8> {
         if let startLineSIMD {
             return startLineSIMD
@@ -141,12 +129,6 @@ extension AbstractHTTPRequest._Storage {
     }
 
     /// - Warning: `requestLine` **MUST NOT** be `nil`!
-    #if Inlinable
-    @inlinable
-    #endif
-    #if InlineAlways
-    @inline(__always)
-    #endif
     mutating func startLineSIMDLowercased<let count: Int>(buffer: borrowing InlineByteBuffer<count>) -> SIMD64<UInt8> {
         if let startLineSIMDLowercased {
             return startLineSIMDLowercased
@@ -160,12 +142,6 @@ extension AbstractHTTPRequest._Storage {
 // MARK: Method
 extension AbstractHTTPRequest._Storage {
     /// - Warning: `requestLine` **MUST NOT** be `nil`!
-    #if Inlinable
-    @inlinable
-    #endif
-    #if InlineAlways
-    @inline(__always)
-    #endif
     package mutating func methodString<let count: Int>(buffer: borrowing InlineByteBuffer<count>) -> String {
         if let methodString {
             return methodString
@@ -180,12 +156,6 @@ extension AbstractHTTPRequest._Storage {
 // MARK: Path
 extension AbstractHTTPRequest._Storage {
     /// - Warning: `requestLine` **MUST NOT** be `nil`!
-    #if Inlinable
-    @inlinable
-    #endif
-    #if InlineAlways
-    @inline(__always)
-    #endif
     mutating func path<let count: Int>(buffer: borrowing InlineByteBuffer<count>) -> [String] {
         if let path {
             return path
@@ -215,9 +185,6 @@ extension AbstractHTTPRequest._Storage {
 extension AbstractHTTPRequest._Storage {
     /// - Throws: `SocketError`
     /// - Warning: `_headers` **MUST NOT** be `nil`!
-    #if Inlinable
-    @inlinable
-    #endif
     mutating func bodyCollect<let initialBufferCount: Int, let bufferCount: Int>(
         fileDescriptor: some FileDescriptor,
         initialBuffer: borrowing InlineByteBuffer<initialBufferCount>
@@ -233,12 +200,6 @@ extension AbstractHTTPRequest._Storage {
 
 // MARK: Copy
 extension AbstractHTTPRequest._Storage {
-    #if Inlinable
-    @inlinable
-    #endif
-    #if InlineAlways
-    @inline(__always)
-    #endif
     func copy() -> Self {
         Self(
             requestLine: requestLine?.copy(),

--- a/Sources/DestinyEmbedded/request/AbstractHTTPRequest.swift
+++ b/Sources/DestinyEmbedded/request/AbstractHTTPRequest.swift
@@ -14,12 +14,6 @@ package struct AbstractHTTPRequest<let initalBufferCount: Int>: Sendable, ~Copya
     @usableFromInline
     package var customStorage:HTTPRequest.Storage
 
-    #if Inlinable
-    @inlinable
-    #endif
-    #if InlineAlways
-    @inline(__always)
-    #endif
     init(
         _storage: consuming _Storage = .init(),
         storage: consuming HTTPRequest.Storage = .init([:])
@@ -32,12 +26,6 @@ package struct AbstractHTTPRequest<let initalBufferCount: Int>: Sendable, ~Copya
     /// 
     /// - Returns: An efficient, case-sensitive dictionary of the headers.
     /// - Throws: `SocketError`
-    #if Inlinable
-    @inlinable
-    #endif
-    #if InlineAlways
-    @inline(__always)
-    #endif
     mutating func headers(fileDescriptor: some FileDescriptor) throws(SocketError) -> [Substring:Substring] {
         #if RequestHeaders
         if initialBuffer == nil {
@@ -56,12 +44,6 @@ package struct AbstractHTTPRequest<let initalBufferCount: Int>: Sendable, ~Copya
 // MARK: Generic logic
 extension AbstractHTTPRequest {
     /// - Throws: `SocketError`
-    #if Inlinable
-    @inlinable
-    #endif
-    #if InlineAlways
-    @inline(__always)
-    #endif
     mutating func forEachPath(
         fileDescriptor: some FileDescriptor,
         offset: Int,
@@ -79,12 +61,6 @@ extension AbstractHTTPRequest {
     }
 
     /// - Throws: `SocketError`
-    #if Inlinable
-    @inlinable
-    #endif
-    #if InlineAlways
-    @inline(__always)
-    #endif
     mutating func path(fileDescriptor: some FileDescriptor, at index: Int) throws(SocketError) -> String {
         if initialBuffer == nil {
             try loadStorage(fileDescriptor: fileDescriptor)
@@ -93,12 +69,6 @@ extension AbstractHTTPRequest {
     }
 
     /// - Throws: `SocketError`
-    #if Inlinable
-    @inlinable
-    #endif
-    #if InlineAlways
-    @inline(__always)
-    #endif
     mutating func pathCount(fileDescriptor: some FileDescriptor) throws(SocketError) -> Int {
         if initialBuffer == nil {
             try loadStorage(fileDescriptor: fileDescriptor)
@@ -107,12 +77,6 @@ extension AbstractHTTPRequest {
     }
 
     /// - Throws: `SocketError`
-    #if Inlinable
-    @inlinable
-    #endif
-    #if InlineAlways
-    @inline(__always)
-    #endif
     mutating func isMethod(fileDescriptor: some FileDescriptor, _ method: HTTPRequestMethod) throws(SocketError) -> Bool {
         if initialBuffer == nil {
             try loadStorage(fileDescriptor: fileDescriptor)
@@ -121,12 +85,6 @@ extension AbstractHTTPRequest {
     }
 
     /// - Throws: `SocketError`
-    #if Inlinable
-    @inlinable
-    #endif
-    #if InlineAlways
-    @inline(__always)
-    #endif
     mutating func header(fileDescriptor: some FileDescriptor, forKey key: String) throws(SocketError) -> String? {
         #if RequestHeaders
         guard let value = try headers(fileDescriptor: fileDescriptor)[Substring(key)] else { return nil }
@@ -136,12 +94,6 @@ extension AbstractHTTPRequest {
         #endif
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
-    #if InlineAlways
-    @inline(__always)
-    #endif
     func copy() -> Self {
         var c = Self()
         c.storage = storage.copy()
@@ -154,12 +106,6 @@ extension AbstractHTTPRequest {
 // MARK: Load
 extension AbstractHTTPRequest {
     /// - Throws: `SocketError`
-    #if Inlinable
-    @inlinable
-    #endif
-    #if InlineAlways
-    @inline(__always)
-    #endif
     static func load(from socket: consuming some FileDescriptor & ~Copyable) throws(SocketError) -> Self {
         Self()
     }
@@ -170,12 +116,6 @@ extension AbstractHTTPRequest {
     /// Loads `initialBuffer` and `_storage`.
     /// 
     /// - Throws: `SocketError`
-    #if Inlinable
-    @inlinable
-    #endif
-    #if InlineAlways
-    @inline(__always)
-    #endif
     package mutating func loadStorage(fileDescriptor: some FileDescriptor) throws(SocketError) {
         let initialBuffer:InlineByteBuffer<initalBufferCount> = try readBuffer(fileDescriptor: fileDescriptor)
         if initialBuffer.endIndex <= 0 {
@@ -192,12 +132,6 @@ extension AbstractHTTPRequest {
 extension AbstractHTTPRequest {
     /// - Throws: `SocketError`
     /// - Warning: **DOESN'T** check if the read bytes are >= 0!
-    #if Inlinable
-    @inlinable
-    #endif
-    #if InlineAlways
-    @inline(__always)
-    #endif
     func readBuffer<let count: Int>(fileDescriptor: some FileDescriptor) throws(SocketError) -> InlineByteBuffer<count> {
         var buffer = InlineArray<count, UInt8>(repeating: 0)
         var mutableSpan = buffer.mutableSpan
@@ -220,12 +154,6 @@ extension AbstractHTTPRequest {
 // MARK: Start line
 extension AbstractHTTPRequest {
     /// - Throws: `SocketError`
-    #if Inlinable
-    @inlinable
-    #endif
-    #if InlineAlways
-    @inline(__always)
-    #endif
     mutating func startLine(fileDescriptor: some FileDescriptor) throws(SocketError) -> SIMD64<UInt8> {
         if initialBuffer == nil {
             try loadStorage(fileDescriptor: fileDescriptor)
@@ -234,12 +162,6 @@ extension AbstractHTTPRequest {
     }
 
     /// - Throws: `SocketError`
-    #if Inlinable
-    @inlinable
-    #endif
-    #if InlineAlways
-    @inline(__always)
-    #endif
     mutating func startLineLowercased(fileDescriptor: some FileDescriptor) throws(SocketError) -> SIMD64<UInt8> {
         if initialBuffer == nil {
             try loadStorage(fileDescriptor: fileDescriptor)
@@ -253,12 +175,6 @@ extension AbstractHTTPRequest {
 // MARK: Body
 extension AbstractHTTPRequest {
     /// - Throws: `SocketError`
-    #if Inlinable
-    @inlinable
-    #endif
-    #if InlineAlways
-    @inline(__always)
-    #endif
     mutating func bodyCollect<let count: Int>(fileDescriptor: some FileDescriptor) throws(SocketError) -> InlineByteBuffer<count> {
         if initialBuffer == nil {
             try loadStorage(fileDescriptor: fileDescriptor)

--- a/Sources/DestinyEmbedded/request/HTTPRequest+Storage.swift
+++ b/Sources/DestinyEmbedded/request/HTTPRequest+Storage.swift
@@ -5,24 +5,15 @@ extension HTTPRequest {
         @usableFromInline
         var storage:[ObjectIdentifier:any Sendable] // TODO: fix (avoid existentials)
 
-        #if Inlinable
-        @inlinable
-        #endif
         public init(_ storage: [ObjectIdentifier:any Sendable]) {
             self.storage = storage
         }
 
         /// Removes all values from the storage.
-        #if Inlinable
-        @inlinable
-        #endif
         public mutating func clear() {
             storage = [:]
         }
 
-        #if Inlinable
-        @inlinable
-        #endif
         public subscript<Key: StorageKey>(_ key: Key) -> Key.Value? {
             get {
                 guard let v = storage[ObjectIdentifier(Key.self)] as? Value<Key.Value> else { return nil }
@@ -39,18 +30,12 @@ extension HTTPRequest {
         }
 
         /// - Returns: Whether the key exists in the storage.
-        #if Inlinable
-        @inlinable
-        #endif
         public func contains<Key>(_ key: Key.Type) -> Bool {
             storage.keys.contains(ObjectIdentifier(Key.self))
         }
 
         /// - Note: Only use if you need it (e.g. required if doing async work from a responder).
         /// - Returns: A copy of self.
-        #if Inlinable
-        @inlinable
-        #endif
         public func copy() -> Self {
             Self(storage)
         }

--- a/Sources/DestinyEmbedded/request/HTTPRequest.swift
+++ b/Sources/DestinyEmbedded/request/HTTPRequest.swift
@@ -9,9 +9,6 @@ public struct HTTPRequest: NetworkAddressable, ~Copyable {
     @usableFromInline
     package var abstractRequest:AbstractHTTPRequest<1024>
 
-    #if Inlinable
-    @inlinable
-    #endif
     public init(
         fileDescriptor: Int32,
         storage: consuming Storage = .init([:])
@@ -24,9 +21,6 @@ public struct HTTPRequest: NetworkAddressable, ~Copyable {
 // MARK: Load
 extension HTTPRequest {
     /// - Throws: `SocketError`
-    #if Inlinable
-    @inlinable
-    #endif
     public static func load(from socket: consuming some FileDescriptor & ~Copyable) throws(SocketError) -> Self {
         Self(fileDescriptor: socket.fileDescriptor)
     }
@@ -34,16 +28,10 @@ extension HTTPRequest {
 
 // MARK: General logic
 extension HTTPRequest {
-    #if Inlinable
-    @inlinable
-    #endif
     public func socketLocalAddress() -> String? {
         fileDescriptor.socketLocalAddress()
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func socketPeerAddress() -> String? {
         fileDescriptor.socketPeerAddress()
     }
@@ -51,9 +39,6 @@ extension HTTPRequest {
     /// The HTTP start-line.
     /// 
     /// - Throws: `SocketError`
-    #if Inlinable
-    @inlinable
-    #endif
     public mutating func startLine() throws(SocketError) -> SIMD64<UInt8> {
         try abstractRequest.startLine(fileDescriptor: fileDescriptor)
     }
@@ -61,9 +46,6 @@ extension HTTPRequest {
     /// The HTTP start-line in all lowercase bytes.
     /// 
     /// - Throws: `SocketError`
-    #if Inlinable
-    @inlinable
-    #endif
     public mutating func startLineLowercased() throws(SocketError) -> SIMD64<UInt8> {
         try abstractRequest.startLineLowercased(fileDescriptor: fileDescriptor)
     }
@@ -71,9 +53,6 @@ extension HTTPRequest {
     /// Yields the endpoint the request wants to reach, separated by the forward slash character.
     /// 
     /// - Throws: `SocketError`
-    #if Inlinable
-    @inlinable
-    #endif
     public mutating func forEachPath(
         offset: Int,
         _ yield: (String) -> Void
@@ -86,9 +65,6 @@ extension HTTPRequest {
     /// 
     /// - Returns: The path component at the given index.
     /// - Throws: `SocketError`
-    #if Inlinable
-    @inlinable
-    #endif
     public mutating func path(at index: Int) throws(SocketError) -> String {
         try abstractRequest.path(fileDescriptor: fileDescriptor, at: index)
     }
@@ -96,18 +72,12 @@ extension HTTPRequest {
     /// Number of path components the request contains.
     /// 
     /// - Throws: `SocketError`
-    #if Inlinable
-    @inlinable
-    #endif
     public mutating func pathCount() throws(SocketError) -> Int {
         try abstractRequest.pathCount(fileDescriptor: fileDescriptor)
     }
 
     /// - Returns: Whether or not the request's method matches the given one.
     /// - Throws: `SocketError`
-    #if Inlinable
-    @inlinable
-    #endif
     public mutating func isMethod(_ method: HTTPRequestMethod) throws(SocketError) -> Bool {
         try abstractRequest.isMethod(fileDescriptor: fileDescriptor, method)
     }
@@ -115,9 +85,6 @@ extension HTTPRequest {
     /// - Returns: The value for the corresponding header key.
     /// - Throws: `SocketError`
     /// - Warning: `key` is case-sensitive!
-    #if Inlinable
-    @inlinable
-    #endif
     public mutating func header(forKey key: String) throws(SocketError) -> String? {
         #if RequestHeaders
         return try abstractRequest.header(fileDescriptor: fileDescriptor, forKey: key)
@@ -126,9 +93,6 @@ extension HTTPRequest {
         #endif
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public mutating func headers() throws(SocketError) -> [Substring:Substring] {
         #if RequestHeaders
         return try abstractRequest.headers(fileDescriptor: fileDescriptor)
@@ -139,9 +103,6 @@ extension HTTPRequest {
 
     /// - Note: Only use if you need it (e.g. required if doing async work from a responder).
     /// - Returns: A copy of self.
-    #if Inlinable
-    @inlinable
-    #endif
     public func copy() -> Self {
         var c = Self(fileDescriptor: fileDescriptor)
         c.abstractRequest = abstractRequest.copy()
@@ -155,16 +116,10 @@ extension HTTPRequest {
 
 // MARK: Body
 extension HTTPRequest {
-    #if Inlinable
-    @inlinable
-    #endif
     public mutating func bodyCollect() throws(SocketError) -> InitialBuffer {
         try abstractRequest.bodyCollect(fileDescriptor: fileDescriptor)
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public mutating func bodyCollect<let count: Int>() throws(SocketError) -> InlineByteBuffer<count> {
         try abstractRequest.bodyCollect(fileDescriptor: fileDescriptor)
     }

--- a/Sources/DestinyEmbedded/request/HTTPRequestLine.swift
+++ b/Sources/DestinyEmbedded/request/HTTPRequestLine.swift
@@ -16,9 +16,6 @@ public struct HTTPRequestLine: Sendable, ~Copyable {
     /// Mapped HTTP Version of a request.
     public let version:HTTPVersion
 
-    #if Inlinable
-    @inlinable
-    #endif
     public init(
         methodEndIndex: Int,
         pathQueryStartIndex: Int?,
@@ -32,24 +29,15 @@ public struct HTTPRequestLine: Sendable, ~Copyable {
     }
 
     /// Number of bytes of the target.
-    #if Inlinable
-    @inlinable
-    #endif
     public var pathCount: Int {
         pathEndIndex -! methodEndIndex -! 1
     }
 
     /// Index in a buffer where the target ends.
-    #if Inlinable
-    @inlinable
-    #endif
     public var pathEndIndex: Int {
         endIndex -! 9
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func path<let count: Int>(
         buffer: InlineArray<count, UInt8>,
         _ closure: (consuming VLArray<UInt8>) -> Void
@@ -72,9 +60,6 @@ public struct HTTPRequestLine: Sendable, ~Copyable {
         })
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func method<let count: Int>(
         buffer: InlineArray<count, UInt8>,
         _ closure: (consuming VLArray<UInt8>) -> Void
@@ -84,9 +69,6 @@ public struct HTTPRequestLine: Sendable, ~Copyable {
         }, closure)
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func simd<let count: Int>(
         buffer: InlineArray<count, UInt8>,
     ) -> SIMD64<UInt8> {
@@ -99,9 +81,6 @@ public struct HTTPRequestLine: Sendable, ~Copyable {
         return simd
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func copy() -> Self {
         Self(
             methodEndIndex: methodEndIndex,
@@ -117,9 +96,6 @@ extension HTTPRequestLine {
     /// Tries parsing a `HTTPRequestLine` from a buffer.
     /// 
     /// - Throws: `SocketError`
-    #if Inlinable
-    @inlinable
-    #endif
     public static func load<let count: Int>(
         buffer: borrowing InlineByteBuffer<count>
     ) throws(SocketError) -> Self {

--- a/Sources/DestinyEmbedded/request/RequestBody.swift
+++ b/Sources/DestinyEmbedded/request/RequestBody.swift
@@ -9,9 +9,6 @@ public struct RequestBody: Sendable, ~Copyable {
     @usableFromInline
     package var _totalRead:UInt64
 
-    #if Inlinable
-    @inlinable
-    #endif
     package init(
         totalRead: UInt64 = 0
     ) {
@@ -19,12 +16,6 @@ public struct RequestBody: Sendable, ~Copyable {
     }
 
     /// Current total number of bytes read from the body.
-    #if Inlinable
-    @inlinable
-    #endif
-    #if InlineAlways
-    @inline(__always)
-    #endif
     public var totalRead: UInt64 {
         _totalRead
     }
@@ -35,12 +26,6 @@ extension RequestBody {
     /// Reads a number of bytes from a file descriptor and writes it into a buffer.
     /// 
     /// - Throws: `SocketError`
-    #if Inlinable
-    @inlinable
-    #endif
-    #if InlineAlways
-    @inline(__always)
-    #endif
     package mutating func read<let count: Int>(
         fileDescriptor: some FileDescriptor,
         into buffer: inout InlineArray<count, UInt8>
@@ -75,9 +60,6 @@ extension RequestBody {
     /// Reads a number of bytes from a file descriptor and writes it into a buffer.
     /// 
     /// - Throws: `SocketError`
-    #if Inlinable
-    @inlinable
-    #endif
     public mutating func collect<let count: Int>(
         fileDescriptor: some FileDescriptor
     ) throws(SocketError) -> InlineByteBuffer<count> {
@@ -94,12 +76,7 @@ extension RequestBody {
         case literal(buffer: InlineArray<count, UInt8>)
         case end(buffer: InlineArray<count, UInt8>, endIndex: Int)
 
-        /*#if Inlinable
-        @inlinable
-        #endif
-        #if InlineAlways
-        @inline(__always)
-        #endif
+        /*
         public var buffer: InlineArray<count, UInt8> {
             switch self {
             case .literal(let b):

--- a/Sources/DestinyEmbedded/routes/DynamicResponse.swift
+++ b/Sources/DestinyEmbedded/routes/DynamicResponse.swift
@@ -18,16 +18,10 @@ public struct DynamicResponse<
         self.parameters = parameters
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public mutating func setBody(_ body: Body) {
         message.setBody(body)
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public mutating func setBody(_ body: some ResponseBodyProtocol) {
         message.setBody(body)
     }
@@ -48,9 +42,6 @@ public struct DynamicResponse: Sendable {
         self.parameters = parameters
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public mutating func setBody(_ body: some ResponseBodyProtocol) {
         message.setBody(body)
     }
@@ -59,69 +50,42 @@ public struct DynamicResponse: Sendable {
 
 // MARK: Logic
 extension DynamicResponse {
-    #if Inlinable
-    @inlinable
-    #endif
     public func parameter(at index: Int) -> String {
         parameters[index]
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public mutating func setParameter(at index: Int, value: consuming VLArray<UInt8>) {
         parameters[index] = value.unsafeString()
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public mutating func appendParameter(value: consuming VLArray<UInt8>) {
         parameters.append(value.unsafeString())
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func yieldParameters(_ yield: (String) -> Void) {
         for parameter in parameters {
             yield(parameter)
         }
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public mutating func setHTTPVersion(_ version: HTTPVersion) {
         message.version = version
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public mutating func setStatusCode(_ code: HTTPResponseStatus.Code) {
         message.setStatusCode(code)
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public mutating func setHeader(key: String, value: String) {
         message.setHeader(key: key, value: value)
     }
 
     #if HTTPCookie
-    #if Inlinable
-    @inlinable
-    #endif
     public mutating func appendCookie(_ cookie: HTTPCookie) throws(HTTPCookieError) {
         try message.appendCookie(cookie)
     }
     #endif
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func write(
         to socket: some FileDescriptor
     ) throws(SocketError) {

--- a/Sources/DestinyMacros/extensions/CharsetExtensions.swift
+++ b/Sources/DestinyMacros/extensions/CharsetExtensions.swift
@@ -22,9 +22,6 @@ extension Charset: RawRepresentable {
         }
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public var rawValue: String {
         switch self {
         case .any: "any"

--- a/Sources/DestinyMacros/router/Router+Compute.swift
+++ b/Sources/DestinyMacros/router/Router+Compute.swift
@@ -260,9 +260,6 @@ extension Router {
 
         var members = MemberBlockItemListSyntax()
         members.append(try! FunctionDeclSyntax("""
-        #if Inlinable
-        @inlinable
-        #endif
         public func respond(
             router: \(raw: routerType),
             socket: some FileDescriptor,

--- a/Sources/DestinyMacros/util/DynamicRoute.swift
+++ b/Sources/DestinyMacros/util/DynamicRoute.swift
@@ -91,9 +91,6 @@ extension DynamicRoute {
 #if StaticMiddleware
 // MARK: Apply static middleware
 extension DynamicRoute {
-    #if Inlinable
-    @inlinable
-    #endif
     public mutating func applyStaticMiddleware(_ middleware: [StaticMiddleware]) throws(AnyError) {
         let path = path.map({ $0.slug }).joined(separator: "/")
         for middleware in middleware {

--- a/Sources/DestinyMacros/util/StaticRoute.swift
+++ b/Sources/DestinyMacros/util/StaticRoute.swift
@@ -64,16 +64,10 @@ public struct StaticRoute: Sendable {
 
 // MARK: Logic
 extension StaticRoute {
-    #if Inlinable
-    @inlinable
-    #endif
     public var startLine: String {
         return "\(method.rawNameString()) /\(path.joined(separator: "/")) \(version.string)" 
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public mutating func insertPath(contentsOf newElements: some Collection<String>, at i: Int) {
         path.insert(contentsOf: newElements, at: i)
     }

--- a/Sources/Documentation.docc/PackageTraits.md
+++ b/Sources/Documentation.docc/PackageTraits.md
@@ -3,7 +3,6 @@ This document lists all the available package traits for Destiny.
 
 ## Table of Contents
 - [Functionality](#functionality)
-- [Annotations](#annotations)
 - [Embedded](#embedded)
 - [Third-party](#third-party)
 - [See Also](#see-also)
@@ -36,15 +35,6 @@ Enables functionality that can stream a request's body.
 
 ### RequestHeaders
 Enables functionality to access a request's headers.
-
-## Annotations
-List of package traits that enable annotations where annotated.
-
-### Inlinable
-Enables the `@inlinable` annotation where annotated.
-
-### InlineAlways
-Enables the `@inline(__always)` annotation where annotated.
 
 
 ## Embedded

--- a/Sources/Documentation.docc/Performance.md
+++ b/Sources/Documentation.docc/Performance.md
@@ -20,8 +20,6 @@ Destiny uses the Swift 6 Language Mode by default so data races are guaranteed t
 ### Annotations
 
 Destiny utilizes certain annotations to improve performance.
-- `@inlinable`
-- `@inline(__always)`
 - `@_marker`
 
 ### CodeGen

--- a/Sources/PerfectHashing/HashCandidate.swift
+++ b/Sources/PerfectHashing/HashCandidate.swift
@@ -32,23 +32,11 @@ public struct HashCandidate: Sendable {
     }
 
     /// - Complexity: O(1).
-    #if Inlinable
-    @inlinable
-    #endif
-    #if InlineAlways
-    @inline(__always)
-    #endif
     public var mask: UInt64 {
         _mask
     }
 
     /// - Complexity: O(1).
-    #if Inlinable
-    @inlinable
-    #endif
-    #if InlineAlways
-    @inline(__always)
-    #endif
     public func hash(_ key: UInt64) -> Int {
         Int(((key &* seed) >> shift) & _mask)
     }

--- a/Sources/PerfectHashing/PerfectHashGenerator.swift
+++ b/Sources/PerfectHashing/PerfectHashGenerator.swift
@@ -37,9 +37,6 @@ public struct PerfectHashGenerator<T: PerfectHashable>: PerfectHashGeneratorProt
 // MARK: Positions
 extension PerfectHashGenerator {
     /// - Returns: Route indexes that have the most unique characters.
-    #if Inlinable
-    @inlinable
-    #endif
     public static func findPerfectHashPositions(
         routes: [PerfectHashableItem<T>],
         maxBytes: Int
@@ -83,9 +80,6 @@ extension PerfectHashGenerator {
 
 // MARK: Perfect
 extension PerfectHashGenerator {
-    #if Inlinable
-    @inlinable
-    #endif
     public func findPerfectHashFunction<let count: Int>(
         seeds: InlineArray<count, UInt64>
     ) -> (candidate: HashCandidate, hashTable: [UInt8], verificationKeys: [UInt64])? {
@@ -121,9 +115,6 @@ extension PerfectHashGenerator {
         return nil
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func tryHashFunction(
         candidate: HashCandidate,
         hashTable: inout [UInt8],
@@ -154,9 +145,6 @@ extension PerfectHashGenerator {
     }
 
     @discardableResult
-    #if Inlinable
-    @inlinable
-    #endif
     public func generatePerfectHash<let count: Int>(seeds: InlineArray<count, UInt64>) -> (
         candidate: HashCandidate,
         hashTable: [UInt8],
@@ -194,9 +182,6 @@ extension PerfectHashGenerator {
 // MARK: Minimal
 extension PerfectHashGenerator {
     // for minimal perfect hash, table size = number of entries
-    #if Inlinable
-    @inlinable
-    #endif
     public func findMinimalPerfectHash<let count: Int>(seeds: InlineArray<count, UInt64>) -> (candidate: HashCandidate, result: MinimalResult)? {
         var candidate = HashCandidate(
             seed: .max,
@@ -216,9 +201,6 @@ extension PerfectHashGenerator {
         return nil
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func tryMinimalHashFunction(
         _ candidate: HashCandidate
     ) -> MinimalResult? {

--- a/Sources/PerfectHashing/PerfectHashGeneratorProtocol.swift
+++ b/Sources/PerfectHashing/PerfectHashGeneratorProtocol.swift
@@ -4,9 +4,6 @@ public protocol PerfectHashGeneratorProtocol: Sendable, ~Copyable {
 }
 
 extension PerfectHashGeneratorProtocol {
-    #if Inlinable
-    @inlinable
-    #endif
     public static func extractKeyClosure<T: PerfectHashable>(
         positions: InlineArray<64, Int>,
         maxBytes: Int

--- a/Sources/PerfectHashing/PerfectHashable.swift
+++ b/Sources/PerfectHashing/PerfectHashable.swift
@@ -12,9 +12,6 @@ public protocol PerfectHashable: Sendable, SIMD where Scalar == UInt8 {
 
 // MARK: SIMD64 extension
 extension SIMD64<UInt8>: PerfectHashable {
-    #if Inlinable
-    @inlinable
-    #endif
     public func extractKey1(positions: InlineArray<1, Int>) -> UInt64 {
         return withUnsafeBytes(of: (
             0,
@@ -30,9 +27,6 @@ extension SIMD64<UInt8>: PerfectHashable {
         }
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func extractKey2(positions: InlineArray<2, Int>) -> UInt64 {
         return withUnsafeBytes(of: (
             0,
@@ -48,9 +42,6 @@ extension SIMD64<UInt8>: PerfectHashable {
         }
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func extractKey3(positions: InlineArray<3, Int>) -> UInt64 {
         return withUnsafeBytes(of: (
             0,
@@ -66,9 +57,6 @@ extension SIMD64<UInt8>: PerfectHashable {
         }
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func extractKey4(positions: InlineArray<4, Int>) -> UInt64 {
         return withUnsafeBytes(of: (
             0,
@@ -84,9 +72,6 @@ extension SIMD64<UInt8>: PerfectHashable {
         }
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func extractKey5(positions: InlineArray<5, Int>) -> UInt64 {
         return withUnsafeBytes(of: self, { b in
             return withUnsafeBytes(of: (
@@ -104,9 +89,6 @@ extension SIMD64<UInt8>: PerfectHashable {
         })
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func extractKey6(positions: InlineArray<6, Int>) -> UInt64 {
         return withUnsafeBytes(of: self, { b in
             return withUnsafeBytes(of: (
@@ -124,9 +106,6 @@ extension SIMD64<UInt8>: PerfectHashable {
         })
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func extractKey7(positions: InlineArray<7, Int>) -> UInt64 {
         return withUnsafeBytes(of: self, { b in
             return withUnsafeBytes(of: (
@@ -144,9 +123,6 @@ extension SIMD64<UInt8>: PerfectHashable {
         })
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func extractKey8(positions: InlineArray<8, Int>) -> UInt64 {
         return withUnsafeBytes(of: self, { b in
             return withUnsafeBytes(of: (

--- a/Tests/DestinyTests/util/TestFileDescriptor.swift
+++ b/Tests/DestinyTests/util/TestFileDescriptor.swift
@@ -100,6 +100,7 @@ extension TestFileDescriptor {
         appendBuffer(b2)
         appendBuffer(b3)
     }
+
     func writeBuffers4(
         _ b1: UnsafeBufferPointer<UInt8>,
         _ b2: UnsafeBufferPointer<UInt8>,
@@ -111,9 +112,6 @@ extension TestFileDescriptor {
         appendBuffer((b3.baseAddress!, b3.count))
     }
 
-    #if Inlinable
-    @inlinable
-    #endif
     public func writeBuffers6(
         _ b1: (buffer: UnsafePointer<UInt8>, bufferCount: Int),
         _ b2: (buffer: UnsafePointer<UInt8>, bufferCount: Int),

--- a/script.js
+++ b/script.js
@@ -5,7 +5,7 @@ export const options = {
   // A number specifying the number of VUs to run concurrently.
   vus: 900,
   // A string specifying the total duration of the test run.
-  duration: '60s',
+  duration: '360s',
 
   // Uncomment this section to enable the use of Browser API in your tests.
   //


### PR DESCRIPTION
Upon further benchmarking, neither of the inline annotations improve performance. They both hurt runtime performance and overall binary size (adds ~80 KB to the stripped binary size).

Remove them. See attached files.

## Environment
OS: Arch Linux (6.17.5-arch1-1)
CPU: AMD Ryzen 7 7800X3D (16) @ 5.053G
RAM: DD5 32 GB
Swift: swift-6.2-RELEASE
Swiftly: 1.0.0

Both binaries built using: `swiftly run swift package clean && swiftly run swift build -c release`
The only difference between them is one has the `Inlinable` package trait enabled and the other has it disabled.

## Benchmark files
[inlinableResults.txt](https://github.com/user-attachments/files/23246027/inlinableResults.txt) (6 minute k6 output)
[inlinable-perf-report.txt](https://github.com/user-attachments/files/23246026/inlinable-perf-report.txt)

[noInliningResults.txt](https://github.com/user-attachments/files/23246029/noInliningResults.txt) (6 minute k6 output)
[noInlining-perf-report.txt](https://github.com/user-attachments/files/23246028/noInlining-perf-report.txt)
