### PR TITLE
Optimize responders

### DIFF
--- a/Sources/Destiny/extensions/Int32Extensions.swift
+++ b/Sources/Destiny/extensions/Int32Extensions.swift
@@ -61,16 +61,11 @@ extension Int32 {
     }
 
     public func writeBuffers3(
-        _ b1: (buffer: UnsafePointer<UInt8>, bufferCount: Int),
-        _ b2: (buffer: UnsafePointer<UInt8>, bufferCount: Int),
-        _ b3: (buffer: UnsafePointer<UInt8>, bufferCount: Int)
+        _ b1: iovec,
+        _ b2: iovec,
+        _ b3: iovec
     ) throws(DestinyError) {
-        var iovecs = (
-            iovec(iov_base: .init(mutating: b1.0), iov_len: b1.1),
-            iovec(iov_base: .init(mutating: b2.0), iov_len: b2.1),
-            iovec(iov_base: .init(mutating: b3.0), iov_len: b3.1)
-        )
-        let result = withUnsafePointer(to: &iovecs) {
+        let result = withUnsafePointer(to: (b1, b2, b3)) {
             writev(fileDescriptor, UnsafePointer<iovec>(OpaquePointer($0)), 3)
         }
         if result <= 0 {
@@ -79,15 +74,15 @@ extension Int32 {
     }
 
     public func writeBuffers4(
-        _ b1: UnsafeBufferPointer<UInt8>,
+        _ b1: iovec,
         _ b2: UnsafeBufferPointer<UInt8>,
-        _ b3: UnsafeBufferPointer<UInt8>,
+        _ b3: iovec,
         _ b4: UnsafeBufferPointer<UInt8>
     ) throws(DestinyError) {
         var iovecs = (
-            iovec(iov_base: .init(mutating: b1.baseAddress), iov_len: b1.count),
+            b1,
             iovec(iov_base: .init(mutating: b2.baseAddress), iov_len: b2.count),
-            iovec(iov_base: .init(mutating: b3.baseAddress), iov_len: b3.count),
+            b3,
             iovec(iov_base: .init(mutating: b4.baseAddress), iov_len: b4.count)
         )
         let result = withUnsafePointer(to: &iovecs) {
@@ -99,19 +94,19 @@ extension Int32 {
     }
 
     public func writeBuffers6(
-        _ b1: (buffer: UnsafePointer<UInt8>, bufferCount: Int),
-        _ b2: (buffer: UnsafePointer<UInt8>, bufferCount: Int),
-        _ b3: (buffer: UnsafePointer<UInt8>, bufferCount: Int),
+        _ b1: iovec,
+        _ b2: iovec,
+        _ b3: iovec,
         _ b4: (buffer: UnsafePointer<UInt8>, bufferCount: Int),
-        _ b5: (buffer: UnsafePointer<UInt8>, bufferCount: Int),
+        _ b5: iovec,
         _ b6: (buffer: UnsafePointer<UInt8>, bufferCount: Int)
     ) throws(DestinyError) {
         var iovecs = (
-            iovec(iov_base: .init(mutating: b1.0), iov_len: b1.1),
-            iovec(iov_base: .init(mutating: b2.0), iov_len: b2.1),
-            iovec(iov_base: .init(mutating: b3.0), iov_len: b3.1),
+            b1,
+            b2,
+            b3,
             iovec(iov_base: .init(mutating: b4.0), iov_len: b4.1),
-            iovec(iov_base: .init(mutating: b5.0), iov_len: b5.1),
+            b5,
             iovec(iov_base: .init(mutating: b6.0), iov_len: b6.1)
         )
         let result = withUnsafePointer(to: &iovecs) {
@@ -208,3 +203,7 @@ extension Int32 {
 extension Int32: FileDescriptor {}
 
 //#endif
+
+
+// MARK: iovec
+extension iovec: @unchecked @retroactive Sendable {}

--- a/Sources/Destiny/extensions/Int32Extensions.swift
+++ b/Sources/Destiny/extensions/Int32Extensions.swift
@@ -93,6 +93,26 @@ extension Int32 {
         }
     }
 
+    public func writeBuffers4(
+        _ b1: UnsafeBufferPointer<UInt8>,
+        _ b2: iovec,
+        _ b3: UnsafeBufferPointer<UInt8>,
+        _ b4: UnsafeBufferPointer<UInt8>
+    ) throws(DestinyError) {
+        var iovecs = (
+            iovec(iov_base: .init(mutating: b1.baseAddress), iov_len: b1.count),
+            b2,
+            iovec(iov_base: .init(mutating: b3.baseAddress), iov_len: b3.count),
+            iovec(iov_base: .init(mutating: b4.baseAddress), iov_len: b4.count)
+        )
+        let result = withUnsafePointer(to: &iovecs) {
+            writev(fileDescriptor, UnsafePointer<iovec>(OpaquePointer($0)), 4)
+        }
+        if result <= 0 {
+            throw .socketWriteFailed(errno)
+        }
+    }
+
     public func writeBuffers6(
         _ b1: iovec,
         _ b2: iovec,

--- a/Sources/Destiny/http/HTTPDateFormat.swift
+++ b/Sources/Destiny/http/HTTPDateFormat.swift
@@ -50,6 +50,10 @@ public struct HTTPDateFormat: Sendable {
     @usableFromInline
     nonisolated(unsafe) static private(set) var _nowString = placeholder
 
+    /// Last calculated date value in the HTTP Format as an `iovec`.
+    @usableFromInline
+    nonisolated(unsafe) static private(set) var _nowIovec = iovec()
+
 
     /// Last calculated date value in the HTTP Format as an `UnsafeBufferPointer<UInt8>`.
     /// 
@@ -63,6 +67,11 @@ public struct HTTPDateFormat: Sendable {
     /// Last calculated date value in the HTTP Format as a `String`.
     public static var nowString: String {
         _read { yield _nowString }
+    }
+
+    /// Last calculated date value in the HTTP Format as an `iovec`.
+    public static var nowIovec: iovec {
+        _read { yield _nowIovec }
     }
 
     /// Current number of non-zero bytes in the `_nowUnsafeBufferPointer`.
@@ -110,6 +119,7 @@ extension HTTPDateFormat {
                             }
                         }
                         _nowString = s
+                        _nowIovec = .init(iov_base: _nowUnsafeBufferPointer.baseAddress!, iov_len: _count)
                     }
                     try await Task.sleep(for: .seconds(1))
                 } catch {
@@ -143,6 +153,7 @@ extension HTTPDateFormat {
                             }
                         }
                         _nowString = s
+                        _nowIovec = .init(iov_base: _nowUnsafeBufferPointer.baseAddress!, iov_len: _count)
                     }
                     try await Task.sleep(for: .seconds(1))
                 } catch {

--- a/Sources/Destiny/http/HTTPSocket.swift
+++ b/Sources/Destiny/http/HTTPSocket.swift
@@ -137,6 +137,15 @@ extension HTTPSocket {
         try fileDescriptor.writeBuffers4(b1, b2, b3, b4)
     }
 
+    public func writeBuffers4(
+        _ b1: UnsafeBufferPointer<UInt8>,
+        _ b2: iovec,
+        _ b3: UnsafeBufferPointer<UInt8>,
+        _ b4: UnsafeBufferPointer<UInt8>
+    ) throws(DestinyError) {
+        try fileDescriptor.writeBuffers4(b1, b2, b3, b4)
+    }
+
     public func writeBuffers6(
         _ b1: iovec,
         _ b2: iovec,

--- a/Sources/Destiny/http/HTTPSocket.swift
+++ b/Sources/Destiny/http/HTTPSocket.swift
@@ -1,4 +1,22 @@
 
+#if canImport(Android)
+import Android
+#elseif canImport(Bionic)
+import Bionic
+#elseif canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif canImport(WASILibc)
+import WASILibc
+#elseif canImport(Windows)
+import Windows
+#elseif canImport(WinSDK)
+import WinSDK
+#endif
+
 import UnwrapArithmeticOperators
 
 /// Default HTTP Socket implementation.
@@ -103,28 +121,28 @@ extension HTTPSocket {
     }
 
     public func writeBuffers3(
-        _ b1: (buffer: UnsafePointer<UInt8>, bufferCount: Int),
-        _ b2: (buffer: UnsafePointer<UInt8>, bufferCount: Int),
-        _ b3: (buffer: UnsafePointer<UInt8>, bufferCount: Int)
+        _ b1: iovec,
+        _ b2: iovec,
+        _ b3: iovec
     ) throws(DestinyError) {
         try fileDescriptor.writeBuffers3(b1, b2, b3)
     }
 
     public func writeBuffers4(
-        _ b1: UnsafeBufferPointer<UInt8>,
+        _ b1: iovec,
         _ b2: UnsafeBufferPointer<UInt8>,
-        _ b3: UnsafeBufferPointer<UInt8>,
+        _ b3: iovec,
         _ b4: UnsafeBufferPointer<UInt8>
     ) throws(DestinyError) {
         try fileDescriptor.writeBuffers4(b1, b2, b3, b4)
     }
 
     public func writeBuffers6(
-        _ b1: (buffer: UnsafePointer<UInt8>, bufferCount: Int),
-        _ b2: (buffer: UnsafePointer<UInt8>, bufferCount: Int),
-        _ b3: (buffer: UnsafePointer<UInt8>, bufferCount: Int),
+        _ b1: iovec,
+        _ b2: iovec,
+        _ b3: iovec,
         _ b4: (buffer: UnsafePointer<UInt8>, bufferCount: Int),
-        _ b5: (buffer: UnsafePointer<UInt8>, bufferCount: Int),
+        _ b5: iovec,
         _ b6: (buffer: UnsafePointer<UInt8>, bufferCount: Int)
     ) throws(DestinyError) {
         try fileDescriptor.writeBuffers6(b1, b2, b3, b4, b5, b6)

--- a/Sources/Destiny/responders/copyable/DateHeaderPayload.swift
+++ b/Sources/Destiny/responders/copyable/DateHeaderPayload.swift
@@ -1,21 +1,39 @@
 
 #if CopyableDateHeaderPayload
 
+#if canImport(Android)
+import Android
+#elseif canImport(Bionic)
+import Bionic
+#elseif canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif canImport(WASILibc)
+import WASILibc
+#elseif canImport(Windows)
+import Windows
+#elseif canImport(WinSDK)
+import WinSDK
+#endif
+
 /// Default storage to efficiently handle the `date` header payload for responders.
 public struct DateHeaderPayload: @unchecked Sendable {
     @usableFromInline let preDatePointer:UnsafePointer<UInt8>
-    @usableFromInline let preDatePointerCount:Int
     @usableFromInline let postDatePointer:UnsafePointer<UInt8>
-    @usableFromInline let postDatePointerCount:Int
+    @usableFromInline let preDateIovec:iovec
+    @usableFromInline let postDateIovec:iovec
 
     public init(
         preDate: StaticString,
         postDate: StaticString
     ) {
         self.preDatePointer = preDate.utf8Start
-        self.preDatePointerCount = preDate.utf8CodeUnitCount
         self.postDatePointer = postDate.utf8Start
-        self.postDatePointerCount = postDate.utf8CodeUnitCount
+        self.preDateIovec = .init(iov_base: .init(mutating: preDate.utf8Start), iov_len: preDate.utf8CodeUnitCount)
+        self.postDateIovec = .init(iov_base: .init(mutating: postDate.utf8Start), iov_len: postDate.utf8CodeUnitCount)
     }
 
     /// Efficiently writes the `preDate` value, `date` header and `postDate` value to a file descriptor.
@@ -23,9 +41,9 @@ public struct DateHeaderPayload: @unchecked Sendable {
     /// - Throws: `DestinyError`
     public func write(to socket: some FileDescriptor) throws(DestinyError) {
         try socket.writeBuffers3(
-            (preDatePointer, preDatePointerCount),
-            (HTTPDateFormat.nowUnsafeBufferPointer.baseAddress!, HTTPDateFormat.count),
-            (postDatePointer, postDatePointerCount)
+            preDateIovec,
+            HTTPDateFormat.nowIovec,
+            postDateIovec
         )
     }
 }

--- a/Sources/Destiny/responders/copyable/RouteResponses+MacroExpansion.swift
+++ b/Sources/Destiny/responders/copyable/RouteResponses+MacroExpansion.swift
@@ -1,14 +1,37 @@
 
 #if CopyableMacroExpansion
 
+#if canImport(Android)
+import Android
+#elseif canImport(Bionic)
+import Bionic
+#elseif canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif canImport(WASILibc)
+import WASILibc
+#elseif canImport(Windows)
+import Windows
+#elseif canImport(WinSDK)
+import WinSDK
+#endif
+
 extension RouteResponses {
     public struct MacroExpansion: Sendable {
+        public static let bodyCountSuffix:iovec = {
+            let ss:StaticString = "\r\n\r\n"
+            return .init(iov_base: .init(mutating: ss.utf8Start), iov_len: ss.utf8CodeUnitCount)
+        }()
+
         public let bodyCount:String.UTF8View
         public let body:String.UTF8View
-        public let value:StaticString
+        public let value:iovec
 
         public init(_ value: StaticString, body: String) {
-            self.value = value
+            self.value = .init(iov_base: .init(mutating: value.utf8Start), iov_len: value.utf8CodeUnitCount)
             bodyCount = String(body.utf8Span.count).utf8
             self.body = body.utf8
         }
@@ -29,22 +52,17 @@ extension RouteResponses.MacroExpansion {
         socket: some FileDescriptor
     ) throws(DestinyError) {
         var err:DestinyError? = nil
-        value.withUTF8Buffer { valuePointer in
-            bodyCount.withContiguousStorageIfAvailable { bodyCountPointer in
-                body.withContiguousStorageIfAvailable { bodyPointer in
-                    let bodyCountSuffix:InlineArray<4, UInt8> = [.carriageReturn, .lineFeed, .carriageReturn, .lineFeed]
-                    bodyCountSuffix.span.withUnsafeBufferPointer { bodyCountSuffixPointer in
-                        do throws(DestinyError) {
-                            try socket.writeBuffers4(
-                                valuePointer,
-                                bodyCountPointer,
-                                bodyCountSuffixPointer,
-                                bodyPointer
-                            )
-                        } catch {
-                            err = error
-                        }
-                    }
+        bodyCount.withContiguousStorageIfAvailable { bodyCountPointer in
+            body.withContiguousStorageIfAvailable { bodyPointer in
+                do throws(DestinyError) {
+                    try socket.writeBuffers4(
+                        value,
+                        bodyCountPointer,
+                        Self.bodyCountSuffix,
+                        bodyPointer
+                    )
+                } catch {
+                    err = error
                 }
             }
         }

--- a/Sources/Destiny/responders/copyable/StaticStringWithDateHeader.swift
+++ b/Sources/Destiny/responders/copyable/StaticStringWithDateHeader.swift
@@ -24,7 +24,7 @@ public struct StaticStringWithDateHeader: Sendable {
     }
 
     public var count: Int {
-        payload.preDatePointerCount +! HTTPDateFormat.InlineArrayResult.count +! payload.postDatePointerCount
+        payload.preDateIovec.iov_len +! HTTPDateFormat.InlineArrayResult.count +! payload.postDateIovec.iov_len
     }
     
     public func string() -> String {
@@ -40,9 +40,9 @@ public struct StaticStringWithDateHeader: Sendable {
 extension StaticStringWithDateHeader {
     public func write(to buffer: UnsafeMutableBufferPointer<UInt8>, at index: inout Int) {
         index = 0
-        buffer.copyBuffer(baseAddress: payload.preDatePointer, count: payload.preDatePointerCount, at: &index)
+        buffer.copyBuffer(baseAddress: payload.preDatePointer, count: payload.preDateIovec.iov_len, at: &index)
         buffer.copyBuffer(baseAddress: HTTPDateFormat.nowUnsafeBufferPointer.baseAddress!, count: HTTPDateFormat.count, at: &index)
-        buffer.copyBuffer(baseAddress: payload.postDatePointer, count: payload.postDatePointerCount, at: &index)
+        buffer.copyBuffer(baseAddress: payload.postDatePointer, count: payload.postDateIovec.iov_len, at: &index)
     }
 }
 

--- a/Sources/Destiny/responders/copyable/StreamWithDateHeader.swift
+++ b/Sources/Destiny/responders/copyable/StreamWithDateHeader.swift
@@ -29,7 +29,7 @@ public struct StreamWithDateHeader<Body: AsyncHTTPSocketWritable>: Sendable {
     }
 
     public var count: Int {
-        payload.preDatePointerCount +! HTTPDateFormat.InlineArrayResult.count +! payload.postDatePointerCount
+        payload.preDateIovec.iov_len +! HTTPDateFormat.InlineArrayResult.count +! payload.postDateIovec.iov_len
     }
 
     public func string() -> String {

--- a/Sources/Destiny/responders/copyable/StringWithDateHeader.swift
+++ b/Sources/Destiny/responders/copyable/StringWithDateHeader.swift
@@ -73,7 +73,7 @@ extension StringWithDateHeader {
                     do throws(DestinyError) {
                         try socket.writeBuffers4(
                             preDatePointer,
-                            HTTPDateFormat.nowUnsafeBufferPointer, // TODO: fix? (see `HTTPDateFormat.nowUnsafeBufferPointer` warning)
+                            HTTPDateFormat.nowIovec,
                             postDatePointer,
                             valuePointer
                         )

--- a/Sources/Destiny/responders/noncopyable/NonCopyableStaticStringWithDateHeader.swift
+++ b/Sources/Destiny/responders/noncopyable/NonCopyableStaticStringWithDateHeader.swift
@@ -30,7 +30,7 @@ public struct NonCopyableStaticStringWithDateHeader: Sendable, ~Copyable {
     }
 
     public var count: Int {
-        payload.preDatePointerCount +! HTTPDateFormat.InlineArrayResult.count +! payload.postDatePointerCount
+        payload.preDateIovec.iov_len +! HTTPDateFormat.InlineArrayResult.count +! payload.postDateIovec.iov_len
     }
     
     public func string() -> String {
@@ -46,9 +46,9 @@ public struct NonCopyableStaticStringWithDateHeader: Sendable, ~Copyable {
 extension NonCopyableStaticStringWithDateHeader {
     public func write(to buffer: UnsafeMutableBufferPointer<UInt8>, at index: inout Int) {
         index = 0
-        buffer.copyBuffer(baseAddress: payload.preDatePointer, count: payload.preDatePointerCount, at: &index)
+        buffer.copyBuffer(baseAddress: payload.preDatePointer, count: payload.preDateIovec.iov_len, at: &index)
         buffer.copyBuffer(baseAddress: HTTPDateFormat.nowUnsafeBufferPointer.baseAddress!, count: HTTPDateFormat.count, at: &index)
-        buffer.copyBuffer(baseAddress: payload.postDatePointer, count: payload.postDatePointerCount, at: &index)
+        buffer.copyBuffer(baseAddress: payload.postDatePointer, count: payload.postDateIovec.iov_len, at: &index)
     }
 }
 

--- a/Sources/Destiny/responders/noncopyable/NonCopyableStreamWithDateHeader.swift
+++ b/Sources/Destiny/responders/noncopyable/NonCopyableStreamWithDateHeader.swift
@@ -29,7 +29,7 @@ public struct NonCopyableStreamWithDateHeader<Body: AsyncHTTPSocketWritable & ~C
     }
 
     public var count: Int {
-        payload.preDatePointerCount +! HTTPDateFormat.InlineArrayResult.count +! payload.postDatePointerCount
+        payload.preDateIovec.iov_len +! HTTPDateFormat.InlineArrayResult.count +! payload.postDateIovec.iov_len
     }
     
     public func string() -> String {

--- a/Sources/Destiny/util/protocols/FileDescriptor.swift
+++ b/Sources/Destiny/util/protocols/FileDescriptor.swift
@@ -72,6 +72,16 @@ public protocol FileDescriptor: NetworkAddressable, ~Copyable {
         _ b4: UnsafeBufferPointer<UInt8>
     ) throws(DestinyError)
 
+    /// Efficiently writes 4 buffers to the file descriptor.
+    /// 
+    /// - Throws: `DestinyError`
+    func writeBuffers4(
+        _ b1: UnsafeBufferPointer<UInt8>,
+        _ b2: iovec,
+        _ b3: UnsafeBufferPointer<UInt8>,
+        _ b4: UnsafeBufferPointer<UInt8>
+    ) throws(DestinyError)
+
     /// Efficiently writes 6 buffers to the file descriptor.
     /// 
     /// - Throws: `DestinyError`

--- a/Sources/Destiny/util/protocols/FileDescriptor.swift
+++ b/Sources/Destiny/util/protocols/FileDescriptor.swift
@@ -57,18 +57,18 @@ public protocol FileDescriptor: NetworkAddressable, ~Copyable {
     /// 
     /// - Throws: `DestinyError`
     func writeBuffers3(
-        _ b1: (buffer: UnsafePointer<UInt8>, bufferCount: Int),
-        _ b2: (buffer: UnsafePointer<UInt8>, bufferCount: Int),
-        _ b3: (buffer: UnsafePointer<UInt8>, bufferCount: Int)
+        _ b1: iovec,
+        _ b2: iovec,
+        _ b3: iovec
     ) throws(DestinyError)
 
     /// Efficiently writes 4 buffers to the file descriptor.
     /// 
     /// - Throws: `DestinyError`
     func writeBuffers4(
-        _ b1: UnsafeBufferPointer<UInt8>,
+        _ b1: iovec,
         _ b2: UnsafeBufferPointer<UInt8>,
-        _ b3: UnsafeBufferPointer<UInt8>,
+        _ b3: iovec,
         _ b4: UnsafeBufferPointer<UInt8>
     ) throws(DestinyError)
 
@@ -76,11 +76,11 @@ public protocol FileDescriptor: NetworkAddressable, ~Copyable {
     /// 
     /// - Throws: `DestinyError`
     func writeBuffers6(
-        _ b1: (buffer: UnsafePointer<UInt8>, bufferCount: Int),
-        _ b2: (buffer: UnsafePointer<UInt8>, bufferCount: Int),
-        _ b3: (buffer: UnsafePointer<UInt8>, bufferCount: Int),
+        _ b1: iovec,
+        _ b2: iovec,
+        _ b3: iovec,
         _ b4: (buffer: UnsafePointer<UInt8>, bufferCount: Int),
-        _ b5: (buffer: UnsafePointer<UInt8>, bufferCount: Int),
+        _ b5: iovec,
         _ b6: (buffer: UnsafePointer<UInt8>, bufferCount: Int)
     ) throws(DestinyError)
 

--- a/Tests/DestinyTests/ResponseTests.swift
+++ b/Tests/DestinyTests/ResponseTests.swift
@@ -57,9 +57,9 @@ extension NonCopyableDateHeaderPayload {
         s.withUTF8 { datePointer in
             do throws(DestinyError) {
                 try socket.writeBuffers3(
-                    (preDatePointer, preDatePointerCount),
-                    (datePointer.baseAddress!, datePointer.count),
-                    (postDatePointer, postDatePointerCount)
+                    preDateIovec,
+                    .init(iov_base: .init(mutating: datePointer.baseAddress!), iov_len: datePointer.count),
+                    postDateIovec
                 )
             } catch {
                 err = error

--- a/Tests/DestinyTests/util/TestHTTPSocket.swift
+++ b/Tests/DestinyTests/util/TestHTTPSocket.swift
@@ -1,4 +1,22 @@
 
+#if canImport(Android)
+import Android
+#elseif canImport(Bionic)
+import Bionic
+#elseif canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif canImport(WASILibc)
+import WASILibc
+#elseif canImport(Windows)
+import Windows
+#elseif canImport(WinSDK)
+import WinSDK
+#endif
+
 @testable import Destiny
 
 struct TestHTTPSocket: FileDescriptor, ~Copyable {
@@ -54,16 +72,25 @@ extension TestHTTPSocket {
     }
 
     func writeBuffers3(
-        _ b1: (buffer: UnsafePointer<UInt8>, bufferCount: Int),
-        _ b2: (buffer: UnsafePointer<UInt8>, bufferCount: Int),
-        _ b3: (buffer: UnsafePointer<UInt8>, bufferCount: Int)
+        _ b1: iovec,
+        _ b2: iovec,
+        _ b3: iovec
     ) throws(DestinyError) {
         try fileDescriptor.writeBuffers3(b1, b2, b3)
     }
 
     func writeBuffers4(
-        _ b1: UnsafeBufferPointer<UInt8>,
+        _ b1: iovec,
         _ b2: UnsafeBufferPointer<UInt8>,
+        _ b3: iovec,
+        _ b4: UnsafeBufferPointer<UInt8>
+    ) throws(DestinyError) {
+        try fileDescriptor.writeBuffers4(b1, b2, b3, b4)
+    }
+
+    func writeBuffers4(
+        _ b1: UnsafeBufferPointer<UInt8>,
+        _ b2: iovec,
         _ b3: UnsafeBufferPointer<UInt8>,
         _ b4: UnsafeBufferPointer<UInt8>
     ) throws(DestinyError) {
@@ -71,11 +98,11 @@ extension TestHTTPSocket {
     }
 
     func writeBuffers6(
-        _ b1: (buffer: UnsafePointer<UInt8>, bufferCount: Int),
-        _ b2: (buffer: UnsafePointer<UInt8>, bufferCount: Int),
-        _ b3: (buffer: UnsafePointer<UInt8>, bufferCount: Int),
+        _ b1: iovec,
+        _ b2: iovec,
+        _ b3: iovec,
         _ b4: (buffer: UnsafePointer<UInt8>, bufferCount: Int),
-        _ b5: (buffer: UnsafePointer<UInt8>, bufferCount: Int),
+        _ b5: iovec,
         _ b6: (buffer: UnsafePointer<UInt8>, bufferCount: Int)
     ) throws(DestinyError) {
         try fileDescriptor.writeBuffers6(b1, b2, b3, b4, b5, b6)


### PR DESCRIPTION
This PR is solely focused on reducing responder overhead, reducing their runtime latency.

Compared to #21 , the runtime performance is usually faster or the same, but the perf report shows the responder bottleneck was reduced so this is still a win.