### PR TITLE
`HTTPRequest` `fileDescriptor` visibility fix

### DIFF
--- a/Sources/Destiny/request/HTTPRequest.swift
+++ b/Sources/Destiny/request/HTTPRequest.swift
@@ -3,8 +3,7 @@
 public struct HTTPRequest: NetworkAddressable, ~Copyable {
     public typealias InitialBuffer = InlineByteBuffer<1024>
 
-    @usableFromInline
-    package let fileDescriptor:Int32
+    public let fileDescriptor:Int32
 
     @usableFromInline
     package var abstractRequest:AbstractHTTPRequest<1024>


### PR DESCRIPTION
Declaring a router using the `declareRouter` macro can fail to compile after expansion since the `fileDescriptor`'s visibility is `package`. Change it to `public` to fix compilation error.