### PR TITLE
Update benchmarks

### DIFF
--- a/Benchmarks/Benchmarks/Destiny/Destiny.swift
+++ b/Benchmarks/Benchmarks/Destiny/Destiny.swift
@@ -1,4 +1,5 @@
 
+import Destiny
 import DestinySwiftSyntax
 import Logging
 
@@ -19,7 +20,7 @@ extension DestinyStorage {
                 appliesStatus: HTTPStandardResponseStatus.ok.code,
                 appliesHeaders: [
                     "server":"destiny",
-                    "connection":"close"
+                    "connection":"keep-alive"
                 ]
             ),
             DynamicCORSMiddleware()
@@ -27,14 +28,9 @@ extension DestinyStorage {
         Route.get(
             path: ["html"],
             contentType: "text/html",
-            body: NonCopyableStaticStringWithDateHeader(#"<!DOCTYPE html><html><head><meta charset="UTF-8"></head><body><h1>This outcome was inevitable; t'was your destiny</h1></body></html>"#)
-        ),
-        Route.get(
-            path: ["dynamic"],
-            contentType: "text/html",
-            handler: { request, response in
-                response.setBody("\(UInt64.random(in: UInt64.min...UInt64.max))")
-            }
+            body: NonCopyableStaticStringWithDateHeader("""
+            <!DOCTYPE html><html><head><meta charset="UTF-8"></head><body><h1>This outcome was inevitable; t'was your destiny</h1></body></html>
+            """)
         )
     )
 }

--- a/Benchmarks/Benchmarks/Hummingbird/Hummingbird.swift
+++ b/Benchmarks/Benchmarks/Hummingbird/Hummingbird.swift
@@ -8,10 +8,12 @@ package struct HummingbirdStorage {
 extension HummingbirdStorage {
     package static func router() -> Router<BasicRequestContext> {
         let router = Hummingbird.Router()
-        let body = Hummingbird.ResponseBody(byteBuffer: ByteBuffer(string: #"<!DOCTYPE html><html><head><meta charset="UTF-8"></head><body><h1>This outcome was inevitable; t'was your destiny</h1></body></html>"#))
+        let body = Hummingbird.ResponseBody(byteBuffer: ByteBuffer(staticString: """
+        <!DOCTYPE html><html><head><meta charset="UTF-8"></head><body><h1>This outcome was inevitable; t'was your destiny</h1></body></html>
+        """))
         let headers = Hummingbird.HTTPFields(dictionaryLiteral:
             (.server, "destiny"),
-            (.connection, "close"),
+            (.connection, "keep-alive"),
             (.contentType, "text/html"),
             (.contentLength, "132")
         )

--- a/Benchmarks/Benchmarks/Run/main.swift
+++ b/Benchmarks/Benchmarks/Run/main.swift
@@ -1,4 +1,5 @@
 
+import Destiny
 import DestinySwiftSyntax
 import TestDestiny
 import TestHummingbird
@@ -52,11 +53,11 @@ struct DestinyService: Service {
     }
 
     func run() async throws {
-        let application = destinyApp(port: port)
-        try await application.run()
+        let server = destinyServer(port: port)
+        try await server.run()
     }
 }
-func destinyApp(port: UInt16) -> NonCopyableHTTPServer<DestinyStorage.DeclaredRouter.CompiledHTTPRouter, HTTPSocket> {
+func destinyServer(port: UInt16) -> NonCopyableHTTPServer<DestinyStorage.DeclaredRouter.CompiledHTTPRouter, HTTPSocket> {
     let server = NonCopyableHTTPServer<DestinyStorage.DeclaredRouter.CompiledHTTPRouter, HTTPSocket>(
         address: hostname,
         port: port,
@@ -64,7 +65,7 @@ func destinyApp(port: UInt16) -> NonCopyableHTTPServer<DestinyStorage.DeclaredRo
         router: DestinyStorage.DeclaredRouter.router,
         logger: Logger(label: "destiny.http.server")
     )
-    HTTPDateFormat.load(logger: Logger(label: "destiny.application"))
+    HTTPDateFormat.load(logger: Logger(label: "destiny.http.dateformat"))
     return server
 }
 

--- a/Benchmarks/Benchmarks/Vapor/Vapor.swift
+++ b/Benchmarks/Benchmarks/Vapor/Vapor.swift
@@ -7,15 +7,17 @@ package struct VaporStorage {
 
 extension VaporStorage {
     package static func registerRoutes(_ app: Application) {
-        let body = Response.Body(staticString: #"<!DOCTYPE html><html><head><meta charset="UTF-8"></head><body><h1>This outcome was inevitable; t'was your destiny</h1></body></html>"#)
-        let headers = HTTPHeaders(dictionaryLiteral:
+        let body = Response.Body(staticString: """
+        <!DOCTYPE html><html><head><meta charset="UTF-8"></head><body><h1>This outcome was inevitable; t'was your destiny</h1></body></html>
+        """)
+        let headers = HTTPHeaders([
             ("server", "destiny"),
-            ("connection", "close"),
+            //("connection", "keep-alive"), // Vapor always add this by default
             ("content-type", "text/html"),
             ("content-length", "132")
-        )
+        ])
         app.get(["html"]) { request in
-            // we have to do it this way because its headers get updated every request (probably 'cause its a class)
+            // we have to do it this way because the headers get updated every request (probably 'cause its a class)
             return Response(status: .ok, version: request.version, headers: headers, body: body)
         }
     } 

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -15,10 +15,11 @@ let package = Package(
 
         .package(url: "https://github.com/swift-server/async-http-client", exact: "1.29.0"),
 
-        .package(
+        .package(path: ".."),
+        /*.package(
             url: "https://github.com/RandomHashTags/destiny",
             branch: "main"
-        ),
+        ),*/
         .package(url: "https://github.com/vapor/vapor", exact: "4.119.0"),
         .package(url: "https://github.com/hummingbird-project/hummingbird", exact: "2.17.0")
     ],

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -10,20 +10,17 @@ let package = Package(
     dependencies: [
         // networking
         .package(url: "https://github.com/swift-server/swift-service-lifecycle", exact: "2.9.0"),
-        .package(url: "https://github.com/apple/swift-nio", exact: "2.87.0"),
+        .package(url: "https://github.com/apple/swift-nio", exact: "2.88.0"),
         .package(url: "https://github.com/apple/swift-log", exact: "1.6.4"),
 
         .package(url: "https://github.com/swift-server/async-http-client", exact: "1.29.0"),
 
         .package(
             url: "https://github.com/RandomHashTags/destiny",
-            branch: "main",
-            traits: [
-                "Inlinable"
-            ]
+            branch: "main"
         ),
-        .package(url: "https://github.com/vapor/vapor", exact: "4.117.0"),
-        .package(url: "https://github.com/hummingbird-project/hummingbird", exact: "2.16.0")
+        .package(url: "https://github.com/vapor/vapor", exact: "4.119.0"),
+        .package(url: "https://github.com/hummingbird-project/hummingbird", exact: "2.17.0")
     ],
     targets: [
         .target(

--- a/Benchmarks/results_destiny.txt
+++ b/Benchmarks/results_destiny.txt
@@ -197,19 +197,19 @@ default   [ 100% ] 900 VUs  1m00.0s/1m0s
   █ TOTAL RESULTS 
 
     HTTP
-    http_req_duration..............: avg=1.33ms min=28.85µs med=794.55µs max=33.66ms p(90)=2.1ms p(95)=3.17ms
-      { expected_response:true }...: avg=1.33ms min=28.85µs med=794.55µs max=33.66ms p(90)=2.1ms p(95)=3.17ms
+    http_req_duration..............: avg=775.13µs min=19.63µs med=609.98µs max=13.28ms p(90)=1.36ms p(95)=2ms
+      { expected_response:true }...: avg=775.13µs min=19.63µs med=609.98µs max=13.28ms p(90)=1.36ms p(95)=2ms
     http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  897.844566/s
+    http_reqs......................: 54000  898.500669/s
 
     EXECUTION
-    iteration_duration.............: avg=1s     min=1s      med=1s       max=1.05s   p(90)=1s    p(95)=1s    
-    iterations.....................: 54000  897.844566/s
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.03s   p(90)=1s     p(95)=1s 
+    iterations.....................: 54000  898.500669/s
     vus............................: 900    min=900        max=900
     vus_max........................: 900    min=900        max=900
 
     NETWORK
-    data_received..................: 14 MB  240 kB/s
+    data_received..................: 15 MB  244 kB/s
     data_sent......................: 4.2 MB 70 kB/s
 
 
@@ -416,19 +416,19 @@ default   [ 100% ] 900 VUs  1m00.0s/1m0s
   █ TOTAL RESULTS 
 
     HTTP
-    http_req_duration..............: avg=1.07ms min=25.03µs med=877.27µs max=30.64ms p(90)=1.7ms p(95)=2.14ms
-      { expected_response:true }...: avg=1.07ms min=25.03µs med=877.27µs max=30.64ms p(90)=1.7ms p(95)=2.14ms
+    http_req_duration..............: avg=709.96µs min=20.71µs med=627.97µs max=20.69ms p(90)=1.2ms p(95)=1.38ms
+      { expected_response:true }...: avg=709.96µs min=20.71µs med=627.97µs max=20.69ms p(90)=1.2ms p(95)=1.38ms
     http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.16573/s
+    http_reqs......................: 54000  898.738624/s
 
     EXECUTION
-    iteration_duration.............: avg=1s     min=1s      med=1s       max=1.04s   p(90)=1s    p(95)=1s    
-    iterations.....................: 54000  898.16573/s
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.03s   p(90)=1s    p(95)=1s    
+    iterations.....................: 54000  898.738624/s
     vus............................: 900    min=900        max=900
     vus_max........................: 900    min=900        max=900
 
     NETWORK
-    data_received..................: 14 MB  240 kB/s
+    data_received..................: 15 MB  245 kB/s
     data_sent......................: 4.2 MB 70 kB/s
 
 
@@ -635,19 +635,1552 @@ default   [ 100% ] 900 VUs  1m00.0s/1m0s
   █ TOTAL RESULTS 
 
     HTTP
-    http_req_duration..............: avg=888.09µs min=32.45µs med=593.77µs max=26.58ms p(90)=1.58ms p(95)=2.36ms
-      { expected_response:true }...: avg=888.09µs min=32.45µs med=593.77µs max=26.58ms p(90)=1.58ms p(95)=2.36ms
+    http_req_duration..............: avg=862.72µs min=20.72µs med=662.58µs max=27.15ms p(90)=1.42ms p(95)=1.69ms
+      { expected_response:true }...: avg=862.72µs min=20.72µs med=662.58µs max=27.15ms p(90)=1.42ms p(95)=1.69ms
     http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.320359/s
+    http_reqs......................: 54000  898.490831/s
 
     EXECUTION
-    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.03s   p(90)=1s     p(95)=1s    
-    iterations.....................: 54000  898.320359/s
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.04s   p(90)=1s     p(95)=1s    
+    iterations.....................: 54000  898.490831/s
     vus............................: 900    min=900        max=900
     vus_max........................: 900    min=900        max=900
 
     NETWORK
-    data_received..................: 14 MB  240 kB/s
+    data_received..................: 15 MB  244 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkDestiny.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=795.51µs min=18.45µs med=734.05µs max=22.4ms p(90)=1.29ms p(95)=1.55ms
+      { expected_response:true }...: avg=795.51µs min=18.45µs med=734.05µs max=22.4ms p(90)=1.29ms p(95)=1.55ms
+    http_req_failed................: 0.00%  0 out of 54000
+    http_reqs......................: 54000  898.476742/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.04s  p(90)=1s     p(95)=1s    
+    iterations.....................: 54000  898.476742/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  244 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkDestiny.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=854.97µs min=21.15µs med=715.97µs max=33.77ms p(90)=1.45ms p(95)=1.73ms
+      { expected_response:true }...: avg=854.97µs min=21.15µs med=715.97µs max=33.77ms p(90)=1.45ms p(95)=1.73ms
+    http_req_failed................: 0.00%  0 out of 54000
+    http_reqs......................: 54000  898.464843/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.04s   p(90)=1s     p(95)=1s    
+    iterations.....................: 54000  898.464843/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  244 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkDestiny.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=828.08µs min=19.56µs med=701.56µs max=26.78ms p(90)=1.4ms p(95)=1.85ms
+      { expected_response:true }...: avg=828.08µs min=19.56µs med=701.56µs max=26.78ms p(90)=1.4ms p(95)=1.85ms
+    http_req_failed................: 0.00%  0 out of 54000
+    http_reqs......................: 54000  898.534395/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.03s   p(90)=1s    p(95)=1s    
+    iterations.....................: 54000  898.534395/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  244 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkDestiny.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=640.67µs min=19.37µs med=453.8µs max=39.73ms p(90)=1.18ms p(95)=1.68ms
+      { expected_response:true }...: avg=640.67µs min=19.37µs med=453.8µs max=39.73ms p(90)=1.18ms p(95)=1.68ms
+    http_req_failed................: 0.00%  0 out of 54000
+    http_reqs......................: 54000  898.36451/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s       min=1s      med=1s      max=1.04s   p(90)=1s     p(95)=1s    
+    iterations.....................: 54000  898.36451/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  244 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkDestiny.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=875.11µs min=21.6µs med=821.84µs max=36.42ms p(90)=1.28ms p(95)=1.5ms
+      { expected_response:true }...: avg=875.11µs min=21.6µs med=821.84µs max=36.42ms p(90)=1.28ms p(95)=1.5ms
+    http_req_failed................: 0.00%  0 out of 54000
+    http_reqs......................: 54000  898.411364/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s       min=1s     med=1s       max=1.04s   p(90)=1s     p(95)=1s   
+    iterations.....................: 54000  898.411364/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  244 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkDestiny.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=717.52µs min=20.54µs med=473.11µs max=38.46ms p(90)=1.21ms p(95)=2.33ms
+      { expected_response:true }...: avg=717.52µs min=20.54µs med=473.11µs max=38.46ms p(90)=1.21ms p(95)=2.33ms
+    http_req_failed................: 0.00%  0 out of 54000
+    http_reqs......................: 54000  898.400917/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.04s   p(90)=1s     p(95)=1s    
+    iterations.....................: 54000  898.400917/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  244 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkDestiny.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=616.09µs min=21.46µs med=392.93µs max=30.9ms p(90)=1.1ms p(95)=1.44ms
+      { expected_response:true }...: avg=616.09µs min=21.46µs med=392.93µs max=30.9ms p(90)=1.1ms p(95)=1.44ms
+    http_req_failed................: 0.00%  0 out of 54000
+    http_reqs......................: 54000  898.712187/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.03s  p(90)=1s    p(95)=1s    
+    iterations.....................: 54000  898.712187/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  244 kB/s
     data_sent......................: 4.2 MB 70 kB/s
 
 

--- a/Benchmarks/results_destiny.txt
+++ b/Benchmarks/results_destiny.txt
@@ -197,14 +197,14 @@ default   [ 100% ] 900 VUs  1m00.0s/1m0s
   █ TOTAL RESULTS 
 
     HTTP
-    http_req_duration..............: avg=775.13µs min=19.63µs med=609.98µs max=13.28ms p(90)=1.36ms p(95)=2ms
-      { expected_response:true }...: avg=775.13µs min=19.63µs med=609.98µs max=13.28ms p(90)=1.36ms p(95)=2ms
+    http_req_duration..............: avg=818.13µs min=19.14µs med=712.76µs max=8.43ms p(90)=1.43ms p(95)=1.79ms
+      { expected_response:true }...: avg=818.13µs min=19.14µs med=712.76µs max=8.43ms p(90)=1.43ms p(95)=1.79ms
     http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.500669/s
+    http_reqs......................: 54000  898.541733/s
 
     EXECUTION
-    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.03s   p(90)=1s     p(95)=1s 
-    iterations.....................: 54000  898.500669/s
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.03s  p(90)=1s     p(95)=1s    
+    iterations.....................: 54000  898.541733/s
     vus............................: 900    min=900        max=900
     vus_max........................: 900    min=900        max=900
 
@@ -416,14 +416,1109 @@ default   [ 100% ] 900 VUs  1m00.0s/1m0s
   █ TOTAL RESULTS 
 
     HTTP
-    http_req_duration..............: avg=709.96µs min=20.71µs med=627.97µs max=20.69ms p(90)=1.2ms p(95)=1.38ms
-      { expected_response:true }...: avg=709.96µs min=20.71µs med=627.97µs max=20.69ms p(90)=1.2ms p(95)=1.38ms
+    http_req_duration..............: avg=475.76µs min=20.48µs med=315.11µs max=48.41ms p(90)=900.02µs p(95)=1.07ms
+      { expected_response:true }...: avg=475.76µs min=20.48µs med=315.11µs max=48.41ms p(90)=900.02µs p(95)=1.07ms
     http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.738624/s
+    http_reqs......................: 54000  898.611897/s
 
     EXECUTION
-    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.03s   p(90)=1s    p(95)=1s    
-    iterations.....................: 54000  898.738624/s
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.05s   p(90)=1s       p(95)=1s    
+    iterations.....................: 54000  898.611897/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  244 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkDestiny.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=825.74µs min=19.22µs med=720.3µs max=31.99ms p(90)=1.41ms p(95)=1.74ms
+      { expected_response:true }...: avg=825.74µs min=19.22µs med=720.3µs max=31.99ms p(90)=1.41ms p(95)=1.74ms
+    http_req_failed................: 0.00%  0 out of 54000
+    http_reqs......................: 54000  898.514406/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s       min=1s      med=1s      max=1.03s   p(90)=1s     p(95)=1s    
+    iterations.....................: 54000  898.514406/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  244 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkDestiny.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=780.63µs min=20.08µs med=618.44µs max=30.41ms p(90)=1.36ms p(95)=1.77ms
+      { expected_response:true }...: avg=780.63µs min=20.08µs med=618.44µs max=30.41ms p(90)=1.36ms p(95)=1.77ms
+    http_req_failed................: 0.00%  0 out of 54000
+    http_reqs......................: 54000  898.609708/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.03s   p(90)=1s     p(95)=1s    
+    iterations.....................: 54000  898.609708/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  244 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkDestiny.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=667.41µs min=21.02µs med=452.84µs max=26.33ms p(90)=1.17ms p(95)=1.36ms
+      { expected_response:true }...: avg=667.41µs min=21.02µs med=452.84µs max=26.33ms p(90)=1.17ms p(95)=1.36ms
+    http_req_failed................: 0.00%  0 out of 54000
+    http_reqs......................: 54000  898.626055/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.03s   p(90)=1s     p(95)=1s    
+    iterations.....................: 54000  898.626055/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  244 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkDestiny.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=794.26µs min=20.35µs med=529.39µs max=27.84ms p(90)=1.34ms p(95)=1.9ms
+      { expected_response:true }...: avg=794.26µs min=20.35µs med=529.39µs max=27.84ms p(90)=1.34ms p(95)=1.9ms
+    http_req_failed................: 0.00%  0 out of 54000
+    http_reqs......................: 54000  898.567723/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.03s   p(90)=1s     p(95)=1s   
+    iterations.....................: 54000  898.567723/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  244 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkDestiny.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=751.49µs min=21.9µs med=665.82µs max=27.99ms p(90)=1.32ms p(95)=1.56ms
+      { expected_response:true }...: avg=751.49µs min=21.9µs med=665.82µs max=27.99ms p(90)=1.32ms p(95)=1.56ms
+    http_req_failed................: 0.00%  0 out of 54000
+    http_reqs......................: 54000  898.753597/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s       min=1s     med=1s       max=1.02s   p(90)=1s     p(95)=1s    
+    iterations.....................: 54000  898.753597/s
     vus............................: 900    min=900        max=900
     vus_max........................: 900    min=900        max=900
 
@@ -635,14 +1730,14 @@ default   [ 100% ] 900 VUs  1m00.0s/1m0s
   █ TOTAL RESULTS 
 
     HTTP
-    http_req_duration..............: avg=862.72µs min=20.72µs med=662.58µs max=27.15ms p(90)=1.42ms p(95)=1.69ms
-      { expected_response:true }...: avg=862.72µs min=20.72µs med=662.58µs max=27.15ms p(90)=1.42ms p(95)=1.69ms
+    http_req_duration..............: avg=639.75µs min=21.19µs med=476.89µs max=24.67ms p(90)=1.1ms p(95)=1.4ms
+      { expected_response:true }...: avg=639.75µs min=21.19µs med=476.89µs max=24.67ms p(90)=1.1ms p(95)=1.4ms
     http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.490831/s
+    http_reqs......................: 54000  898.676077/s
 
     EXECUTION
-    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.04s   p(90)=1s     p(95)=1s    
-    iterations.....................: 54000  898.490831/s
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.03s   p(90)=1s    p(95)=1s   
+    iterations.....................: 54000  898.676077/s
     vus............................: 900    min=900        max=900
     vus_max........................: 900    min=900        max=900
 
@@ -854,19 +1949,19 @@ default   [ 100% ] 900 VUs  1m00.0s/1m0s
   █ TOTAL RESULTS 
 
     HTTP
-    http_req_duration..............: avg=795.51µs min=18.45µs med=734.05µs max=22.4ms p(90)=1.29ms p(95)=1.55ms
-      { expected_response:true }...: avg=795.51µs min=18.45µs med=734.05µs max=22.4ms p(90)=1.29ms p(95)=1.55ms
+    http_req_duration..............: avg=606.84µs min=20.18µs med=514.75µs max=25.79ms p(90)=1.18ms p(95)=1.36ms
+      { expected_response:true }...: avg=606.84µs min=20.18µs med=514.75µs max=25.79ms p(90)=1.18ms p(95)=1.36ms
     http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.476742/s
+    http_reqs......................: 54000  898.874212/s
 
     EXECUTION
-    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.04s  p(90)=1s     p(95)=1s    
-    iterations.....................: 54000  898.476742/s
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.02s   p(90)=1s     p(95)=1s    
+    iterations.....................: 54000  898.874212/s
     vus............................: 900    min=900        max=900
     vus_max........................: 900    min=900        max=900
 
     NETWORK
-    data_received..................: 15 MB  244 kB/s
+    data_received..................: 15 MB  245 kB/s
     data_sent......................: 4.2 MB 70 kB/s
 
 
@@ -1073,1109 +2168,14 @@ default   [ 100% ] 900 VUs  1m00.0s/1m0s
   █ TOTAL RESULTS 
 
     HTTP
-    http_req_duration..............: avg=854.97µs min=21.15µs med=715.97µs max=33.77ms p(90)=1.45ms p(95)=1.73ms
-      { expected_response:true }...: avg=854.97µs min=21.15µs med=715.97µs max=33.77ms p(90)=1.45ms p(95)=1.73ms
+    http_req_duration..............: avg=875.6µs min=22.55µs med=701.89µs max=43.63ms p(90)=1.5ms p(95)=1.85ms
+      { expected_response:true }...: avg=875.6µs min=22.55µs med=701.89µs max=43.63ms p(90)=1.5ms p(95)=1.85ms
     http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.464843/s
+    http_reqs......................: 54000  898.381843/s
 
     EXECUTION
-    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.04s   p(90)=1s     p(95)=1s    
-    iterations.....................: 54000  898.464843/s
-    vus............................: 900    min=900        max=900
-    vus_max........................: 900    min=900        max=900
-
-    NETWORK
-    data_received..................: 15 MB  244 kB/s
-    data_sent......................: 4.2 MB 70 kB/s
-
-
-
-
-running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
-default ✓ [ 100% ] 900 VUs  1m0s
-
-         /\      Grafana   /‾‾/  
-    /\  /  \     |\  __   /  /   
-   /  \/    \    | |/ /  /   ‾‾\ 
-  /          \   |   (  |  (‾)  |
- / __________ \  |_|\_\  \_____/ 
-
-     execution: local
-        script: benchmarkDestiny.js
-        output: -
-
-     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
-              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
-
-
-running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
-default   [   2% ] 900 VUs  0m01.0s/1m0s
-
-running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
-default   [   3% ] 900 VUs  0m02.0s/1m0s
-
-running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
-default   [   5% ] 900 VUs  0m03.0s/1m0s
-
-running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
-default   [   7% ] 900 VUs  0m04.0s/1m0s
-
-running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
-default   [   8% ] 900 VUs  0m05.0s/1m0s
-
-running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
-default   [  10% ] 900 VUs  0m06.0s/1m0s
-
-running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
-default   [  12% ] 900 VUs  0m07.0s/1m0s
-
-running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
-default   [  13% ] 900 VUs  0m08.0s/1m0s
-
-running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
-default   [  15% ] 900 VUs  0m09.0s/1m0s
-
-running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
-default   [  17% ] 900 VUs  0m10.0s/1m0s
-
-running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
-default   [  18% ] 900 VUs  0m11.0s/1m0s
-
-running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
-default   [  20% ] 900 VUs  0m12.0s/1m0s
-
-running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
-default   [  22% ] 900 VUs  0m13.0s/1m0s
-
-running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
-default   [  23% ] 900 VUs  0m14.0s/1m0s
-
-running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
-default   [  25% ] 900 VUs  0m15.0s/1m0s
-
-running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
-default   [  27% ] 900 VUs  0m16.0s/1m0s
-
-running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
-default   [  28% ] 900 VUs  0m17.0s/1m0s
-
-running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
-default   [  30% ] 900 VUs  0m18.0s/1m0s
-
-running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
-default   [  32% ] 900 VUs  0m19.0s/1m0s
-
-running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
-default   [  33% ] 900 VUs  0m20.0s/1m0s
-
-running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
-default   [  35% ] 900 VUs  0m21.0s/1m0s
-
-running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
-default   [  37% ] 900 VUs  0m22.0s/1m0s
-
-running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
-default   [  38% ] 900 VUs  0m23.0s/1m0s
-
-running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
-default   [  40% ] 900 VUs  0m24.0s/1m0s
-
-running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
-default   [  42% ] 900 VUs  0m25.0s/1m0s
-
-running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
-default   [  43% ] 900 VUs  0m26.0s/1m0s
-
-running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
-default   [  45% ] 900 VUs  0m27.0s/1m0s
-
-running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
-default   [  47% ] 900 VUs  0m28.0s/1m0s
-
-running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
-default   [  48% ] 900 VUs  0m29.0s/1m0s
-
-running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
-default   [  50% ] 900 VUs  0m30.0s/1m0s
-
-running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
-default   [  52% ] 900 VUs  0m31.0s/1m0s
-
-running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
-default   [  53% ] 900 VUs  0m32.0s/1m0s
-
-running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
-default   [  55% ] 900 VUs  0m33.0s/1m0s
-
-running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
-default   [  57% ] 900 VUs  0m34.0s/1m0s
-
-running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
-default   [  58% ] 900 VUs  0m35.0s/1m0s
-
-running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
-default   [  60% ] 900 VUs  0m36.0s/1m0s
-
-running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
-default   [  62% ] 900 VUs  0m37.0s/1m0s
-
-running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
-default   [  63% ] 900 VUs  0m38.0s/1m0s
-
-running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
-default   [  65% ] 900 VUs  0m39.0s/1m0s
-
-running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
-default   [  67% ] 900 VUs  0m40.0s/1m0s
-
-running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
-default   [  68% ] 900 VUs  0m41.0s/1m0s
-
-running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
-default   [  70% ] 900 VUs  0m42.0s/1m0s
-
-running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
-default   [  72% ] 900 VUs  0m43.0s/1m0s
-
-running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
-default   [  73% ] 900 VUs  0m44.0s/1m0s
-
-running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
-default   [  75% ] 900 VUs  0m45.0s/1m0s
-
-running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
-default   [  77% ] 900 VUs  0m46.0s/1m0s
-
-running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
-default   [  78% ] 900 VUs  0m47.0s/1m0s
-
-running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
-default   [  80% ] 900 VUs  0m48.0s/1m0s
-
-running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
-default   [  82% ] 900 VUs  0m49.0s/1m0s
-
-running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
-default   [  83% ] 900 VUs  0m50.0s/1m0s
-
-running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
-default   [  85% ] 900 VUs  0m51.0s/1m0s
-
-running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
-default   [  87% ] 900 VUs  0m52.0s/1m0s
-
-running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
-default   [  88% ] 900 VUs  0m53.0s/1m0s
-
-running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
-default   [  90% ] 900 VUs  0m54.0s/1m0s
-
-running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
-default   [  92% ] 900 VUs  0m55.0s/1m0s
-
-running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
-default   [  93% ] 900 VUs  0m56.0s/1m0s
-
-running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
-default   [  95% ] 900 VUs  0m57.0s/1m0s
-
-running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
-default   [  97% ] 900 VUs  0m58.0s/1m0s
-
-running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
-default   [  98% ] 900 VUs  0m59.0s/1m0s
-
-running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
-default   [ 100% ] 900 VUs  1m00.0s/1m0s
-
-
-  █ TOTAL RESULTS 
-
-    HTTP
-    http_req_duration..............: avg=828.08µs min=19.56µs med=701.56µs max=26.78ms p(90)=1.4ms p(95)=1.85ms
-      { expected_response:true }...: avg=828.08µs min=19.56µs med=701.56µs max=26.78ms p(90)=1.4ms p(95)=1.85ms
-    http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.534395/s
-
-    EXECUTION
-    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.03s   p(90)=1s    p(95)=1s    
-    iterations.....................: 54000  898.534395/s
-    vus............................: 900    min=900        max=900
-    vus_max........................: 900    min=900        max=900
-
-    NETWORK
-    data_received..................: 15 MB  244 kB/s
-    data_sent......................: 4.2 MB 70 kB/s
-
-
-
-
-running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
-default ✓ [ 100% ] 900 VUs  1m0s
-
-         /\      Grafana   /‾‾/  
-    /\  /  \     |\  __   /  /   
-   /  \/    \    | |/ /  /   ‾‾\ 
-  /          \   |   (  |  (‾)  |
- / __________ \  |_|\_\  \_____/ 
-
-     execution: local
-        script: benchmarkDestiny.js
-        output: -
-
-     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
-              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
-
-
-running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
-default   [   2% ] 900 VUs  0m01.0s/1m0s
-
-running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
-default   [   3% ] 900 VUs  0m02.0s/1m0s
-
-running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
-default   [   5% ] 900 VUs  0m03.0s/1m0s
-
-running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
-default   [   7% ] 900 VUs  0m04.0s/1m0s
-
-running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
-default   [   8% ] 900 VUs  0m05.0s/1m0s
-
-running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
-default   [  10% ] 900 VUs  0m06.0s/1m0s
-
-running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
-default   [  12% ] 900 VUs  0m07.0s/1m0s
-
-running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
-default   [  13% ] 900 VUs  0m08.0s/1m0s
-
-running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
-default   [  15% ] 900 VUs  0m09.0s/1m0s
-
-running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
-default   [  17% ] 900 VUs  0m10.0s/1m0s
-
-running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
-default   [  18% ] 900 VUs  0m11.0s/1m0s
-
-running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
-default   [  20% ] 900 VUs  0m12.0s/1m0s
-
-running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
-default   [  22% ] 900 VUs  0m13.0s/1m0s
-
-running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
-default   [  23% ] 900 VUs  0m14.0s/1m0s
-
-running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
-default   [  25% ] 900 VUs  0m15.0s/1m0s
-
-running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
-default   [  27% ] 900 VUs  0m16.0s/1m0s
-
-running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
-default   [  28% ] 900 VUs  0m17.0s/1m0s
-
-running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
-default   [  30% ] 900 VUs  0m18.0s/1m0s
-
-running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
-default   [  32% ] 900 VUs  0m19.0s/1m0s
-
-running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
-default   [  33% ] 900 VUs  0m20.0s/1m0s
-
-running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
-default   [  35% ] 900 VUs  0m21.0s/1m0s
-
-running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
-default   [  37% ] 900 VUs  0m22.0s/1m0s
-
-running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
-default   [  38% ] 900 VUs  0m23.0s/1m0s
-
-running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
-default   [  40% ] 900 VUs  0m24.0s/1m0s
-
-running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
-default   [  42% ] 900 VUs  0m25.0s/1m0s
-
-running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
-default   [  43% ] 900 VUs  0m26.0s/1m0s
-
-running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
-default   [  45% ] 900 VUs  0m27.0s/1m0s
-
-running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
-default   [  47% ] 900 VUs  0m28.0s/1m0s
-
-running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
-default   [  48% ] 900 VUs  0m29.0s/1m0s
-
-running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
-default   [  50% ] 900 VUs  0m30.0s/1m0s
-
-running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
-default   [  52% ] 900 VUs  0m31.0s/1m0s
-
-running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
-default   [  53% ] 900 VUs  0m32.0s/1m0s
-
-running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
-default   [  55% ] 900 VUs  0m33.0s/1m0s
-
-running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
-default   [  57% ] 900 VUs  0m34.0s/1m0s
-
-running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
-default   [  58% ] 900 VUs  0m35.0s/1m0s
-
-running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
-default   [  60% ] 900 VUs  0m36.0s/1m0s
-
-running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
-default   [  62% ] 900 VUs  0m37.0s/1m0s
-
-running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
-default   [  63% ] 900 VUs  0m38.0s/1m0s
-
-running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
-default   [  65% ] 900 VUs  0m39.0s/1m0s
-
-running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
-default   [  67% ] 900 VUs  0m40.0s/1m0s
-
-running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
-default   [  68% ] 900 VUs  0m41.0s/1m0s
-
-running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
-default   [  70% ] 900 VUs  0m42.0s/1m0s
-
-running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
-default   [  72% ] 900 VUs  0m43.0s/1m0s
-
-running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
-default   [  73% ] 900 VUs  0m44.0s/1m0s
-
-running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
-default   [  75% ] 900 VUs  0m45.0s/1m0s
-
-running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
-default   [  77% ] 900 VUs  0m46.0s/1m0s
-
-running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
-default   [  78% ] 900 VUs  0m47.0s/1m0s
-
-running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
-default   [  80% ] 900 VUs  0m48.0s/1m0s
-
-running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
-default   [  82% ] 900 VUs  0m49.0s/1m0s
-
-running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
-default   [  83% ] 900 VUs  0m50.0s/1m0s
-
-running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
-default   [  85% ] 900 VUs  0m51.0s/1m0s
-
-running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
-default   [  87% ] 900 VUs  0m52.0s/1m0s
-
-running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
-default   [  88% ] 900 VUs  0m53.0s/1m0s
-
-running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
-default   [  90% ] 900 VUs  0m54.0s/1m0s
-
-running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
-default   [  92% ] 900 VUs  0m55.0s/1m0s
-
-running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
-default   [  93% ] 900 VUs  0m56.0s/1m0s
-
-running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
-default   [  95% ] 900 VUs  0m57.0s/1m0s
-
-running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
-default   [  97% ] 900 VUs  0m58.0s/1m0s
-
-running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
-default   [  98% ] 900 VUs  0m59.0s/1m0s
-
-running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
-default   [ 100% ] 900 VUs  1m00.0s/1m0s
-
-
-  █ TOTAL RESULTS 
-
-    HTTP
-    http_req_duration..............: avg=640.67µs min=19.37µs med=453.8µs max=39.73ms p(90)=1.18ms p(95)=1.68ms
-      { expected_response:true }...: avg=640.67µs min=19.37µs med=453.8µs max=39.73ms p(90)=1.18ms p(95)=1.68ms
-    http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.36451/s
-
-    EXECUTION
-    iteration_duration.............: avg=1s       min=1s      med=1s      max=1.04s   p(90)=1s     p(95)=1s    
-    iterations.....................: 54000  898.36451/s
-    vus............................: 900    min=900        max=900
-    vus_max........................: 900    min=900        max=900
-
-    NETWORK
-    data_received..................: 15 MB  244 kB/s
-    data_sent......................: 4.2 MB 70 kB/s
-
-
-
-
-running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
-default ✓ [ 100% ] 900 VUs  1m0s
-
-         /\      Grafana   /‾‾/  
-    /\  /  \     |\  __   /  /   
-   /  \/    \    | |/ /  /   ‾‾\ 
-  /          \   |   (  |  (‾)  |
- / __________ \  |_|\_\  \_____/ 
-
-     execution: local
-        script: benchmarkDestiny.js
-        output: -
-
-     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
-              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
-
-
-running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
-default   [   2% ] 900 VUs  0m01.0s/1m0s
-
-running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
-default   [   3% ] 900 VUs  0m02.0s/1m0s
-
-running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
-default   [   5% ] 900 VUs  0m03.0s/1m0s
-
-running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
-default   [   7% ] 900 VUs  0m04.0s/1m0s
-
-running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
-default   [   8% ] 900 VUs  0m05.0s/1m0s
-
-running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
-default   [  10% ] 900 VUs  0m06.0s/1m0s
-
-running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
-default   [  12% ] 900 VUs  0m07.0s/1m0s
-
-running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
-default   [  13% ] 900 VUs  0m08.0s/1m0s
-
-running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
-default   [  15% ] 900 VUs  0m09.0s/1m0s
-
-running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
-default   [  17% ] 900 VUs  0m10.0s/1m0s
-
-running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
-default   [  18% ] 900 VUs  0m11.0s/1m0s
-
-running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
-default   [  20% ] 900 VUs  0m12.0s/1m0s
-
-running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
-default   [  22% ] 900 VUs  0m13.0s/1m0s
-
-running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
-default   [  23% ] 900 VUs  0m14.0s/1m0s
-
-running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
-default   [  25% ] 900 VUs  0m15.0s/1m0s
-
-running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
-default   [  27% ] 900 VUs  0m16.0s/1m0s
-
-running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
-default   [  28% ] 900 VUs  0m17.0s/1m0s
-
-running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
-default   [  30% ] 900 VUs  0m18.0s/1m0s
-
-running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
-default   [  32% ] 900 VUs  0m19.0s/1m0s
-
-running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
-default   [  33% ] 900 VUs  0m20.0s/1m0s
-
-running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
-default   [  35% ] 900 VUs  0m21.0s/1m0s
-
-running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
-default   [  37% ] 900 VUs  0m22.0s/1m0s
-
-running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
-default   [  38% ] 900 VUs  0m23.0s/1m0s
-
-running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
-default   [  40% ] 900 VUs  0m24.0s/1m0s
-
-running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
-default   [  42% ] 900 VUs  0m25.0s/1m0s
-
-running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
-default   [  43% ] 900 VUs  0m26.0s/1m0s
-
-running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
-default   [  45% ] 900 VUs  0m27.0s/1m0s
-
-running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
-default   [  47% ] 900 VUs  0m28.0s/1m0s
-
-running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
-default   [  48% ] 900 VUs  0m29.0s/1m0s
-
-running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
-default   [  50% ] 900 VUs  0m30.0s/1m0s
-
-running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
-default   [  52% ] 900 VUs  0m31.0s/1m0s
-
-running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
-default   [  53% ] 900 VUs  0m32.0s/1m0s
-
-running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
-default   [  55% ] 900 VUs  0m33.0s/1m0s
-
-running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
-default   [  57% ] 900 VUs  0m34.0s/1m0s
-
-running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
-default   [  58% ] 900 VUs  0m35.0s/1m0s
-
-running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
-default   [  60% ] 900 VUs  0m36.0s/1m0s
-
-running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
-default   [  62% ] 900 VUs  0m37.0s/1m0s
-
-running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
-default   [  63% ] 900 VUs  0m38.0s/1m0s
-
-running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
-default   [  65% ] 900 VUs  0m39.0s/1m0s
-
-running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
-default   [  67% ] 900 VUs  0m40.0s/1m0s
-
-running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
-default   [  68% ] 900 VUs  0m41.0s/1m0s
-
-running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
-default   [  70% ] 900 VUs  0m42.0s/1m0s
-
-running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
-default   [  72% ] 900 VUs  0m43.0s/1m0s
-
-running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
-default   [  73% ] 900 VUs  0m44.0s/1m0s
-
-running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
-default   [  75% ] 900 VUs  0m45.0s/1m0s
-
-running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
-default   [  77% ] 900 VUs  0m46.0s/1m0s
-
-running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
-default   [  78% ] 900 VUs  0m47.0s/1m0s
-
-running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
-default   [  80% ] 900 VUs  0m48.0s/1m0s
-
-running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
-default   [  82% ] 900 VUs  0m49.0s/1m0s
-
-running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
-default   [  83% ] 900 VUs  0m50.0s/1m0s
-
-running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
-default   [  85% ] 900 VUs  0m51.0s/1m0s
-
-running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
-default   [  87% ] 900 VUs  0m52.0s/1m0s
-
-running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
-default   [  88% ] 900 VUs  0m53.0s/1m0s
-
-running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
-default   [  90% ] 900 VUs  0m54.0s/1m0s
-
-running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
-default   [  92% ] 900 VUs  0m55.0s/1m0s
-
-running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
-default   [  93% ] 900 VUs  0m56.0s/1m0s
-
-running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
-default   [  95% ] 900 VUs  0m57.0s/1m0s
-
-running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
-default   [  97% ] 900 VUs  0m58.0s/1m0s
-
-running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
-default   [  98% ] 900 VUs  0m59.0s/1m0s
-
-running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
-default   [ 100% ] 900 VUs  1m00.0s/1m0s
-
-
-  █ TOTAL RESULTS 
-
-    HTTP
-    http_req_duration..............: avg=875.11µs min=21.6µs med=821.84µs max=36.42ms p(90)=1.28ms p(95)=1.5ms
-      { expected_response:true }...: avg=875.11µs min=21.6µs med=821.84µs max=36.42ms p(90)=1.28ms p(95)=1.5ms
-    http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.411364/s
-
-    EXECUTION
-    iteration_duration.............: avg=1s       min=1s     med=1s       max=1.04s   p(90)=1s     p(95)=1s   
-    iterations.....................: 54000  898.411364/s
-    vus............................: 900    min=900        max=900
-    vus_max........................: 900    min=900        max=900
-
-    NETWORK
-    data_received..................: 15 MB  244 kB/s
-    data_sent......................: 4.2 MB 70 kB/s
-
-
-
-
-running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
-default ✓ [ 100% ] 900 VUs  1m0s
-
-         /\      Grafana   /‾‾/  
-    /\  /  \     |\  __   /  /   
-   /  \/    \    | |/ /  /   ‾‾\ 
-  /          \   |   (  |  (‾)  |
- / __________ \  |_|\_\  \_____/ 
-
-     execution: local
-        script: benchmarkDestiny.js
-        output: -
-
-     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
-              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
-
-
-running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
-default   [   2% ] 900 VUs  0m01.0s/1m0s
-
-running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
-default   [   3% ] 900 VUs  0m02.0s/1m0s
-
-running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
-default   [   5% ] 900 VUs  0m03.0s/1m0s
-
-running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
-default   [   7% ] 900 VUs  0m04.0s/1m0s
-
-running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
-default   [   8% ] 900 VUs  0m05.0s/1m0s
-
-running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
-default   [  10% ] 900 VUs  0m06.0s/1m0s
-
-running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
-default   [  12% ] 900 VUs  0m07.0s/1m0s
-
-running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
-default   [  13% ] 900 VUs  0m08.0s/1m0s
-
-running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
-default   [  15% ] 900 VUs  0m09.0s/1m0s
-
-running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
-default   [  17% ] 900 VUs  0m10.0s/1m0s
-
-running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
-default   [  18% ] 900 VUs  0m11.0s/1m0s
-
-running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
-default   [  20% ] 900 VUs  0m12.0s/1m0s
-
-running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
-default   [  22% ] 900 VUs  0m13.0s/1m0s
-
-running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
-default   [  23% ] 900 VUs  0m14.0s/1m0s
-
-running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
-default   [  25% ] 900 VUs  0m15.0s/1m0s
-
-running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
-default   [  27% ] 900 VUs  0m16.0s/1m0s
-
-running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
-default   [  28% ] 900 VUs  0m17.0s/1m0s
-
-running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
-default   [  30% ] 900 VUs  0m18.0s/1m0s
-
-running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
-default   [  32% ] 900 VUs  0m19.0s/1m0s
-
-running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
-default   [  33% ] 900 VUs  0m20.0s/1m0s
-
-running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
-default   [  35% ] 900 VUs  0m21.0s/1m0s
-
-running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
-default   [  37% ] 900 VUs  0m22.0s/1m0s
-
-running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
-default   [  38% ] 900 VUs  0m23.0s/1m0s
-
-running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
-default   [  40% ] 900 VUs  0m24.0s/1m0s
-
-running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
-default   [  42% ] 900 VUs  0m25.0s/1m0s
-
-running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
-default   [  43% ] 900 VUs  0m26.0s/1m0s
-
-running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
-default   [  45% ] 900 VUs  0m27.0s/1m0s
-
-running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
-default   [  47% ] 900 VUs  0m28.0s/1m0s
-
-running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
-default   [  48% ] 900 VUs  0m29.0s/1m0s
-
-running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
-default   [  50% ] 900 VUs  0m30.0s/1m0s
-
-running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
-default   [  52% ] 900 VUs  0m31.0s/1m0s
-
-running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
-default   [  53% ] 900 VUs  0m32.0s/1m0s
-
-running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
-default   [  55% ] 900 VUs  0m33.0s/1m0s
-
-running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
-default   [  57% ] 900 VUs  0m34.0s/1m0s
-
-running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
-default   [  58% ] 900 VUs  0m35.0s/1m0s
-
-running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
-default   [  60% ] 900 VUs  0m36.0s/1m0s
-
-running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
-default   [  62% ] 900 VUs  0m37.0s/1m0s
-
-running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
-default   [  63% ] 900 VUs  0m38.0s/1m0s
-
-running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
-default   [  65% ] 900 VUs  0m39.0s/1m0s
-
-running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
-default   [  67% ] 900 VUs  0m40.0s/1m0s
-
-running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
-default   [  68% ] 900 VUs  0m41.0s/1m0s
-
-running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
-default   [  70% ] 900 VUs  0m42.0s/1m0s
-
-running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
-default   [  72% ] 900 VUs  0m43.0s/1m0s
-
-running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
-default   [  73% ] 900 VUs  0m44.0s/1m0s
-
-running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
-default   [  75% ] 900 VUs  0m45.0s/1m0s
-
-running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
-default   [  77% ] 900 VUs  0m46.0s/1m0s
-
-running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
-default   [  78% ] 900 VUs  0m47.0s/1m0s
-
-running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
-default   [  80% ] 900 VUs  0m48.0s/1m0s
-
-running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
-default   [  82% ] 900 VUs  0m49.0s/1m0s
-
-running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
-default   [  83% ] 900 VUs  0m50.0s/1m0s
-
-running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
-default   [  85% ] 900 VUs  0m51.0s/1m0s
-
-running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
-default   [  87% ] 900 VUs  0m52.0s/1m0s
-
-running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
-default   [  88% ] 900 VUs  0m53.0s/1m0s
-
-running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
-default   [  90% ] 900 VUs  0m54.0s/1m0s
-
-running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
-default   [  92% ] 900 VUs  0m55.0s/1m0s
-
-running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
-default   [  93% ] 900 VUs  0m56.0s/1m0s
-
-running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
-default   [  95% ] 900 VUs  0m57.0s/1m0s
-
-running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
-default   [  97% ] 900 VUs  0m58.0s/1m0s
-
-running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
-default   [  98% ] 900 VUs  0m59.0s/1m0s
-
-running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
-default   [ 100% ] 900 VUs  1m00.0s/1m0s
-
-
-  █ TOTAL RESULTS 
-
-    HTTP
-    http_req_duration..............: avg=717.52µs min=20.54µs med=473.11µs max=38.46ms p(90)=1.21ms p(95)=2.33ms
-      { expected_response:true }...: avg=717.52µs min=20.54µs med=473.11µs max=38.46ms p(90)=1.21ms p(95)=2.33ms
-    http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.400917/s
-
-    EXECUTION
-    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.04s   p(90)=1s     p(95)=1s    
-    iterations.....................: 54000  898.400917/s
-    vus............................: 900    min=900        max=900
-    vus_max........................: 900    min=900        max=900
-
-    NETWORK
-    data_received..................: 15 MB  244 kB/s
-    data_sent......................: 4.2 MB 70 kB/s
-
-
-
-
-running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
-default ✓ [ 100% ] 900 VUs  1m0s
-
-         /\      Grafana   /‾‾/  
-    /\  /  \     |\  __   /  /   
-   /  \/    \    | |/ /  /   ‾‾\ 
-  /          \   |   (  |  (‾)  |
- / __________ \  |_|\_\  \_____/ 
-
-     execution: local
-        script: benchmarkDestiny.js
-        output: -
-
-     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
-              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
-
-
-running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
-default   [   2% ] 900 VUs  0m01.0s/1m0s
-
-running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
-default   [   3% ] 900 VUs  0m02.0s/1m0s
-
-running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
-default   [   5% ] 900 VUs  0m03.0s/1m0s
-
-running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
-default   [   7% ] 900 VUs  0m04.0s/1m0s
-
-running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
-default   [   8% ] 900 VUs  0m05.0s/1m0s
-
-running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
-default   [  10% ] 900 VUs  0m06.0s/1m0s
-
-running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
-default   [  12% ] 900 VUs  0m07.0s/1m0s
-
-running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
-default   [  13% ] 900 VUs  0m08.0s/1m0s
-
-running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
-default   [  15% ] 900 VUs  0m09.0s/1m0s
-
-running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
-default   [  17% ] 900 VUs  0m10.0s/1m0s
-
-running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
-default   [  18% ] 900 VUs  0m11.0s/1m0s
-
-running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
-default   [  20% ] 900 VUs  0m12.0s/1m0s
-
-running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
-default   [  22% ] 900 VUs  0m13.0s/1m0s
-
-running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
-default   [  23% ] 900 VUs  0m14.0s/1m0s
-
-running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
-default   [  25% ] 900 VUs  0m15.0s/1m0s
-
-running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
-default   [  27% ] 900 VUs  0m16.0s/1m0s
-
-running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
-default   [  28% ] 900 VUs  0m17.0s/1m0s
-
-running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
-default   [  30% ] 900 VUs  0m18.0s/1m0s
-
-running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
-default   [  32% ] 900 VUs  0m19.0s/1m0s
-
-running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
-default   [  33% ] 900 VUs  0m20.0s/1m0s
-
-running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
-default   [  35% ] 900 VUs  0m21.0s/1m0s
-
-running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
-default   [  37% ] 900 VUs  0m22.0s/1m0s
-
-running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
-default   [  38% ] 900 VUs  0m23.0s/1m0s
-
-running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
-default   [  40% ] 900 VUs  0m24.0s/1m0s
-
-running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
-default   [  42% ] 900 VUs  0m25.0s/1m0s
-
-running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
-default   [  43% ] 900 VUs  0m26.0s/1m0s
-
-running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
-default   [  45% ] 900 VUs  0m27.0s/1m0s
-
-running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
-default   [  47% ] 900 VUs  0m28.0s/1m0s
-
-running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
-default   [  48% ] 900 VUs  0m29.0s/1m0s
-
-running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
-default   [  50% ] 900 VUs  0m30.0s/1m0s
-
-running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
-default   [  52% ] 900 VUs  0m31.0s/1m0s
-
-running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
-default   [  53% ] 900 VUs  0m32.0s/1m0s
-
-running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
-default   [  55% ] 900 VUs  0m33.0s/1m0s
-
-running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
-default   [  57% ] 900 VUs  0m34.0s/1m0s
-
-running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
-default   [  58% ] 900 VUs  0m35.0s/1m0s
-
-running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
-default   [  60% ] 900 VUs  0m36.0s/1m0s
-
-running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
-default   [  62% ] 900 VUs  0m37.0s/1m0s
-
-running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
-default   [  63% ] 900 VUs  0m38.0s/1m0s
-
-running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
-default   [  65% ] 900 VUs  0m39.0s/1m0s
-
-running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
-default   [  67% ] 900 VUs  0m40.0s/1m0s
-
-running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
-default   [  68% ] 900 VUs  0m41.0s/1m0s
-
-running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
-default   [  70% ] 900 VUs  0m42.0s/1m0s
-
-running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
-default   [  72% ] 900 VUs  0m43.0s/1m0s
-
-running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
-default   [  73% ] 900 VUs  0m44.0s/1m0s
-
-running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
-default   [  75% ] 900 VUs  0m45.0s/1m0s
-
-running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
-default   [  77% ] 900 VUs  0m46.0s/1m0s
-
-running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
-default   [  78% ] 900 VUs  0m47.0s/1m0s
-
-running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
-default   [  80% ] 900 VUs  0m48.0s/1m0s
-
-running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
-default   [  82% ] 900 VUs  0m49.0s/1m0s
-
-running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
-default   [  83% ] 900 VUs  0m50.0s/1m0s
-
-running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
-default   [  85% ] 900 VUs  0m51.0s/1m0s
-
-running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
-default   [  87% ] 900 VUs  0m52.0s/1m0s
-
-running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
-default   [  88% ] 900 VUs  0m53.0s/1m0s
-
-running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
-default   [  90% ] 900 VUs  0m54.0s/1m0s
-
-running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
-default   [  92% ] 900 VUs  0m55.0s/1m0s
-
-running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
-default   [  93% ] 900 VUs  0m56.0s/1m0s
-
-running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
-default   [  95% ] 900 VUs  0m57.0s/1m0s
-
-running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
-default   [  97% ] 900 VUs  0m58.0s/1m0s
-
-running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
-default   [  98% ] 900 VUs  0m59.0s/1m0s
-
-running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
-default   [ 100% ] 900 VUs  1m00.0s/1m0s
-
-
-  █ TOTAL RESULTS 
-
-    HTTP
-    http_req_duration..............: avg=616.09µs min=21.46µs med=392.93µs max=30.9ms p(90)=1.1ms p(95)=1.44ms
-      { expected_response:true }...: avg=616.09µs min=21.46µs med=392.93µs max=30.9ms p(90)=1.1ms p(95)=1.44ms
-    http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.712187/s
-
-    EXECUTION
-    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.03s  p(90)=1s    p(95)=1s    
-    iterations.....................: 54000  898.712187/s
+    iteration_duration.............: avg=1s      min=1s      med=1s       max=1.04s   p(90)=1s    p(95)=1s    
+    iterations.....................: 54000  898.381843/s
     vus............................: 900    min=900        max=900
     vus_max........................: 900    min=900        max=900
 

--- a/Benchmarks/results_destiny.txt
+++ b/Benchmarks/results_destiny.txt
@@ -197,14 +197,452 @@ default   [ 100% ] 900 VUs  1m00.0s/1m0s
   █ TOTAL RESULTS 
 
     HTTP
-    http_req_duration..............: avg=804.17µs min=21.85µs med=685.54µs max=30.65ms p(90)=1.46ms p(95)=1.69ms
-      { expected_response:true }...: avg=804.17µs min=21.85µs med=685.54µs max=30.65ms p(90)=1.46ms p(95)=1.69ms
+    http_req_duration..............: avg=709.02µs min=19.65µs med=527.57µs max=33.11ms p(90)=1.25ms p(95)=1.65ms
+      { expected_response:true }...: avg=709.02µs min=19.65µs med=527.57µs max=33.11ms p(90)=1.25ms p(95)=1.65ms
     http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.579492/s
+    http_reqs......................: 54000  898.555874/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.04s   p(90)=1s     p(95)=1s    
+    iterations.....................: 54000  898.555874/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  244 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkDestiny.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=843.56µs min=21.12µs med=719.9µs max=29.88ms p(90)=1.42ms p(95)=1.89ms
+      { expected_response:true }...: avg=843.56µs min=21.12µs med=719.9µs max=29.88ms p(90)=1.42ms p(95)=1.89ms
+    http_req_failed................: 0.00%  0 out of 54000
+    http_reqs......................: 54000  898.490887/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s       min=1s      med=1s      max=1.04s   p(90)=1s     p(95)=1s    
+    iterations.....................: 54000  898.490887/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  244 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkDestiny.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=765.91µs min=18.64µs med=516.29µs max=16.71ms p(90)=1.53ms p(95)=1.92ms
+      { expected_response:true }...: avg=765.91µs min=18.64µs med=516.29µs max=16.71ms p(90)=1.53ms p(95)=1.92ms
+    http_req_failed................: 0.00%  0 out of 54000
+    http_reqs......................: 54000  898.676633/s
 
     EXECUTION
     iteration_duration.............: avg=1s       min=1s      med=1s       max=1.03s   p(90)=1s     p(95)=1s    
-    iterations.....................: 54000  898.579492/s
+    iterations.....................: 54000  898.676633/s
     vus............................: 900    min=900        max=900
     vus_max........................: 900    min=900        max=900
 
@@ -416,19 +854,19 @@ default   [ 100% ] 900 VUs  1m00.0s/1m0s
   █ TOTAL RESULTS 
 
     HTTP
-    http_req_duration..............: avg=612.39µs min=20.54µs med=526.88µs max=23.11ms p(90)=1.03ms p(95)=1.25ms
-      { expected_response:true }...: avg=612.39µs min=20.54µs med=526.88µs max=23.11ms p(90)=1.03ms p(95)=1.25ms
+    http_req_duration..............: avg=803.46µs min=19.67µs med=685.46µs max=33.77ms p(90)=1.47ms p(95)=1.94ms
+      { expected_response:true }...: avg=803.46µs min=19.67µs med=685.46µs max=33.77ms p(90)=1.47ms p(95)=1.94ms
     http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.715424/s
+    http_reqs......................: 54000  898.468828/s
 
     EXECUTION
     iteration_duration.............: avg=1s       min=1s      med=1s       max=1.04s   p(90)=1s     p(95)=1s    
-    iterations.....................: 54000  898.715424/s
+    iterations.....................: 54000  898.468828/s
     vus............................: 900    min=900        max=900
     vus_max........................: 900    min=900        max=900
 
     NETWORK
-    data_received..................: 15 MB  245 kB/s
+    data_received..................: 15 MB  244 kB/s
     data_sent......................: 4.2 MB 70 kB/s
 
 
@@ -635,14 +1073,671 @@ default   [ 100% ] 900 VUs  1m00.0s/1m0s
   █ TOTAL RESULTS 
 
     HTTP
-    http_req_duration..............: avg=748.73µs min=20.93µs med=570.32µs max=25.71ms p(90)=1.33ms p(95)=1.79ms
-      { expected_response:true }...: avg=748.73µs min=20.93µs med=570.32µs max=25.71ms p(90)=1.33ms p(95)=1.79ms
+    http_req_duration..............: avg=818.83µs min=20.73µs med=657.46µs max=38.08ms p(90)=1.33ms p(95)=1.6ms
+      { expected_response:true }...: avg=818.83µs min=20.73µs med=657.46µs max=38.08ms p(90)=1.33ms p(95)=1.6ms
     http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.538803/s
+    http_reqs......................: 54000  898.62282/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.04s   p(90)=1s     p(95)=1s   
+    iterations.....................: 54000  898.62282/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  244 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkDestiny.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=653.8µs min=20.72µs med=497.32µs max=25.45ms p(90)=1.15ms p(95)=1.46ms
+      { expected_response:true }...: avg=653.8µs min=20.72µs med=497.32µs max=25.45ms p(90)=1.15ms p(95)=1.46ms
+    http_req_failed................: 0.00%  0 out of 54000
+    http_reqs......................: 54000  898.576365/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s      min=1s      med=1s       max=1.04s   p(90)=1s     p(95)=1s    
+    iterations.....................: 54000  898.576365/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  244 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkDestiny.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=756.92µs min=20.64µs med=694.29µs max=27.07ms p(90)=1.2ms p(95)=1.42ms
+      { expected_response:true }...: avg=756.92µs min=20.64µs med=694.29µs max=27.07ms p(90)=1.2ms p(95)=1.42ms
+    http_req_failed................: 0.00%  0 out of 54000
+    http_reqs......................: 54000  898.686769/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.03s   p(90)=1s    p(95)=1s    
+    iterations.....................: 54000  898.686769/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  244 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkDestiny.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=762.31µs min=20.97µs med=580.54µs max=29.74ms p(90)=1.52ms p(95)=1.85ms
+      { expected_response:true }...: avg=762.31µs min=20.97µs med=580.54µs max=29.74ms p(90)=1.52ms p(95)=1.85ms
+    http_req_failed................: 0.00%  0 out of 54000
+    http_reqs......................: 54000  898.584936/s
 
     EXECUTION
     iteration_duration.............: avg=1s       min=1s      med=1s       max=1.04s   p(90)=1s     p(95)=1s    
-    iterations.....................: 54000  898.538803/s
+    iterations.....................: 54000  898.584936/s
     vus............................: 900    min=900        max=900
     vus_max........................: 900    min=900        max=900
 
@@ -854,1328 +1949,233 @@ default   [ 100% ] 900 VUs  1m00.0s/1m0s
   █ TOTAL RESULTS 
 
     HTTP
-    http_req_duration..............: avg=730.45µs min=20.27µs med=523.72µs max=20.41ms p(90)=1.46ms p(95)=2.26ms
-      { expected_response:true }...: avg=730.45µs min=20.27µs med=523.72µs max=20.41ms p(90)=1.46ms p(95)=2.26ms
+    http_req_duration..............: avg=685.92µs min=20.45µs med=455.19µs max=26.85ms p(90)=1.06ms p(95)=1.35ms
+      { expected_response:true }...: avg=685.92µs min=20.45µs med=455.19µs max=26.85ms p(90)=1.06ms p(95)=1.35ms
     http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.673058/s
-
-    EXECUTION
-    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.02s   p(90)=1s     p(95)=1s    
-    iterations.....................: 54000  898.673058/s
-    vus............................: 900    min=900        max=900
-    vus_max........................: 900    min=900        max=900
-
-    NETWORK
-    data_received..................: 15 MB  244 kB/s
-    data_sent......................: 4.2 MB 70 kB/s
-
-
-
-
-running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
-default ✓ [ 100% ] 900 VUs  1m0s
-
-         /\      Grafana   /‾‾/  
-    /\  /  \     |\  __   /  /   
-   /  \/    \    | |/ /  /   ‾‾\ 
-  /          \   |   (  |  (‾)  |
- / __________ \  |_|\_\  \_____/ 
-
-     execution: local
-        script: benchmarkDestiny.js
-        output: -
-
-     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
-              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
-
-
-running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
-default   [   2% ] 900 VUs  0m01.0s/1m0s
-
-running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
-default   [   3% ] 900 VUs  0m02.0s/1m0s
-
-running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
-default   [   5% ] 900 VUs  0m03.0s/1m0s
-
-running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
-default   [   7% ] 900 VUs  0m04.0s/1m0s
-
-running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
-default   [   8% ] 900 VUs  0m05.0s/1m0s
-
-running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
-default   [  10% ] 900 VUs  0m06.0s/1m0s
-
-running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
-default   [  12% ] 900 VUs  0m07.0s/1m0s
-
-running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
-default   [  13% ] 900 VUs  0m08.0s/1m0s
-
-running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
-default   [  15% ] 900 VUs  0m09.0s/1m0s
-
-running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
-default   [  17% ] 900 VUs  0m10.0s/1m0s
-
-running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
-default   [  18% ] 900 VUs  0m11.0s/1m0s
-
-running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
-default   [  20% ] 900 VUs  0m12.0s/1m0s
-
-running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
-default   [  22% ] 900 VUs  0m13.0s/1m0s
-
-running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
-default   [  23% ] 900 VUs  0m14.0s/1m0s
-
-running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
-default   [  25% ] 900 VUs  0m15.0s/1m0s
-
-running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
-default   [  27% ] 900 VUs  0m16.0s/1m0s
-
-running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
-default   [  28% ] 900 VUs  0m17.0s/1m0s
-
-running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
-default   [  30% ] 900 VUs  0m18.0s/1m0s
-
-running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
-default   [  32% ] 900 VUs  0m19.0s/1m0s
-
-running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
-default   [  33% ] 900 VUs  0m20.0s/1m0s
-
-running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
-default   [  35% ] 900 VUs  0m21.0s/1m0s
-
-running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
-default   [  37% ] 900 VUs  0m22.0s/1m0s
-
-running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
-default   [  38% ] 900 VUs  0m23.0s/1m0s
-
-running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
-default   [  40% ] 900 VUs  0m24.0s/1m0s
-
-running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
-default   [  42% ] 900 VUs  0m25.0s/1m0s
-
-running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
-default   [  43% ] 900 VUs  0m26.0s/1m0s
-
-running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
-default   [  45% ] 900 VUs  0m27.0s/1m0s
-
-running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
-default   [  47% ] 900 VUs  0m28.0s/1m0s
-
-running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
-default   [  48% ] 900 VUs  0m29.0s/1m0s
-
-running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
-default   [  50% ] 900 VUs  0m30.0s/1m0s
-
-running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
-default   [  52% ] 900 VUs  0m31.0s/1m0s
-
-running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
-default   [  53% ] 900 VUs  0m32.0s/1m0s
-
-running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
-default   [  55% ] 900 VUs  0m33.0s/1m0s
-
-running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
-default   [  57% ] 900 VUs  0m34.0s/1m0s
-
-running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
-default   [  58% ] 900 VUs  0m35.0s/1m0s
-
-running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
-default   [  60% ] 900 VUs  0m36.0s/1m0s
-
-running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
-default   [  62% ] 900 VUs  0m37.0s/1m0s
-
-running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
-default   [  63% ] 900 VUs  0m38.0s/1m0s
-
-running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
-default   [  65% ] 900 VUs  0m39.0s/1m0s
-
-running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
-default   [  67% ] 900 VUs  0m40.0s/1m0s
-
-running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
-default   [  68% ] 900 VUs  0m41.0s/1m0s
-
-running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
-default   [  70% ] 900 VUs  0m42.0s/1m0s
-
-running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
-default   [  72% ] 900 VUs  0m43.0s/1m0s
-
-running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
-default   [  73% ] 900 VUs  0m44.0s/1m0s
-
-running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
-default   [  75% ] 900 VUs  0m45.0s/1m0s
-
-running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
-default   [  77% ] 900 VUs  0m46.0s/1m0s
-
-running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
-default   [  78% ] 900 VUs  0m47.0s/1m0s
-
-running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
-default   [  80% ] 900 VUs  0m48.0s/1m0s
-
-running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
-default   [  82% ] 900 VUs  0m49.0s/1m0s
-
-running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
-default   [  83% ] 900 VUs  0m50.0s/1m0s
-
-running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
-default   [  85% ] 900 VUs  0m51.0s/1m0s
-
-running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
-default   [  87% ] 900 VUs  0m52.0s/1m0s
-
-running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
-default   [  88% ] 900 VUs  0m53.0s/1m0s
-
-running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
-default   [  90% ] 900 VUs  0m54.0s/1m0s
-
-running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
-default   [  92% ] 900 VUs  0m55.0s/1m0s
-
-running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
-default   [  93% ] 900 VUs  0m56.0s/1m0s
-
-running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
-default   [  95% ] 900 VUs  0m57.0s/1m0s
-
-running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
-default   [  97% ] 900 VUs  0m58.0s/1m0s
-
-running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
-default   [  98% ] 900 VUs  0m59.0s/1m0s
-
-running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
-default   [ 100% ] 900 VUs  1m00.0s/1m0s
-
-
-  █ TOTAL RESULTS 
-
-    HTTP
-    http_req_duration..............: avg=620.88µs min=20.4µs med=520.53µs max=27.84ms p(90)=1.12ms p(95)=1.27ms
-      { expected_response:true }...: avg=620.88µs min=20.4µs med=520.53µs max=27.84ms p(90)=1.12ms p(95)=1.27ms
-    http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.659588/s
-
-    EXECUTION
-    iteration_duration.............: avg=1s       min=1s     med=1s       max=1.04s   p(90)=1s     p(95)=1s    
-    iterations.....................: 54000  898.659588/s
-    vus............................: 900    min=900        max=900
-    vus_max........................: 900    min=900        max=900
-
-    NETWORK
-    data_received..................: 15 MB  244 kB/s
-    data_sent......................: 4.2 MB 70 kB/s
-
-
-
-
-running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
-default ✓ [ 100% ] 900 VUs  1m0s
-
-         /\      Grafana   /‾‾/  
-    /\  /  \     |\  __   /  /   
-   /  \/    \    | |/ /  /   ‾‾\ 
-  /          \   |   (  |  (‾)  |
- / __________ \  |_|\_\  \_____/ 
-
-     execution: local
-        script: benchmarkDestiny.js
-        output: -
-
-     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
-              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
-
-
-running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
-default   [   2% ] 900 VUs  0m01.0s/1m0s
-
-running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
-default   [   3% ] 900 VUs  0m02.0s/1m0s
-
-running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
-default   [   5% ] 900 VUs  0m03.0s/1m0s
-
-running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
-default   [   7% ] 900 VUs  0m04.0s/1m0s
-
-running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
-default   [   8% ] 900 VUs  0m05.0s/1m0s
-
-running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
-default   [  10% ] 900 VUs  0m06.0s/1m0s
-
-running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
-default   [  12% ] 900 VUs  0m07.0s/1m0s
-
-running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
-default   [  13% ] 900 VUs  0m08.0s/1m0s
-
-running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
-default   [  15% ] 900 VUs  0m09.0s/1m0s
-
-running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
-default   [  17% ] 900 VUs  0m10.0s/1m0s
-
-running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
-default   [  18% ] 900 VUs  0m11.0s/1m0s
-
-running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
-default   [  20% ] 900 VUs  0m12.0s/1m0s
-
-running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
-default   [  22% ] 900 VUs  0m13.0s/1m0s
-
-running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
-default   [  23% ] 900 VUs  0m14.0s/1m0s
-
-running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
-default   [  25% ] 900 VUs  0m15.0s/1m0s
-
-running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
-default   [  27% ] 900 VUs  0m16.0s/1m0s
-
-running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
-default   [  28% ] 900 VUs  0m17.0s/1m0s
-
-running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
-default   [  30% ] 900 VUs  0m18.0s/1m0s
-
-running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
-default   [  32% ] 900 VUs  0m19.0s/1m0s
-
-running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
-default   [  33% ] 900 VUs  0m20.0s/1m0s
-
-running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
-default   [  35% ] 900 VUs  0m21.0s/1m0s
-
-running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
-default   [  37% ] 900 VUs  0m22.0s/1m0s
-
-running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
-default   [  38% ] 900 VUs  0m23.0s/1m0s
-
-running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
-default   [  40% ] 900 VUs  0m24.0s/1m0s
-
-running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
-default   [  42% ] 900 VUs  0m25.0s/1m0s
-
-running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
-default   [  43% ] 900 VUs  0m26.0s/1m0s
-
-running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
-default   [  45% ] 900 VUs  0m27.0s/1m0s
-
-running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
-default   [  47% ] 900 VUs  0m28.0s/1m0s
-
-running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
-default   [  48% ] 900 VUs  0m29.0s/1m0s
-
-running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
-default   [  50% ] 900 VUs  0m30.0s/1m0s
-
-running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
-default   [  52% ] 900 VUs  0m31.0s/1m0s
-
-running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
-default   [  53% ] 900 VUs  0m32.0s/1m0s
-
-running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
-default   [  55% ] 900 VUs  0m33.0s/1m0s
-
-running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
-default   [  57% ] 900 VUs  0m34.0s/1m0s
-
-running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
-default   [  58% ] 900 VUs  0m35.0s/1m0s
-
-running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
-default   [  60% ] 900 VUs  0m36.0s/1m0s
-
-running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
-default   [  62% ] 900 VUs  0m37.0s/1m0s
-
-running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
-default   [  63% ] 900 VUs  0m38.0s/1m0s
-
-running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
-default   [  65% ] 900 VUs  0m39.0s/1m0s
-
-running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
-default   [  67% ] 900 VUs  0m40.0s/1m0s
-
-running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
-default   [  68% ] 900 VUs  0m41.0s/1m0s
-
-running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
-default   [  70% ] 900 VUs  0m42.0s/1m0s
-
-running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
-default   [  72% ] 900 VUs  0m43.0s/1m0s
-
-running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
-default   [  73% ] 900 VUs  0m44.0s/1m0s
-
-running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
-default   [  75% ] 900 VUs  0m45.0s/1m0s
-
-running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
-default   [  77% ] 900 VUs  0m46.0s/1m0s
-
-running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
-default   [  78% ] 900 VUs  0m47.0s/1m0s
-
-running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
-default   [  80% ] 900 VUs  0m48.0s/1m0s
-
-running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
-default   [  82% ] 900 VUs  0m49.0s/1m0s
-
-running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
-default   [  83% ] 900 VUs  0m50.0s/1m0s
-
-running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
-default   [  85% ] 900 VUs  0m51.0s/1m0s
-
-running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
-default   [  87% ] 900 VUs  0m52.0s/1m0s
-
-running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
-default   [  88% ] 900 VUs  0m53.0s/1m0s
-
-running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
-default   [  90% ] 900 VUs  0m54.0s/1m0s
-
-running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
-default   [  92% ] 900 VUs  0m55.0s/1m0s
-
-running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
-default   [  93% ] 900 VUs  0m56.0s/1m0s
-
-running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
-default   [  95% ] 900 VUs  0m57.0s/1m0s
-
-running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
-default   [  97% ] 900 VUs  0m58.0s/1m0s
-
-running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
-default   [  98% ] 900 VUs  0m59.0s/1m0s
-
-running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
-default   [ 100% ] 900 VUs  1m00.0s/1m0s
-
-
-  █ TOTAL RESULTS 
-
-    HTTP
-    http_req_duration..............: avg=487.73µs min=20.06µs med=333.38µs max=50.44ms p(90)=962.03µs p(95)=1.26ms
-      { expected_response:true }...: avg=487.73µs min=20.06µs med=333.38µs max=50.44ms p(90)=962.03µs p(95)=1.26ms
-    http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.716124/s
-
-    EXECUTION
-    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.05s   p(90)=1s       p(95)=1s    
-    iterations.....................: 54000  898.716124/s
-    vus............................: 900    min=900        max=900
-    vus_max........................: 900    min=900        max=900
-
-    NETWORK
-    data_received..................: 15 MB  245 kB/s
-    data_sent......................: 4.2 MB 70 kB/s
-
-
-
-
-running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
-default ✓ [ 100% ] 900 VUs  1m0s
-
-         /\      Grafana   /‾‾/  
-    /\  /  \     |\  __   /  /   
-   /  \/    \    | |/ /  /   ‾‾\ 
-  /          \   |   (  |  (‾)  |
- / __________ \  |_|\_\  \_____/ 
-
-     execution: local
-        script: benchmarkDestiny.js
-        output: -
-
-     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
-              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
-
-
-running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
-default   [   2% ] 900 VUs  0m01.0s/1m0s
-
-running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
-default   [   3% ] 900 VUs  0m02.0s/1m0s
-
-running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
-default   [   5% ] 900 VUs  0m03.0s/1m0s
-
-running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
-default   [   7% ] 900 VUs  0m04.0s/1m0s
-
-running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
-default   [   8% ] 900 VUs  0m05.0s/1m0s
-
-running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
-default   [  10% ] 900 VUs  0m06.0s/1m0s
-
-running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
-default   [  12% ] 900 VUs  0m07.0s/1m0s
-
-running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
-default   [  13% ] 900 VUs  0m08.0s/1m0s
-
-running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
-default   [  15% ] 900 VUs  0m09.0s/1m0s
-
-running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
-default   [  17% ] 900 VUs  0m10.0s/1m0s
-
-running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
-default   [  18% ] 900 VUs  0m11.0s/1m0s
-
-running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
-default   [  20% ] 900 VUs  0m12.0s/1m0s
-
-running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
-default   [  22% ] 900 VUs  0m13.0s/1m0s
-
-running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
-default   [  23% ] 900 VUs  0m14.0s/1m0s
-
-running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
-default   [  25% ] 900 VUs  0m15.0s/1m0s
-
-running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
-default   [  27% ] 900 VUs  0m16.0s/1m0s
-
-running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
-default   [  28% ] 900 VUs  0m17.0s/1m0s
-
-running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
-default   [  30% ] 900 VUs  0m18.0s/1m0s
-
-running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
-default   [  32% ] 900 VUs  0m19.0s/1m0s
-
-running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
-default   [  33% ] 900 VUs  0m20.0s/1m0s
-
-running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
-default   [  35% ] 900 VUs  0m21.0s/1m0s
-
-running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
-default   [  37% ] 900 VUs  0m22.0s/1m0s
-
-running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
-default   [  38% ] 900 VUs  0m23.0s/1m0s
-
-running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
-default   [  40% ] 900 VUs  0m24.0s/1m0s
-
-running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
-default   [  42% ] 900 VUs  0m25.0s/1m0s
-
-running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
-default   [  43% ] 900 VUs  0m26.0s/1m0s
-
-running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
-default   [  45% ] 900 VUs  0m27.0s/1m0s
-
-running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
-default   [  47% ] 900 VUs  0m28.0s/1m0s
-
-running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
-default   [  48% ] 900 VUs  0m29.0s/1m0s
-
-running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
-default   [  50% ] 900 VUs  0m30.0s/1m0s
-
-running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
-default   [  52% ] 900 VUs  0m31.0s/1m0s
-
-running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
-default   [  53% ] 900 VUs  0m32.0s/1m0s
-
-running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
-default   [  55% ] 900 VUs  0m33.0s/1m0s
-
-running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
-default   [  57% ] 900 VUs  0m34.0s/1m0s
-
-running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
-default   [  58% ] 900 VUs  0m35.0s/1m0s
-
-running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
-default   [  60% ] 900 VUs  0m36.0s/1m0s
-
-running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
-default   [  62% ] 900 VUs  0m37.0s/1m0s
-
-running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
-default   [  63% ] 900 VUs  0m38.0s/1m0s
-
-running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
-default   [  65% ] 900 VUs  0m39.0s/1m0s
-
-running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
-default   [  67% ] 900 VUs  0m40.0s/1m0s
-
-running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
-default   [  68% ] 900 VUs  0m41.0s/1m0s
-
-running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
-default   [  70% ] 900 VUs  0m42.0s/1m0s
-
-running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
-default   [  72% ] 900 VUs  0m43.0s/1m0s
-
-running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
-default   [  73% ] 900 VUs  0m44.0s/1m0s
-
-running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
-default   [  75% ] 900 VUs  0m45.0s/1m0s
-
-running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
-default   [  77% ] 900 VUs  0m46.0s/1m0s
-
-running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
-default   [  78% ] 900 VUs  0m47.0s/1m0s
-
-running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
-default   [  80% ] 900 VUs  0m48.0s/1m0s
-
-running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
-default   [  82% ] 900 VUs  0m49.0s/1m0s
-
-running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
-default   [  83% ] 900 VUs  0m50.0s/1m0s
-
-running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
-default   [  85% ] 900 VUs  0m51.0s/1m0s
-
-running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
-default   [  87% ] 900 VUs  0m52.0s/1m0s
-
-running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
-default   [  88% ] 900 VUs  0m53.0s/1m0s
-
-running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
-default   [  90% ] 900 VUs  0m54.0s/1m0s
-
-running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
-default   [  92% ] 900 VUs  0m55.0s/1m0s
-
-running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
-default   [  93% ] 900 VUs  0m56.0s/1m0s
-
-running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
-default   [  95% ] 900 VUs  0m57.0s/1m0s
-
-running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
-default   [  97% ] 900 VUs  0m58.0s/1m0s
-
-running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
-default   [  98% ] 900 VUs  0m59.0s/1m0s
-
-running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
-default   [ 100% ] 900 VUs  1m00.0s/1m0s
-
-
-  █ TOTAL RESULTS 
-
-    HTTP
-    http_req_duration..............: avg=749µs min=19.61µs med=618.34µs max=19.95ms p(90)=1.25ms p(95)=1.51ms
-      { expected_response:true }...: avg=749µs min=19.61µs med=618.34µs max=19.95ms p(90)=1.25ms p(95)=1.51ms
-    http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.544984/s
-
-    EXECUTION
-    iteration_duration.............: avg=1s    min=1s      med=1s       max=1.04s   p(90)=1s     p(95)=1s    
-    iterations.....................: 54000  898.544984/s
-    vus............................: 900    min=900        max=900
-    vus_max........................: 900    min=900        max=900
-
-    NETWORK
-    data_received..................: 15 MB  244 kB/s
-    data_sent......................: 4.2 MB 70 kB/s
-
-
-
-
-running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
-default ✓ [ 100% ] 900 VUs  1m0s
-
-         /\      Grafana   /‾‾/  
-    /\  /  \     |\  __   /  /   
-   /  \/    \    | |/ /  /   ‾‾\ 
-  /          \   |   (  |  (‾)  |
- / __________ \  |_|\_\  \_____/ 
-
-     execution: local
-        script: benchmarkDestiny.js
-        output: -
-
-     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
-              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
-
-
-running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
-default   [   2% ] 900 VUs  0m01.0s/1m0s
-
-running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
-default   [   3% ] 900 VUs  0m02.0s/1m0s
-
-running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
-default   [   5% ] 900 VUs  0m03.0s/1m0s
-
-running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
-default   [   7% ] 900 VUs  0m04.0s/1m0s
-
-running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
-default   [   8% ] 900 VUs  0m05.0s/1m0s
-
-running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
-default   [  10% ] 900 VUs  0m06.0s/1m0s
-
-running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
-default   [  12% ] 900 VUs  0m07.0s/1m0s
-
-running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
-default   [  13% ] 900 VUs  0m08.0s/1m0s
-
-running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
-default   [  15% ] 900 VUs  0m09.0s/1m0s
-
-running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
-default   [  17% ] 900 VUs  0m10.0s/1m0s
-
-running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
-default   [  18% ] 900 VUs  0m11.0s/1m0s
-
-running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
-default   [  20% ] 900 VUs  0m12.0s/1m0s
-
-running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
-default   [  22% ] 900 VUs  0m13.0s/1m0s
-
-running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
-default   [  23% ] 900 VUs  0m14.0s/1m0s
-
-running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
-default   [  25% ] 900 VUs  0m15.0s/1m0s
-
-running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
-default   [  27% ] 900 VUs  0m16.0s/1m0s
-
-running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
-default   [  28% ] 900 VUs  0m17.0s/1m0s
-
-running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
-default   [  30% ] 900 VUs  0m18.0s/1m0s
-
-running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
-default   [  32% ] 900 VUs  0m19.0s/1m0s
-
-running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
-default   [  33% ] 900 VUs  0m20.0s/1m0s
-
-running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
-default   [  35% ] 900 VUs  0m21.0s/1m0s
-
-running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
-default   [  37% ] 900 VUs  0m22.0s/1m0s
-
-running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
-default   [  38% ] 900 VUs  0m23.0s/1m0s
-
-running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
-default   [  40% ] 900 VUs  0m24.0s/1m0s
-
-running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
-default   [  42% ] 900 VUs  0m25.0s/1m0s
-
-running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
-default   [  43% ] 900 VUs  0m26.0s/1m0s
-
-running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
-default   [  45% ] 900 VUs  0m27.0s/1m0s
-
-running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
-default   [  47% ] 900 VUs  0m28.0s/1m0s
-
-running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
-default   [  48% ] 900 VUs  0m29.0s/1m0s
-
-running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
-default   [  50% ] 900 VUs  0m30.0s/1m0s
-
-running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
-default   [  52% ] 900 VUs  0m31.0s/1m0s
-
-running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
-default   [  53% ] 900 VUs  0m32.0s/1m0s
-
-running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
-default   [  55% ] 900 VUs  0m33.0s/1m0s
-
-running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
-default   [  57% ] 900 VUs  0m34.0s/1m0s
-
-running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
-default   [  58% ] 900 VUs  0m35.0s/1m0s
-
-running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
-default   [  60% ] 900 VUs  0m36.0s/1m0s
-
-running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
-default   [  62% ] 900 VUs  0m37.0s/1m0s
-
-running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
-default   [  63% ] 900 VUs  0m38.0s/1m0s
-
-running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
-default   [  65% ] 900 VUs  0m39.0s/1m0s
-
-running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
-default   [  67% ] 900 VUs  0m40.0s/1m0s
-
-running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
-default   [  68% ] 900 VUs  0m41.0s/1m0s
-
-running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
-default   [  70% ] 900 VUs  0m42.0s/1m0s
-
-running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
-default   [  72% ] 900 VUs  0m43.0s/1m0s
-
-running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
-default   [  73% ] 900 VUs  0m44.0s/1m0s
-
-running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
-default   [  75% ] 900 VUs  0m45.0s/1m0s
-
-running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
-default   [  77% ] 900 VUs  0m46.0s/1m0s
-
-running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
-default   [  78% ] 900 VUs  0m47.0s/1m0s
-
-running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
-default   [  80% ] 900 VUs  0m48.0s/1m0s
-
-running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
-default   [  82% ] 900 VUs  0m49.0s/1m0s
-
-running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
-default   [  83% ] 900 VUs  0m50.0s/1m0s
-
-running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
-default   [  85% ] 900 VUs  0m51.0s/1m0s
-
-running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
-default   [  87% ] 900 VUs  0m52.0s/1m0s
-
-running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
-default   [  88% ] 900 VUs  0m53.0s/1m0s
-
-running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
-default   [  90% ] 900 VUs  0m54.0s/1m0s
-
-running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
-default   [  92% ] 900 VUs  0m55.0s/1m0s
-
-running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
-default   [  93% ] 900 VUs  0m56.0s/1m0s
-
-running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
-default   [  95% ] 900 VUs  0m57.0s/1m0s
-
-running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
-default   [  97% ] 900 VUs  0m58.0s/1m0s
-
-running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
-default   [  98% ] 900 VUs  0m59.0s/1m0s
-
-running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
-default   [ 100% ] 900 VUs  1m00.0s/1m0s
-
-
-  █ TOTAL RESULTS 
-
-    HTTP
-    http_req_duration..............: avg=805.66µs min=20.04µs med=612.95µs max=26.74ms p(90)=1.38ms p(95)=1.65ms
-      { expected_response:true }...: avg=805.66µs min=20.04µs med=612.95µs max=26.74ms p(90)=1.38ms p(95)=1.65ms
-    http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.628751/s
-
-    EXECUTION
-    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.03s   p(90)=1s     p(95)=1s    
-    iterations.....................: 54000  898.628751/s
-    vus............................: 900    min=900        max=900
-    vus_max........................: 900    min=900        max=900
-
-    NETWORK
-    data_received..................: 15 MB  244 kB/s
-    data_sent......................: 4.2 MB 70 kB/s
-
-
-
-
-running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
-default ✓ [ 100% ] 900 VUs  1m0s
-
-         /\      Grafana   /‾‾/  
-    /\  /  \     |\  __   /  /   
-   /  \/    \    | |/ /  /   ‾‾\ 
-  /          \   |   (  |  (‾)  |
- / __________ \  |_|\_\  \_____/ 
-
-     execution: local
-        script: benchmarkDestiny.js
-        output: -
-
-     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
-              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
-
-
-running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
-default   [   2% ] 900 VUs  0m01.0s/1m0s
-
-running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
-default   [   3% ] 900 VUs  0m02.0s/1m0s
-
-running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
-default   [   5% ] 900 VUs  0m03.0s/1m0s
-
-running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
-default   [   7% ] 900 VUs  0m04.0s/1m0s
-
-running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
-default   [   8% ] 900 VUs  0m05.0s/1m0s
-
-running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
-default   [  10% ] 900 VUs  0m06.0s/1m0s
-
-running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
-default   [  12% ] 900 VUs  0m07.0s/1m0s
-
-running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
-default   [  13% ] 900 VUs  0m08.0s/1m0s
-
-running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
-default   [  15% ] 900 VUs  0m09.0s/1m0s
-
-running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
-default   [  17% ] 900 VUs  0m10.0s/1m0s
-
-running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
-default   [  18% ] 900 VUs  0m11.0s/1m0s
-
-running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
-default   [  20% ] 900 VUs  0m12.0s/1m0s
-
-running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
-default   [  22% ] 900 VUs  0m13.0s/1m0s
-
-running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
-default   [  23% ] 900 VUs  0m14.0s/1m0s
-
-running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
-default   [  25% ] 900 VUs  0m15.0s/1m0s
-
-running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
-default   [  27% ] 900 VUs  0m16.0s/1m0s
-
-running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
-default   [  28% ] 900 VUs  0m17.0s/1m0s
-
-running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
-default   [  30% ] 900 VUs  0m18.0s/1m0s
-
-running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
-default   [  32% ] 900 VUs  0m19.0s/1m0s
-
-running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
-default   [  33% ] 900 VUs  0m20.0s/1m0s
-
-running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
-default   [  35% ] 900 VUs  0m21.0s/1m0s
-
-running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
-default   [  37% ] 900 VUs  0m22.0s/1m0s
-
-running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
-default   [  38% ] 900 VUs  0m23.0s/1m0s
-
-running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
-default   [  40% ] 900 VUs  0m24.0s/1m0s
-
-running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
-default   [  42% ] 900 VUs  0m25.0s/1m0s
-
-running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
-default   [  43% ] 900 VUs  0m26.0s/1m0s
-
-running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
-default   [  45% ] 900 VUs  0m27.0s/1m0s
-
-running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
-default   [  47% ] 900 VUs  0m28.0s/1m0s
-
-running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
-default   [  48% ] 900 VUs  0m29.0s/1m0s
-
-running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
-default   [  50% ] 900 VUs  0m30.0s/1m0s
-
-running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
-default   [  52% ] 900 VUs  0m31.0s/1m0s
-
-running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
-default   [  53% ] 900 VUs  0m32.0s/1m0s
-
-running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
-default   [  55% ] 900 VUs  0m33.0s/1m0s
-
-running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
-default   [  57% ] 900 VUs  0m34.0s/1m0s
-
-running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
-default   [  58% ] 900 VUs  0m35.0s/1m0s
-
-running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
-default   [  60% ] 900 VUs  0m36.0s/1m0s
-
-running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
-default   [  62% ] 900 VUs  0m37.0s/1m0s
-
-running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
-default   [  63% ] 900 VUs  0m38.0s/1m0s
-
-running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
-default   [  65% ] 900 VUs  0m39.0s/1m0s
-
-running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
-default   [  67% ] 900 VUs  0m40.0s/1m0s
-
-running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
-default   [  68% ] 900 VUs  0m41.0s/1m0s
-
-running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
-default   [  70% ] 900 VUs  0m42.0s/1m0s
-
-running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
-default   [  72% ] 900 VUs  0m43.0s/1m0s
-
-running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
-default   [  73% ] 900 VUs  0m44.0s/1m0s
-
-running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
-default   [  75% ] 900 VUs  0m45.0s/1m0s
-
-running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
-default   [  77% ] 900 VUs  0m46.0s/1m0s
-
-running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
-default   [  78% ] 900 VUs  0m47.0s/1m0s
-
-running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
-default   [  80% ] 900 VUs  0m48.0s/1m0s
-
-running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
-default   [  82% ] 900 VUs  0m49.0s/1m0s
-
-running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
-default   [  83% ] 900 VUs  0m50.0s/1m0s
-
-running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
-default   [  85% ] 900 VUs  0m51.0s/1m0s
-
-running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
-default   [  87% ] 900 VUs  0m52.0s/1m0s
-
-running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
-default   [  88% ] 900 VUs  0m53.0s/1m0s
-
-running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
-default   [  90% ] 900 VUs  0m54.0s/1m0s
-
-running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
-default   [  92% ] 900 VUs  0m55.0s/1m0s
-
-running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
-default   [  93% ] 900 VUs  0m56.0s/1m0s
-
-running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
-default   [  95% ] 900 VUs  0m57.0s/1m0s
-
-running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
-default   [  97% ] 900 VUs  0m58.0s/1m0s
-
-running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
-default   [  98% ] 900 VUs  0m59.0s/1m0s
-
-running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
-default   [ 100% ] 900 VUs  1m00.0s/1m0s
-
-
-  █ TOTAL RESULTS 
-
-    HTTP
-    http_req_duration..............: avg=588.25µs min=20.87µs med=384.5µs max=41.63ms p(90)=957.34µs p(95)=1.18ms
-      { expected_response:true }...: avg=588.25µs min=20.87µs med=384.5µs max=41.63ms p(90)=957.34µs p(95)=1.18ms
-    http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.681564/s
-
-    EXECUTION
-    iteration_duration.............: avg=1s       min=1s      med=1s      max=1.04s   p(90)=1s       p(95)=1s    
-    iterations.....................: 54000  898.681564/s
-    vus............................: 900    min=900        max=900
-    vus_max........................: 900    min=900        max=900
-
-    NETWORK
-    data_received..................: 15 MB  244 kB/s
-    data_sent......................: 4.2 MB 70 kB/s
-
-
-
-
-running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
-default ✓ [ 100% ] 900 VUs  1m0s
-
-         /\      Grafana   /‾‾/  
-    /\  /  \     |\  __   /  /   
-   /  \/    \    | |/ /  /   ‾‾\ 
-  /          \   |   (  |  (‾)  |
- / __________ \  |_|\_\  \_____/ 
-
-     execution: local
-        script: benchmarkDestiny.js
-        output: -
-
-     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
-              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
-
-
-running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
-default   [   2% ] 900 VUs  0m01.0s/1m0s
-
-running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
-default   [   3% ] 900 VUs  0m02.0s/1m0s
-
-running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
-default   [   5% ] 900 VUs  0m03.0s/1m0s
-
-running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
-default   [   7% ] 900 VUs  0m04.0s/1m0s
-
-running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
-default   [   8% ] 900 VUs  0m05.0s/1m0s
-
-running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
-default   [  10% ] 900 VUs  0m06.0s/1m0s
-
-running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
-default   [  12% ] 900 VUs  0m07.0s/1m0s
-
-running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
-default   [  13% ] 900 VUs  0m08.0s/1m0s
-
-running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
-default   [  15% ] 900 VUs  0m09.0s/1m0s
-
-running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
-default   [  17% ] 900 VUs  0m10.0s/1m0s
-
-running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
-default   [  18% ] 900 VUs  0m11.0s/1m0s
-
-running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
-default   [  20% ] 900 VUs  0m12.0s/1m0s
-
-running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
-default   [  22% ] 900 VUs  0m13.0s/1m0s
-
-running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
-default   [  23% ] 900 VUs  0m14.0s/1m0s
-
-running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
-default   [  25% ] 900 VUs  0m15.0s/1m0s
-
-running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
-default   [  27% ] 900 VUs  0m16.0s/1m0s
-
-running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
-default   [  28% ] 900 VUs  0m17.0s/1m0s
-
-running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
-default   [  30% ] 900 VUs  0m18.0s/1m0s
-
-running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
-default   [  32% ] 900 VUs  0m19.0s/1m0s
-
-running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
-default   [  33% ] 900 VUs  0m20.0s/1m0s
-
-running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
-default   [  35% ] 900 VUs  0m21.0s/1m0s
-
-running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
-default   [  37% ] 900 VUs  0m22.0s/1m0s
-
-running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
-default   [  38% ] 900 VUs  0m23.0s/1m0s
-
-running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
-default   [  40% ] 900 VUs  0m24.0s/1m0s
-
-running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
-default   [  42% ] 900 VUs  0m25.0s/1m0s
-
-running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
-default   [  43% ] 900 VUs  0m26.0s/1m0s
-
-running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
-default   [  45% ] 900 VUs  0m27.0s/1m0s
-
-running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
-default   [  47% ] 900 VUs  0m28.0s/1m0s
-
-running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
-default   [  48% ] 900 VUs  0m29.0s/1m0s
-
-running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
-default   [  50% ] 900 VUs  0m30.0s/1m0s
-
-running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
-default   [  52% ] 900 VUs  0m31.0s/1m0s
-
-running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
-default   [  53% ] 900 VUs  0m32.0s/1m0s
-
-running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
-default   [  55% ] 900 VUs  0m33.0s/1m0s
-
-running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
-default   [  57% ] 900 VUs  0m34.0s/1m0s
-
-running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
-default   [  58% ] 900 VUs  0m35.0s/1m0s
-
-running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
-default   [  60% ] 900 VUs  0m36.0s/1m0s
-
-running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
-default   [  62% ] 900 VUs  0m37.0s/1m0s
-
-running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
-default   [  63% ] 900 VUs  0m38.0s/1m0s
-
-running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
-default   [  65% ] 900 VUs  0m39.0s/1m0s
-
-running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
-default   [  67% ] 900 VUs  0m40.0s/1m0s
-
-running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
-default   [  68% ] 900 VUs  0m41.0s/1m0s
-
-running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
-default   [  70% ] 900 VUs  0m42.0s/1m0s
-
-running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
-default   [  72% ] 900 VUs  0m43.0s/1m0s
-
-running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
-default   [  73% ] 900 VUs  0m44.0s/1m0s
-
-running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
-default   [  75% ] 900 VUs  0m45.0s/1m0s
-
-running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
-default   [  77% ] 900 VUs  0m46.0s/1m0s
-
-running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
-default   [  78% ] 900 VUs  0m47.0s/1m0s
-
-running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
-default   [  80% ] 900 VUs  0m48.0s/1m0s
-
-running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
-default   [  82% ] 900 VUs  0m49.0s/1m0s
-
-running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
-default   [  83% ] 900 VUs  0m50.0s/1m0s
-
-running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
-default   [  85% ] 900 VUs  0m51.0s/1m0s
-
-running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
-default   [  87% ] 900 VUs  0m52.0s/1m0s
-
-running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
-default   [  88% ] 900 VUs  0m53.0s/1m0s
-
-running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
-default   [  90% ] 900 VUs  0m54.0s/1m0s
-
-running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
-default   [  92% ] 900 VUs  0m55.0s/1m0s
-
-running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
-default   [  93% ] 900 VUs  0m56.0s/1m0s
-
-running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
-default   [  95% ] 900 VUs  0m57.0s/1m0s
-
-running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
-default   [  97% ] 900 VUs  0m58.0s/1m0s
-
-running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
-default   [  98% ] 900 VUs  0m59.0s/1m0s
-
-running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
-default   [ 100% ] 900 VUs  1m00.0s/1m0s
-
-
-  █ TOTAL RESULTS 
-
-    HTTP
-    http_req_duration..............: avg=807.98µs min=21.35µs med=632.66µs max=34.24ms p(90)=1.46ms p(95)=1.79ms
-      { expected_response:true }...: avg=807.98µs min=21.35µs med=632.66µs max=34.24ms p(90)=1.46ms p(95)=1.79ms
-    http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.458078/s
+    http_reqs......................: 54000  898.633816/s
 
     EXECUTION
     iteration_duration.............: avg=1s       min=1s      med=1s       max=1.04s   p(90)=1s     p(95)=1s    
-    iterations.....................: 54000  898.458078/s
+    iterations.....................: 54000  898.633816/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  244 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkDestiny.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=732.69µs min=19.6µs med=552.42µs max=33.1ms p(90)=1.25ms p(95)=1.56ms
+      { expected_response:true }...: avg=732.69µs min=19.6µs med=552.42µs max=33.1ms p(90)=1.25ms p(95)=1.56ms
+    http_req_failed................: 0.00%  0 out of 54000
+    http_reqs......................: 54000  898.538704/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s       min=1s     med=1s       max=1.04s  p(90)=1s     p(95)=1s    
+    iterations.....................: 54000  898.538704/s
     vus............................: 900    min=900        max=900
     vus_max........................: 900    min=900        max=900
 

--- a/Benchmarks/results_destiny.txt
+++ b/Benchmarks/results_destiny.txt
@@ -197,671 +197,14 @@ default   [ 100% ] 900 VUs  1m00.0s/1m0s
   █ TOTAL RESULTS 
 
     HTTP
-    http_req_duration..............: avg=818.13µs min=19.14µs med=712.76µs max=8.43ms p(90)=1.43ms p(95)=1.79ms
-      { expected_response:true }...: avg=818.13µs min=19.14µs med=712.76µs max=8.43ms p(90)=1.43ms p(95)=1.79ms
+    http_req_duration..............: avg=804.17µs min=21.85µs med=685.54µs max=30.65ms p(90)=1.46ms p(95)=1.69ms
+      { expected_response:true }...: avg=804.17µs min=21.85µs med=685.54µs max=30.65ms p(90)=1.46ms p(95)=1.69ms
     http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.541733/s
-
-    EXECUTION
-    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.03s  p(90)=1s     p(95)=1s    
-    iterations.....................: 54000  898.541733/s
-    vus............................: 900    min=900        max=900
-    vus_max........................: 900    min=900        max=900
-
-    NETWORK
-    data_received..................: 15 MB  244 kB/s
-    data_sent......................: 4.2 MB 70 kB/s
-
-
-
-
-running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
-default ✓ [ 100% ] 900 VUs  1m0s
-
-         /\      Grafana   /‾‾/  
-    /\  /  \     |\  __   /  /   
-   /  \/    \    | |/ /  /   ‾‾\ 
-  /          \   |   (  |  (‾)  |
- / __________ \  |_|\_\  \_____/ 
-
-     execution: local
-        script: benchmarkDestiny.js
-        output: -
-
-     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
-              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
-
-
-running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
-default   [   2% ] 900 VUs  0m01.0s/1m0s
-
-running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
-default   [   3% ] 900 VUs  0m02.0s/1m0s
-
-running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
-default   [   5% ] 900 VUs  0m03.0s/1m0s
-
-running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
-default   [   7% ] 900 VUs  0m04.0s/1m0s
-
-running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
-default   [   8% ] 900 VUs  0m05.0s/1m0s
-
-running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
-default   [  10% ] 900 VUs  0m06.0s/1m0s
-
-running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
-default   [  12% ] 900 VUs  0m07.0s/1m0s
-
-running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
-default   [  13% ] 900 VUs  0m08.0s/1m0s
-
-running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
-default   [  15% ] 900 VUs  0m09.0s/1m0s
-
-running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
-default   [  17% ] 900 VUs  0m10.0s/1m0s
-
-running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
-default   [  18% ] 900 VUs  0m11.0s/1m0s
-
-running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
-default   [  20% ] 900 VUs  0m12.0s/1m0s
-
-running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
-default   [  22% ] 900 VUs  0m13.0s/1m0s
-
-running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
-default   [  23% ] 900 VUs  0m14.0s/1m0s
-
-running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
-default   [  25% ] 900 VUs  0m15.0s/1m0s
-
-running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
-default   [  27% ] 900 VUs  0m16.0s/1m0s
-
-running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
-default   [  28% ] 900 VUs  0m17.0s/1m0s
-
-running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
-default   [  30% ] 900 VUs  0m18.0s/1m0s
-
-running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
-default   [  32% ] 900 VUs  0m19.0s/1m0s
-
-running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
-default   [  33% ] 900 VUs  0m20.0s/1m0s
-
-running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
-default   [  35% ] 900 VUs  0m21.0s/1m0s
-
-running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
-default   [  37% ] 900 VUs  0m22.0s/1m0s
-
-running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
-default   [  38% ] 900 VUs  0m23.0s/1m0s
-
-running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
-default   [  40% ] 900 VUs  0m24.0s/1m0s
-
-running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
-default   [  42% ] 900 VUs  0m25.0s/1m0s
-
-running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
-default   [  43% ] 900 VUs  0m26.0s/1m0s
-
-running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
-default   [  45% ] 900 VUs  0m27.0s/1m0s
-
-running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
-default   [  47% ] 900 VUs  0m28.0s/1m0s
-
-running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
-default   [  48% ] 900 VUs  0m29.0s/1m0s
-
-running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
-default   [  50% ] 900 VUs  0m30.0s/1m0s
-
-running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
-default   [  52% ] 900 VUs  0m31.0s/1m0s
-
-running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
-default   [  53% ] 900 VUs  0m32.0s/1m0s
-
-running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
-default   [  55% ] 900 VUs  0m33.0s/1m0s
-
-running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
-default   [  57% ] 900 VUs  0m34.0s/1m0s
-
-running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
-default   [  58% ] 900 VUs  0m35.0s/1m0s
-
-running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
-default   [  60% ] 900 VUs  0m36.0s/1m0s
-
-running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
-default   [  62% ] 900 VUs  0m37.0s/1m0s
-
-running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
-default   [  63% ] 900 VUs  0m38.0s/1m0s
-
-running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
-default   [  65% ] 900 VUs  0m39.0s/1m0s
-
-running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
-default   [  67% ] 900 VUs  0m40.0s/1m0s
-
-running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
-default   [  68% ] 900 VUs  0m41.0s/1m0s
-
-running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
-default   [  70% ] 900 VUs  0m42.0s/1m0s
-
-running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
-default   [  72% ] 900 VUs  0m43.0s/1m0s
-
-running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
-default   [  73% ] 900 VUs  0m44.0s/1m0s
-
-running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
-default   [  75% ] 900 VUs  0m45.0s/1m0s
-
-running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
-default   [  77% ] 900 VUs  0m46.0s/1m0s
-
-running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
-default   [  78% ] 900 VUs  0m47.0s/1m0s
-
-running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
-default   [  80% ] 900 VUs  0m48.0s/1m0s
-
-running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
-default   [  82% ] 900 VUs  0m49.0s/1m0s
-
-running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
-default   [  83% ] 900 VUs  0m50.0s/1m0s
-
-running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
-default   [  85% ] 900 VUs  0m51.0s/1m0s
-
-running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
-default   [  87% ] 900 VUs  0m52.0s/1m0s
-
-running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
-default   [  88% ] 900 VUs  0m53.0s/1m0s
-
-running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
-default   [  90% ] 900 VUs  0m54.0s/1m0s
-
-running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
-default   [  92% ] 900 VUs  0m55.0s/1m0s
-
-running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
-default   [  93% ] 900 VUs  0m56.0s/1m0s
-
-running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
-default   [  95% ] 900 VUs  0m57.0s/1m0s
-
-running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
-default   [  97% ] 900 VUs  0m58.0s/1m0s
-
-running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
-default   [  98% ] 900 VUs  0m59.0s/1m0s
-
-running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
-default   [ 100% ] 900 VUs  1m00.0s/1m0s
-
-
-  █ TOTAL RESULTS 
-
-    HTTP
-    http_req_duration..............: avg=475.76µs min=20.48µs med=315.11µs max=48.41ms p(90)=900.02µs p(95)=1.07ms
-      { expected_response:true }...: avg=475.76µs min=20.48µs med=315.11µs max=48.41ms p(90)=900.02µs p(95)=1.07ms
-    http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.611897/s
-
-    EXECUTION
-    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.05s   p(90)=1s       p(95)=1s    
-    iterations.....................: 54000  898.611897/s
-    vus............................: 900    min=900        max=900
-    vus_max........................: 900    min=900        max=900
-
-    NETWORK
-    data_received..................: 15 MB  244 kB/s
-    data_sent......................: 4.2 MB 70 kB/s
-
-
-
-
-running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
-default ✓ [ 100% ] 900 VUs  1m0s
-
-         /\      Grafana   /‾‾/  
-    /\  /  \     |\  __   /  /   
-   /  \/    \    | |/ /  /   ‾‾\ 
-  /          \   |   (  |  (‾)  |
- / __________ \  |_|\_\  \_____/ 
-
-     execution: local
-        script: benchmarkDestiny.js
-        output: -
-
-     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
-              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
-
-
-running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
-default   [   2% ] 900 VUs  0m01.0s/1m0s
-
-running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
-default   [   3% ] 900 VUs  0m02.0s/1m0s
-
-running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
-default   [   5% ] 900 VUs  0m03.0s/1m0s
-
-running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
-default   [   7% ] 900 VUs  0m04.0s/1m0s
-
-running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
-default   [   8% ] 900 VUs  0m05.0s/1m0s
-
-running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
-default   [  10% ] 900 VUs  0m06.0s/1m0s
-
-running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
-default   [  12% ] 900 VUs  0m07.0s/1m0s
-
-running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
-default   [  13% ] 900 VUs  0m08.0s/1m0s
-
-running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
-default   [  15% ] 900 VUs  0m09.0s/1m0s
-
-running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
-default   [  17% ] 900 VUs  0m10.0s/1m0s
-
-running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
-default   [  18% ] 900 VUs  0m11.0s/1m0s
-
-running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
-default   [  20% ] 900 VUs  0m12.0s/1m0s
-
-running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
-default   [  22% ] 900 VUs  0m13.0s/1m0s
-
-running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
-default   [  23% ] 900 VUs  0m14.0s/1m0s
-
-running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
-default   [  25% ] 900 VUs  0m15.0s/1m0s
-
-running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
-default   [  27% ] 900 VUs  0m16.0s/1m0s
-
-running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
-default   [  28% ] 900 VUs  0m17.0s/1m0s
-
-running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
-default   [  30% ] 900 VUs  0m18.0s/1m0s
-
-running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
-default   [  32% ] 900 VUs  0m19.0s/1m0s
-
-running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
-default   [  33% ] 900 VUs  0m20.0s/1m0s
-
-running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
-default   [  35% ] 900 VUs  0m21.0s/1m0s
-
-running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
-default   [  37% ] 900 VUs  0m22.0s/1m0s
-
-running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
-default   [  38% ] 900 VUs  0m23.0s/1m0s
-
-running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
-default   [  40% ] 900 VUs  0m24.0s/1m0s
-
-running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
-default   [  42% ] 900 VUs  0m25.0s/1m0s
-
-running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
-default   [  43% ] 900 VUs  0m26.0s/1m0s
-
-running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
-default   [  45% ] 900 VUs  0m27.0s/1m0s
-
-running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
-default   [  47% ] 900 VUs  0m28.0s/1m0s
-
-running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
-default   [  48% ] 900 VUs  0m29.0s/1m0s
-
-running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
-default   [  50% ] 900 VUs  0m30.0s/1m0s
-
-running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
-default   [  52% ] 900 VUs  0m31.0s/1m0s
-
-running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
-default   [  53% ] 900 VUs  0m32.0s/1m0s
-
-running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
-default   [  55% ] 900 VUs  0m33.0s/1m0s
-
-running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
-default   [  57% ] 900 VUs  0m34.0s/1m0s
-
-running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
-default   [  58% ] 900 VUs  0m35.0s/1m0s
-
-running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
-default   [  60% ] 900 VUs  0m36.0s/1m0s
-
-running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
-default   [  62% ] 900 VUs  0m37.0s/1m0s
-
-running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
-default   [  63% ] 900 VUs  0m38.0s/1m0s
-
-running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
-default   [  65% ] 900 VUs  0m39.0s/1m0s
-
-running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
-default   [  67% ] 900 VUs  0m40.0s/1m0s
-
-running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
-default   [  68% ] 900 VUs  0m41.0s/1m0s
-
-running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
-default   [  70% ] 900 VUs  0m42.0s/1m0s
-
-running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
-default   [  72% ] 900 VUs  0m43.0s/1m0s
-
-running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
-default   [  73% ] 900 VUs  0m44.0s/1m0s
-
-running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
-default   [  75% ] 900 VUs  0m45.0s/1m0s
-
-running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
-default   [  77% ] 900 VUs  0m46.0s/1m0s
-
-running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
-default   [  78% ] 900 VUs  0m47.0s/1m0s
-
-running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
-default   [  80% ] 900 VUs  0m48.0s/1m0s
-
-running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
-default   [  82% ] 900 VUs  0m49.0s/1m0s
-
-running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
-default   [  83% ] 900 VUs  0m50.0s/1m0s
-
-running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
-default   [  85% ] 900 VUs  0m51.0s/1m0s
-
-running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
-default   [  87% ] 900 VUs  0m52.0s/1m0s
-
-running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
-default   [  88% ] 900 VUs  0m53.0s/1m0s
-
-running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
-default   [  90% ] 900 VUs  0m54.0s/1m0s
-
-running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
-default   [  92% ] 900 VUs  0m55.0s/1m0s
-
-running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
-default   [  93% ] 900 VUs  0m56.0s/1m0s
-
-running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
-default   [  95% ] 900 VUs  0m57.0s/1m0s
-
-running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
-default   [  97% ] 900 VUs  0m58.0s/1m0s
-
-running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
-default   [  98% ] 900 VUs  0m59.0s/1m0s
-
-running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
-default   [ 100% ] 900 VUs  1m00.0s/1m0s
-
-
-  █ TOTAL RESULTS 
-
-    HTTP
-    http_req_duration..............: avg=825.74µs min=19.22µs med=720.3µs max=31.99ms p(90)=1.41ms p(95)=1.74ms
-      { expected_response:true }...: avg=825.74µs min=19.22µs med=720.3µs max=31.99ms p(90)=1.41ms p(95)=1.74ms
-    http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.514406/s
-
-    EXECUTION
-    iteration_duration.............: avg=1s       min=1s      med=1s      max=1.03s   p(90)=1s     p(95)=1s    
-    iterations.....................: 54000  898.514406/s
-    vus............................: 900    min=900        max=900
-    vus_max........................: 900    min=900        max=900
-
-    NETWORK
-    data_received..................: 15 MB  244 kB/s
-    data_sent......................: 4.2 MB 70 kB/s
-
-
-
-
-running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
-default ✓ [ 100% ] 900 VUs  1m0s
-
-         /\      Grafana   /‾‾/  
-    /\  /  \     |\  __   /  /   
-   /  \/    \    | |/ /  /   ‾‾\ 
-  /          \   |   (  |  (‾)  |
- / __________ \  |_|\_\  \_____/ 
-
-     execution: local
-        script: benchmarkDestiny.js
-        output: -
-
-     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
-              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
-
-
-running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
-default   [   2% ] 900 VUs  0m01.0s/1m0s
-
-running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
-default   [   3% ] 900 VUs  0m02.0s/1m0s
-
-running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
-default   [   5% ] 900 VUs  0m03.0s/1m0s
-
-running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
-default   [   7% ] 900 VUs  0m04.0s/1m0s
-
-running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
-default   [   8% ] 900 VUs  0m05.0s/1m0s
-
-running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
-default   [  10% ] 900 VUs  0m06.0s/1m0s
-
-running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
-default   [  12% ] 900 VUs  0m07.0s/1m0s
-
-running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
-default   [  13% ] 900 VUs  0m08.0s/1m0s
-
-running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
-default   [  15% ] 900 VUs  0m09.0s/1m0s
-
-running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
-default   [  17% ] 900 VUs  0m10.0s/1m0s
-
-running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
-default   [  18% ] 900 VUs  0m11.0s/1m0s
-
-running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
-default   [  20% ] 900 VUs  0m12.0s/1m0s
-
-running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
-default   [  22% ] 900 VUs  0m13.0s/1m0s
-
-running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
-default   [  23% ] 900 VUs  0m14.0s/1m0s
-
-running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
-default   [  25% ] 900 VUs  0m15.0s/1m0s
-
-running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
-default   [  27% ] 900 VUs  0m16.0s/1m0s
-
-running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
-default   [  28% ] 900 VUs  0m17.0s/1m0s
-
-running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
-default   [  30% ] 900 VUs  0m18.0s/1m0s
-
-running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
-default   [  32% ] 900 VUs  0m19.0s/1m0s
-
-running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
-default   [  33% ] 900 VUs  0m20.0s/1m0s
-
-running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
-default   [  35% ] 900 VUs  0m21.0s/1m0s
-
-running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
-default   [  37% ] 900 VUs  0m22.0s/1m0s
-
-running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
-default   [  38% ] 900 VUs  0m23.0s/1m0s
-
-running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
-default   [  40% ] 900 VUs  0m24.0s/1m0s
-
-running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
-default   [  42% ] 900 VUs  0m25.0s/1m0s
-
-running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
-default   [  43% ] 900 VUs  0m26.0s/1m0s
-
-running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
-default   [  45% ] 900 VUs  0m27.0s/1m0s
-
-running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
-default   [  47% ] 900 VUs  0m28.0s/1m0s
-
-running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
-default   [  48% ] 900 VUs  0m29.0s/1m0s
-
-running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
-default   [  50% ] 900 VUs  0m30.0s/1m0s
-
-running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
-default   [  52% ] 900 VUs  0m31.0s/1m0s
-
-running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
-default   [  53% ] 900 VUs  0m32.0s/1m0s
-
-running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
-default   [  55% ] 900 VUs  0m33.0s/1m0s
-
-running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
-default   [  57% ] 900 VUs  0m34.0s/1m0s
-
-running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
-default   [  58% ] 900 VUs  0m35.0s/1m0s
-
-running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
-default   [  60% ] 900 VUs  0m36.0s/1m0s
-
-running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
-default   [  62% ] 900 VUs  0m37.0s/1m0s
-
-running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
-default   [  63% ] 900 VUs  0m38.0s/1m0s
-
-running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
-default   [  65% ] 900 VUs  0m39.0s/1m0s
-
-running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
-default   [  67% ] 900 VUs  0m40.0s/1m0s
-
-running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
-default   [  68% ] 900 VUs  0m41.0s/1m0s
-
-running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
-default   [  70% ] 900 VUs  0m42.0s/1m0s
-
-running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
-default   [  72% ] 900 VUs  0m43.0s/1m0s
-
-running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
-default   [  73% ] 900 VUs  0m44.0s/1m0s
-
-running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
-default   [  75% ] 900 VUs  0m45.0s/1m0s
-
-running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
-default   [  77% ] 900 VUs  0m46.0s/1m0s
-
-running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
-default   [  78% ] 900 VUs  0m47.0s/1m0s
-
-running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
-default   [  80% ] 900 VUs  0m48.0s/1m0s
-
-running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
-default   [  82% ] 900 VUs  0m49.0s/1m0s
-
-running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
-default   [  83% ] 900 VUs  0m50.0s/1m0s
-
-running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
-default   [  85% ] 900 VUs  0m51.0s/1m0s
-
-running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
-default   [  87% ] 900 VUs  0m52.0s/1m0s
-
-running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
-default   [  88% ] 900 VUs  0m53.0s/1m0s
-
-running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
-default   [  90% ] 900 VUs  0m54.0s/1m0s
-
-running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
-default   [  92% ] 900 VUs  0m55.0s/1m0s
-
-running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
-default   [  93% ] 900 VUs  0m56.0s/1m0s
-
-running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
-default   [  95% ] 900 VUs  0m57.0s/1m0s
-
-running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
-default   [  97% ] 900 VUs  0m58.0s/1m0s
-
-running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
-default   [  98% ] 900 VUs  0m59.0s/1m0s
-
-running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
-default   [ 100% ] 900 VUs  1m00.0s/1m0s
-
-
-  █ TOTAL RESULTS 
-
-    HTTP
-    http_req_duration..............: avg=780.63µs min=20.08µs med=618.44µs max=30.41ms p(90)=1.36ms p(95)=1.77ms
-      { expected_response:true }...: avg=780.63µs min=20.08µs med=618.44µs max=30.41ms p(90)=1.36ms p(95)=1.77ms
-    http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.609708/s
+    http_reqs......................: 54000  898.579492/s
 
     EXECUTION
     iteration_duration.............: avg=1s       min=1s      med=1s       max=1.03s   p(90)=1s     p(95)=1s    
-    iterations.....................: 54000  898.609708/s
+    iterations.....................: 54000  898.579492/s
     vus............................: 900    min=900        max=900
     vus_max........................: 900    min=900        max=900
 
@@ -1073,452 +416,14 @@ default   [ 100% ] 900 VUs  1m00.0s/1m0s
   █ TOTAL RESULTS 
 
     HTTP
-    http_req_duration..............: avg=667.41µs min=21.02µs med=452.84µs max=26.33ms p(90)=1.17ms p(95)=1.36ms
-      { expected_response:true }...: avg=667.41µs min=21.02µs med=452.84µs max=26.33ms p(90)=1.17ms p(95)=1.36ms
+    http_req_duration..............: avg=612.39µs min=20.54µs med=526.88µs max=23.11ms p(90)=1.03ms p(95)=1.25ms
+      { expected_response:true }...: avg=612.39µs min=20.54µs med=526.88µs max=23.11ms p(90)=1.03ms p(95)=1.25ms
     http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.626055/s
+    http_reqs......................: 54000  898.715424/s
 
     EXECUTION
-    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.03s   p(90)=1s     p(95)=1s    
-    iterations.....................: 54000  898.626055/s
-    vus............................: 900    min=900        max=900
-    vus_max........................: 900    min=900        max=900
-
-    NETWORK
-    data_received..................: 15 MB  244 kB/s
-    data_sent......................: 4.2 MB 70 kB/s
-
-
-
-
-running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
-default ✓ [ 100% ] 900 VUs  1m0s
-
-         /\      Grafana   /‾‾/  
-    /\  /  \     |\  __   /  /   
-   /  \/    \    | |/ /  /   ‾‾\ 
-  /          \   |   (  |  (‾)  |
- / __________ \  |_|\_\  \_____/ 
-
-     execution: local
-        script: benchmarkDestiny.js
-        output: -
-
-     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
-              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
-
-
-running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
-default   [   2% ] 900 VUs  0m01.0s/1m0s
-
-running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
-default   [   3% ] 900 VUs  0m02.0s/1m0s
-
-running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
-default   [   5% ] 900 VUs  0m03.0s/1m0s
-
-running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
-default   [   7% ] 900 VUs  0m04.0s/1m0s
-
-running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
-default   [   8% ] 900 VUs  0m05.0s/1m0s
-
-running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
-default   [  10% ] 900 VUs  0m06.0s/1m0s
-
-running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
-default   [  12% ] 900 VUs  0m07.0s/1m0s
-
-running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
-default   [  13% ] 900 VUs  0m08.0s/1m0s
-
-running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
-default   [  15% ] 900 VUs  0m09.0s/1m0s
-
-running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
-default   [  17% ] 900 VUs  0m10.0s/1m0s
-
-running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
-default   [  18% ] 900 VUs  0m11.0s/1m0s
-
-running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
-default   [  20% ] 900 VUs  0m12.0s/1m0s
-
-running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
-default   [  22% ] 900 VUs  0m13.0s/1m0s
-
-running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
-default   [  23% ] 900 VUs  0m14.0s/1m0s
-
-running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
-default   [  25% ] 900 VUs  0m15.0s/1m0s
-
-running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
-default   [  27% ] 900 VUs  0m16.0s/1m0s
-
-running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
-default   [  28% ] 900 VUs  0m17.0s/1m0s
-
-running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
-default   [  30% ] 900 VUs  0m18.0s/1m0s
-
-running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
-default   [  32% ] 900 VUs  0m19.0s/1m0s
-
-running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
-default   [  33% ] 900 VUs  0m20.0s/1m0s
-
-running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
-default   [  35% ] 900 VUs  0m21.0s/1m0s
-
-running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
-default   [  37% ] 900 VUs  0m22.0s/1m0s
-
-running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
-default   [  38% ] 900 VUs  0m23.0s/1m0s
-
-running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
-default   [  40% ] 900 VUs  0m24.0s/1m0s
-
-running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
-default   [  42% ] 900 VUs  0m25.0s/1m0s
-
-running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
-default   [  43% ] 900 VUs  0m26.0s/1m0s
-
-running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
-default   [  45% ] 900 VUs  0m27.0s/1m0s
-
-running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
-default   [  47% ] 900 VUs  0m28.0s/1m0s
-
-running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
-default   [  48% ] 900 VUs  0m29.0s/1m0s
-
-running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
-default   [  50% ] 900 VUs  0m30.0s/1m0s
-
-running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
-default   [  52% ] 900 VUs  0m31.0s/1m0s
-
-running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
-default   [  53% ] 900 VUs  0m32.0s/1m0s
-
-running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
-default   [  55% ] 900 VUs  0m33.0s/1m0s
-
-running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
-default   [  57% ] 900 VUs  0m34.0s/1m0s
-
-running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
-default   [  58% ] 900 VUs  0m35.0s/1m0s
-
-running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
-default   [  60% ] 900 VUs  0m36.0s/1m0s
-
-running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
-default   [  62% ] 900 VUs  0m37.0s/1m0s
-
-running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
-default   [  63% ] 900 VUs  0m38.0s/1m0s
-
-running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
-default   [  65% ] 900 VUs  0m39.0s/1m0s
-
-running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
-default   [  67% ] 900 VUs  0m40.0s/1m0s
-
-running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
-default   [  68% ] 900 VUs  0m41.0s/1m0s
-
-running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
-default   [  70% ] 900 VUs  0m42.0s/1m0s
-
-running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
-default   [  72% ] 900 VUs  0m43.0s/1m0s
-
-running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
-default   [  73% ] 900 VUs  0m44.0s/1m0s
-
-running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
-default   [  75% ] 900 VUs  0m45.0s/1m0s
-
-running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
-default   [  77% ] 900 VUs  0m46.0s/1m0s
-
-running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
-default   [  78% ] 900 VUs  0m47.0s/1m0s
-
-running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
-default   [  80% ] 900 VUs  0m48.0s/1m0s
-
-running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
-default   [  82% ] 900 VUs  0m49.0s/1m0s
-
-running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
-default   [  83% ] 900 VUs  0m50.0s/1m0s
-
-running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
-default   [  85% ] 900 VUs  0m51.0s/1m0s
-
-running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
-default   [  87% ] 900 VUs  0m52.0s/1m0s
-
-running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
-default   [  88% ] 900 VUs  0m53.0s/1m0s
-
-running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
-default   [  90% ] 900 VUs  0m54.0s/1m0s
-
-running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
-default   [  92% ] 900 VUs  0m55.0s/1m0s
-
-running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
-default   [  93% ] 900 VUs  0m56.0s/1m0s
-
-running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
-default   [  95% ] 900 VUs  0m57.0s/1m0s
-
-running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
-default   [  97% ] 900 VUs  0m58.0s/1m0s
-
-running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
-default   [  98% ] 900 VUs  0m59.0s/1m0s
-
-running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
-default   [ 100% ] 900 VUs  1m00.0s/1m0s
-
-
-  █ TOTAL RESULTS 
-
-    HTTP
-    http_req_duration..............: avg=794.26µs min=20.35µs med=529.39µs max=27.84ms p(90)=1.34ms p(95)=1.9ms
-      { expected_response:true }...: avg=794.26µs min=20.35µs med=529.39µs max=27.84ms p(90)=1.34ms p(95)=1.9ms
-    http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.567723/s
-
-    EXECUTION
-    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.03s   p(90)=1s     p(95)=1s   
-    iterations.....................: 54000  898.567723/s
-    vus............................: 900    min=900        max=900
-    vus_max........................: 900    min=900        max=900
-
-    NETWORK
-    data_received..................: 15 MB  244 kB/s
-    data_sent......................: 4.2 MB 70 kB/s
-
-
-
-
-running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
-default ✓ [ 100% ] 900 VUs  1m0s
-
-         /\      Grafana   /‾‾/  
-    /\  /  \     |\  __   /  /   
-   /  \/    \    | |/ /  /   ‾‾\ 
-  /          \   |   (  |  (‾)  |
- / __________ \  |_|\_\  \_____/ 
-
-     execution: local
-        script: benchmarkDestiny.js
-        output: -
-
-     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
-              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
-
-
-running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
-default   [   2% ] 900 VUs  0m01.0s/1m0s
-
-running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
-default   [   3% ] 900 VUs  0m02.0s/1m0s
-
-running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
-default   [   5% ] 900 VUs  0m03.0s/1m0s
-
-running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
-default   [   7% ] 900 VUs  0m04.0s/1m0s
-
-running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
-default   [   8% ] 900 VUs  0m05.0s/1m0s
-
-running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
-default   [  10% ] 900 VUs  0m06.0s/1m0s
-
-running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
-default   [  12% ] 900 VUs  0m07.0s/1m0s
-
-running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
-default   [  13% ] 900 VUs  0m08.0s/1m0s
-
-running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
-default   [  15% ] 900 VUs  0m09.0s/1m0s
-
-running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
-default   [  17% ] 900 VUs  0m10.0s/1m0s
-
-running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
-default   [  18% ] 900 VUs  0m11.0s/1m0s
-
-running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
-default   [  20% ] 900 VUs  0m12.0s/1m0s
-
-running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
-default   [  22% ] 900 VUs  0m13.0s/1m0s
-
-running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
-default   [  23% ] 900 VUs  0m14.0s/1m0s
-
-running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
-default   [  25% ] 900 VUs  0m15.0s/1m0s
-
-running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
-default   [  27% ] 900 VUs  0m16.0s/1m0s
-
-running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
-default   [  28% ] 900 VUs  0m17.0s/1m0s
-
-running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
-default   [  30% ] 900 VUs  0m18.0s/1m0s
-
-running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
-default   [  32% ] 900 VUs  0m19.0s/1m0s
-
-running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
-default   [  33% ] 900 VUs  0m20.0s/1m0s
-
-running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
-default   [  35% ] 900 VUs  0m21.0s/1m0s
-
-running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
-default   [  37% ] 900 VUs  0m22.0s/1m0s
-
-running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
-default   [  38% ] 900 VUs  0m23.0s/1m0s
-
-running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
-default   [  40% ] 900 VUs  0m24.0s/1m0s
-
-running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
-default   [  42% ] 900 VUs  0m25.0s/1m0s
-
-running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
-default   [  43% ] 900 VUs  0m26.0s/1m0s
-
-running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
-default   [  45% ] 900 VUs  0m27.0s/1m0s
-
-running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
-default   [  47% ] 900 VUs  0m28.0s/1m0s
-
-running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
-default   [  48% ] 900 VUs  0m29.0s/1m0s
-
-running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
-default   [  50% ] 900 VUs  0m30.0s/1m0s
-
-running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
-default   [  52% ] 900 VUs  0m31.0s/1m0s
-
-running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
-default   [  53% ] 900 VUs  0m32.0s/1m0s
-
-running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
-default   [  55% ] 900 VUs  0m33.0s/1m0s
-
-running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
-default   [  57% ] 900 VUs  0m34.0s/1m0s
-
-running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
-default   [  58% ] 900 VUs  0m35.0s/1m0s
-
-running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
-default   [  60% ] 900 VUs  0m36.0s/1m0s
-
-running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
-default   [  62% ] 900 VUs  0m37.0s/1m0s
-
-running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
-default   [  63% ] 900 VUs  0m38.0s/1m0s
-
-running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
-default   [  65% ] 900 VUs  0m39.0s/1m0s
-
-running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
-default   [  67% ] 900 VUs  0m40.0s/1m0s
-
-running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
-default   [  68% ] 900 VUs  0m41.0s/1m0s
-
-running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
-default   [  70% ] 900 VUs  0m42.0s/1m0s
-
-running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
-default   [  72% ] 900 VUs  0m43.0s/1m0s
-
-running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
-default   [  73% ] 900 VUs  0m44.0s/1m0s
-
-running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
-default   [  75% ] 900 VUs  0m45.0s/1m0s
-
-running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
-default   [  77% ] 900 VUs  0m46.0s/1m0s
-
-running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
-default   [  78% ] 900 VUs  0m47.0s/1m0s
-
-running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
-default   [  80% ] 900 VUs  0m48.0s/1m0s
-
-running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
-default   [  82% ] 900 VUs  0m49.0s/1m0s
-
-running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
-default   [  83% ] 900 VUs  0m50.0s/1m0s
-
-running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
-default   [  85% ] 900 VUs  0m51.0s/1m0s
-
-running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
-default   [  87% ] 900 VUs  0m52.0s/1m0s
-
-running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
-default   [  88% ] 900 VUs  0m53.0s/1m0s
-
-running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
-default   [  90% ] 900 VUs  0m54.0s/1m0s
-
-running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
-default   [  92% ] 900 VUs  0m55.0s/1m0s
-
-running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
-default   [  93% ] 900 VUs  0m56.0s/1m0s
-
-running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
-default   [  95% ] 900 VUs  0m57.0s/1m0s
-
-running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
-default   [  97% ] 900 VUs  0m58.0s/1m0s
-
-running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
-default   [  98% ] 900 VUs  0m59.0s/1m0s
-
-running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
-default   [ 100% ] 900 VUs  1m00.0s/1m0s
-
-
-  █ TOTAL RESULTS 
-
-    HTTP
-    http_req_duration..............: avg=751.49µs min=21.9µs med=665.82µs max=27.99ms p(90)=1.32ms p(95)=1.56ms
-      { expected_response:true }...: avg=751.49µs min=21.9µs med=665.82µs max=27.99ms p(90)=1.32ms p(95)=1.56ms
-    http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.753597/s
-
-    EXECUTION
-    iteration_duration.............: avg=1s       min=1s     med=1s       max=1.02s   p(90)=1s     p(95)=1s    
-    iterations.....................: 54000  898.753597/s
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.04s   p(90)=1s     p(95)=1s    
+    iterations.....................: 54000  898.715424/s
     vus............................: 900    min=900        max=900
     vus_max........................: 900    min=900        max=900
 
@@ -1730,14 +635,14 @@ default   [ 100% ] 900 VUs  1m00.0s/1m0s
   █ TOTAL RESULTS 
 
     HTTP
-    http_req_duration..............: avg=639.75µs min=21.19µs med=476.89µs max=24.67ms p(90)=1.1ms p(95)=1.4ms
-      { expected_response:true }...: avg=639.75µs min=21.19µs med=476.89µs max=24.67ms p(90)=1.1ms p(95)=1.4ms
+    http_req_duration..............: avg=748.73µs min=20.93µs med=570.32µs max=25.71ms p(90)=1.33ms p(95)=1.79ms
+      { expected_response:true }...: avg=748.73µs min=20.93µs med=570.32µs max=25.71ms p(90)=1.33ms p(95)=1.79ms
     http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.676077/s
+    http_reqs......................: 54000  898.538803/s
 
     EXECUTION
-    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.03s   p(90)=1s    p(95)=1s   
-    iterations.....................: 54000  898.676077/s
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.04s   p(90)=1s     p(95)=1s    
+    iterations.....................: 54000  898.538803/s
     vus............................: 900    min=900        max=900
     vus_max........................: 900    min=900        max=900
 
@@ -1949,14 +854,452 @@ default   [ 100% ] 900 VUs  1m00.0s/1m0s
   █ TOTAL RESULTS 
 
     HTTP
-    http_req_duration..............: avg=606.84µs min=20.18µs med=514.75µs max=25.79ms p(90)=1.18ms p(95)=1.36ms
-      { expected_response:true }...: avg=606.84µs min=20.18µs med=514.75µs max=25.79ms p(90)=1.18ms p(95)=1.36ms
+    http_req_duration..............: avg=730.45µs min=20.27µs med=523.72µs max=20.41ms p(90)=1.46ms p(95)=2.26ms
+      { expected_response:true }...: avg=730.45µs min=20.27µs med=523.72µs max=20.41ms p(90)=1.46ms p(95)=2.26ms
     http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.874212/s
+    http_reqs......................: 54000  898.673058/s
 
     EXECUTION
     iteration_duration.............: avg=1s       min=1s      med=1s       max=1.02s   p(90)=1s     p(95)=1s    
-    iterations.....................: 54000  898.874212/s
+    iterations.....................: 54000  898.673058/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  244 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkDestiny.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=620.88µs min=20.4µs med=520.53µs max=27.84ms p(90)=1.12ms p(95)=1.27ms
+      { expected_response:true }...: avg=620.88µs min=20.4µs med=520.53µs max=27.84ms p(90)=1.12ms p(95)=1.27ms
+    http_req_failed................: 0.00%  0 out of 54000
+    http_reqs......................: 54000  898.659588/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s       min=1s     med=1s       max=1.04s   p(90)=1s     p(95)=1s    
+    iterations.....................: 54000  898.659588/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  244 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkDestiny.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=487.73µs min=20.06µs med=333.38µs max=50.44ms p(90)=962.03µs p(95)=1.26ms
+      { expected_response:true }...: avg=487.73µs min=20.06µs med=333.38µs max=50.44ms p(90)=962.03µs p(95)=1.26ms
+    http_req_failed................: 0.00%  0 out of 54000
+    http_reqs......................: 54000  898.716124/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.05s   p(90)=1s       p(95)=1s    
+    iterations.....................: 54000  898.716124/s
     vus............................: 900    min=900        max=900
     vus_max........................: 900    min=900        max=900
 
@@ -2168,14 +1511,671 @@ default   [ 100% ] 900 VUs  1m00.0s/1m0s
   █ TOTAL RESULTS 
 
     HTTP
-    http_req_duration..............: avg=875.6µs min=22.55µs med=701.89µs max=43.63ms p(90)=1.5ms p(95)=1.85ms
-      { expected_response:true }...: avg=875.6µs min=22.55µs med=701.89µs max=43.63ms p(90)=1.5ms p(95)=1.85ms
+    http_req_duration..............: avg=749µs min=19.61µs med=618.34µs max=19.95ms p(90)=1.25ms p(95)=1.51ms
+      { expected_response:true }...: avg=749µs min=19.61µs med=618.34µs max=19.95ms p(90)=1.25ms p(95)=1.51ms
     http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.381843/s
+    http_reqs......................: 54000  898.544984/s
 
     EXECUTION
-    iteration_duration.............: avg=1s      min=1s      med=1s       max=1.04s   p(90)=1s    p(95)=1s    
-    iterations.....................: 54000  898.381843/s
+    iteration_duration.............: avg=1s    min=1s      med=1s       max=1.04s   p(90)=1s     p(95)=1s    
+    iterations.....................: 54000  898.544984/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  244 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkDestiny.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=805.66µs min=20.04µs med=612.95µs max=26.74ms p(90)=1.38ms p(95)=1.65ms
+      { expected_response:true }...: avg=805.66µs min=20.04µs med=612.95µs max=26.74ms p(90)=1.38ms p(95)=1.65ms
+    http_req_failed................: 0.00%  0 out of 54000
+    http_reqs......................: 54000  898.628751/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.03s   p(90)=1s     p(95)=1s    
+    iterations.....................: 54000  898.628751/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  244 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkDestiny.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=588.25µs min=20.87µs med=384.5µs max=41.63ms p(90)=957.34µs p(95)=1.18ms
+      { expected_response:true }...: avg=588.25µs min=20.87µs med=384.5µs max=41.63ms p(90)=957.34µs p(95)=1.18ms
+    http_req_failed................: 0.00%  0 out of 54000
+    http_reqs......................: 54000  898.681564/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s       min=1s      med=1s      max=1.04s   p(90)=1s       p(95)=1s    
+    iterations.....................: 54000  898.681564/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  244 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkDestiny.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=807.98µs min=21.35µs med=632.66µs max=34.24ms p(90)=1.46ms p(95)=1.79ms
+      { expected_response:true }...: avg=807.98µs min=21.35µs med=632.66µs max=34.24ms p(90)=1.46ms p(95)=1.79ms
+    http_req_failed................: 0.00%  0 out of 54000
+    http_reqs......................: 54000  898.458078/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.04s   p(90)=1s     p(95)=1s    
+    iterations.....................: 54000  898.458078/s
     vus............................: 900    min=900        max=900
     vus_max........................: 900    min=900        max=900
 

--- a/Benchmarks/results_hummingbird.txt
+++ b/Benchmarks/results_hummingbird.txt
@@ -16,431 +16,206 @@
 running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
 default   [   2% ] 900 VUs  0m01.0s/1m0s
 
-running (0m02.0s), 900/900 VUs, 828 complete and 0 interrupted iterations
+running (0m02.0s), 900/900 VUs, 861 complete and 0 interrupted iterations
 default   [   3% ] 900 VUs  0m02.0s/1m0s
 
-running (0m03.0s), 900/900 VUs, 1576 complete and 0 interrupted iterations
+running (0m03.0s), 900/900 VUs, 1761 complete and 0 interrupted iterations
 default   [   5% ] 900 VUs  0m03.0s/1m0s
 
-running (0m04.0s), 900/900 VUs, 2476 complete and 0 interrupted iterations
+running (0m04.0s), 900/900 VUs, 2661 complete and 0 interrupted iterations
 default   [   7% ] 900 VUs  0m04.0s/1m0s
 
-running (0m05.0s), 900/900 VUs, 3376 complete and 0 interrupted iterations
+running (0m05.0s), 900/900 VUs, 3561 complete and 0 interrupted iterations
 default   [   8% ] 900 VUs  0m05.0s/1m0s
 
-running (0m06.0s), 900/900 VUs, 4276 complete and 0 interrupted iterations
+running (0m06.0s), 900/900 VUs, 4461 complete and 0 interrupted iterations
 default   [  10% ] 900 VUs  0m06.0s/1m0s
 
-running (0m07.0s), 900/900 VUs, 5176 complete and 0 interrupted iterations
+running (0m07.0s), 900/900 VUs, 5361 complete and 0 interrupted iterations
 default   [  12% ] 900 VUs  0m07.0s/1m0s
 
-running (0m08.0s), 900/900 VUs, 6076 complete and 0 interrupted iterations
+running (0m08.0s), 900/900 VUs, 6261 complete and 0 interrupted iterations
 default   [  13% ] 900 VUs  0m08.0s/1m0s
 
-running (0m09.0s), 900/900 VUs, 6976 complete and 0 interrupted iterations
+running (0m09.0s), 900/900 VUs, 7161 complete and 0 interrupted iterations
 default   [  15% ] 900 VUs  0m09.0s/1m0s
 
-running (0m10.0s), 900/900 VUs, 7876 complete and 0 interrupted iterations
+running (0m10.0s), 900/900 VUs, 8061 complete and 0 interrupted iterations
 default   [  17% ] 900 VUs  0m10.0s/1m0s
 
-running (0m11.0s), 900/900 VUs, 8776 complete and 0 interrupted iterations
+running (0m11.0s), 900/900 VUs, 8961 complete and 0 interrupted iterations
 default   [  18% ] 900 VUs  0m11.0s/1m0s
 
-running (0m12.0s), 900/900 VUs, 9676 complete and 0 interrupted iterations
+running (0m12.0s), 900/900 VUs, 9861 complete and 0 interrupted iterations
 default   [  20% ] 900 VUs  0m12.0s/1m0s
 
-running (0m13.0s), 900/900 VUs, 10576 complete and 0 interrupted iterations
+running (0m13.0s), 900/900 VUs, 10761 complete and 0 interrupted iterations
 default   [  22% ] 900 VUs  0m13.0s/1m0s
 
-running (0m14.0s), 900/900 VUs, 11476 complete and 0 interrupted iterations
+running (0m14.0s), 900/900 VUs, 11661 complete and 0 interrupted iterations
 default   [  23% ] 900 VUs  0m14.0s/1m0s
 
-running (0m15.0s), 900/900 VUs, 12376 complete and 0 interrupted iterations
+running (0m15.0s), 900/900 VUs, 12561 complete and 0 interrupted iterations
 default   [  25% ] 900 VUs  0m15.0s/1m0s
 
-running (0m16.0s), 900/900 VUs, 13276 complete and 0 interrupted iterations
+running (0m16.0s), 900/900 VUs, 13461 complete and 0 interrupted iterations
 default   [  27% ] 900 VUs  0m16.0s/1m0s
 
-running (0m17.0s), 900/900 VUs, 14176 complete and 0 interrupted iterations
+running (0m17.0s), 900/900 VUs, 14361 complete and 0 interrupted iterations
 default   [  28% ] 900 VUs  0m17.0s/1m0s
 
-running (0m18.0s), 900/900 VUs, 15024 complete and 0 interrupted iterations
+running (0m18.0s), 900/900 VUs, 15261 complete and 0 interrupted iterations
 default   [  30% ] 900 VUs  0m18.0s/1m0s
 
-running (0m19.0s), 900/900 VUs, 15920 complete and 0 interrupted iterations
+running (0m19.0s), 900/900 VUs, 16161 complete and 0 interrupted iterations
 default   [  32% ] 900 VUs  0m19.0s/1m0s
 
-running (0m20.0s), 900/900 VUs, 16820 complete and 0 interrupted iterations
+running (0m20.0s), 900/900 VUs, 17061 complete and 0 interrupted iterations
 default   [  33% ] 900 VUs  0m20.0s/1m0s
 
-running (0m21.0s), 900/900 VUs, 17720 complete and 0 interrupted iterations
+running (0m21.0s), 900/900 VUs, 17961 complete and 0 interrupted iterations
 default   [  35% ] 900 VUs  0m21.0s/1m0s
 
-running (0m22.0s), 900/900 VUs, 18620 complete and 0 interrupted iterations
+running (0m22.0s), 900/900 VUs, 18861 complete and 0 interrupted iterations
 default   [  37% ] 900 VUs  0m22.0s/1m0s
 
-running (0m23.0s), 900/900 VUs, 19520 complete and 0 interrupted iterations
+running (0m23.0s), 900/900 VUs, 19761 complete and 0 interrupted iterations
 default   [  38% ] 900 VUs  0m23.0s/1m0s
 
-running (0m24.0s), 900/900 VUs, 20420 complete and 0 interrupted iterations
+running (0m24.0s), 900/900 VUs, 20661 complete and 0 interrupted iterations
 default   [  40% ] 900 VUs  0m24.0s/1m0s
 
-running (0m25.0s), 900/900 VUs, 21320 complete and 0 interrupted iterations
+running (0m25.0s), 900/900 VUs, 21561 complete and 0 interrupted iterations
 default   [  42% ] 900 VUs  0m25.0s/1m0s
 
-running (0m26.0s), 900/900 VUs, 22220 complete and 0 interrupted iterations
+running (0m26.0s), 900/900 VUs, 22461 complete and 0 interrupted iterations
 default   [  43% ] 900 VUs  0m26.0s/1m0s
 
-running (0m27.0s), 900/900 VUs, 23120 complete and 0 interrupted iterations
+running (0m27.0s), 900/900 VUs, 23361 complete and 0 interrupted iterations
 default   [  45% ] 900 VUs  0m27.0s/1m0s
 
-running (0m28.0s), 900/900 VUs, 24020 complete and 0 interrupted iterations
+running (0m28.0s), 900/900 VUs, 24261 complete and 0 interrupted iterations
 default   [  47% ] 900 VUs  0m28.0s/1m0s
 
-running (0m29.0s), 900/900 VUs, 24920 complete and 0 interrupted iterations
+running (0m29.0s), 900/900 VUs, 25161 complete and 0 interrupted iterations
 default   [  48% ] 900 VUs  0m29.0s/1m0s
 
-running (0m30.0s), 900/900 VUs, 25820 complete and 0 interrupted iterations
+running (0m30.0s), 900/900 VUs, 26061 complete and 0 interrupted iterations
 default   [  50% ] 900 VUs  0m30.0s/1m0s
 
-running (0m31.0s), 900/900 VUs, 26720 complete and 0 interrupted iterations
+running (0m31.0s), 900/900 VUs, 26961 complete and 0 interrupted iterations
 default   [  52% ] 900 VUs  0m31.0s/1m0s
 
-running (0m32.0s), 900/900 VUs, 27620 complete and 0 interrupted iterations
+running (0m32.0s), 900/900 VUs, 27861 complete and 0 interrupted iterations
 default   [  53% ] 900 VUs  0m32.0s/1m0s
 
-running (0m33.0s), 900/900 VUs, 28520 complete and 0 interrupted iterations
+running (0m33.0s), 900/900 VUs, 28761 complete and 0 interrupted iterations
 default   [  55% ] 900 VUs  0m33.0s/1m0s
 
-running (0m34.0s), 900/900 VUs, 29418 complete and 0 interrupted iterations
+running (0m34.0s), 900/900 VUs, 29661 complete and 0 interrupted iterations
 default   [  57% ] 900 VUs  0m34.0s/1m0s
 
-running (0m35.0s), 900/900 VUs, 30063 complete and 0 interrupted iterations
+running (0m35.0s), 900/900 VUs, 30561 complete and 0 interrupted iterations
 default   [  58% ] 900 VUs  0m35.0s/1m0s
 
-running (0m36.0s), 900/900 VUs, 30797 complete and 0 interrupted iterations
+running (0m36.0s), 900/900 VUs, 31461 complete and 0 interrupted iterations
 default   [  60% ] 900 VUs  0m36.0s/1m0s
 
-running (0m37.0s), 900/900 VUs, 31662 complete and 0 interrupted iterations
+running (0m37.0s), 900/900 VUs, 32361 complete and 0 interrupted iterations
 default   [  62% ] 900 VUs  0m37.0s/1m0s
 
-running (0m38.0s), 900/900 VUs, 32547 complete and 0 interrupted iterations
+running (0m38.0s), 900/900 VUs, 33261 complete and 0 interrupted iterations
 default   [  63% ] 900 VUs  0m38.0s/1m0s
 
-running (0m39.0s), 900/900 VUs, 33447 complete and 0 interrupted iterations
+running (0m39.0s), 900/900 VUs, 34161 complete and 0 interrupted iterations
 default   [  65% ] 900 VUs  0m39.0s/1m0s
 
-running (0m40.0s), 900/900 VUs, 34346 complete and 0 interrupted iterations
+running (0m40.0s), 900/900 VUs, 35061 complete and 0 interrupted iterations
 default   [  67% ] 900 VUs  0m40.0s/1m0s
 
-running (0m41.0s), 900/900 VUs, 35245 complete and 0 interrupted iterations
+running (0m41.0s), 900/900 VUs, 35961 complete and 0 interrupted iterations
 default   [  68% ] 900 VUs  0m41.0s/1m0s
 
-running (0m42.0s), 900/900 VUs, 36140 complete and 0 interrupted iterations
+running (0m42.0s), 900/900 VUs, 36861 complete and 0 interrupted iterations
 default   [  70% ] 900 VUs  0m42.0s/1m0s
 
-running (0m43.0s), 900/900 VUs, 37038 complete and 0 interrupted iterations
+running (0m43.0s), 900/900 VUs, 37761 complete and 0 interrupted iterations
 default   [  72% ] 900 VUs  0m43.0s/1m0s
 
-running (0m44.0s), 900/900 VUs, 37935 complete and 0 interrupted iterations
+running (0m44.0s), 900/900 VUs, 38661 complete and 0 interrupted iterations
 default   [  73% ] 900 VUs  0m44.0s/1m0s
 
-running (0m45.0s), 900/900 VUs, 38830 complete and 0 interrupted iterations
+running (0m45.0s), 900/900 VUs, 39561 complete and 0 interrupted iterations
 default   [  75% ] 900 VUs  0m45.0s/1m0s
 
-running (0m46.0s), 900/900 VUs, 39720 complete and 0 interrupted iterations
+running (0m46.0s), 900/900 VUs, 40461 complete and 0 interrupted iterations
 default   [  77% ] 900 VUs  0m46.0s/1m0s
 
-running (0m47.0s), 900/900 VUs, 40617 complete and 0 interrupted iterations
+running (0m47.0s), 900/900 VUs, 41361 complete and 0 interrupted iterations
 default   [  78% ] 900 VUs  0m47.0s/1m0s
 
-running (0m48.0s), 900/900 VUs, 41502 complete and 0 interrupted iterations
+running (0m48.0s), 900/900 VUs, 42261 complete and 0 interrupted iterations
 default   [  80% ] 900 VUs  0m48.0s/1m0s
 
-running (0m49.0s), 900/900 VUs, 42385 complete and 0 interrupted iterations
+running (0m49.0s), 900/900 VUs, 43161 complete and 0 interrupted iterations
 default   [  82% ] 900 VUs  0m49.0s/1m0s
 
-running (0m50.0s), 900/900 VUs, 43270 complete and 0 interrupted iterations
+running (0m50.0s), 900/900 VUs, 44061 complete and 0 interrupted iterations
 default   [  83% ] 900 VUs  0m50.0s/1m0s
 
-running (0m51.0s), 900/900 VUs, 44170 complete and 0 interrupted iterations
+running (0m51.0s), 900/900 VUs, 44961 complete and 0 interrupted iterations
 default   [  85% ] 900 VUs  0m51.0s/1m0s
 
-running (0m52.0s), 900/900 VUs, 45070 complete and 0 interrupted iterations
+running (0m52.0s), 900/900 VUs, 45861 complete and 0 interrupted iterations
 default   [  87% ] 900 VUs  0m52.0s/1m0s
 
-running (0m53.0s), 900/900 VUs, 45970 complete and 0 interrupted iterations
+running (0m53.0s), 900/900 VUs, 46761 complete and 0 interrupted iterations
 default   [  88% ] 900 VUs  0m53.0s/1m0s
 
-running (0m54.0s), 900/900 VUs, 46870 complete and 0 interrupted iterations
+running (0m54.0s), 900/900 VUs, 47661 complete and 0 interrupted iterations
 default   [  90% ] 900 VUs  0m54.0s/1m0s
 
-running (0m55.0s), 900/900 VUs, 47770 complete and 0 interrupted iterations
+running (0m55.0s), 900/900 VUs, 48561 complete and 0 interrupted iterations
 default   [  92% ] 900 VUs  0m55.0s/1m0s
 
-running (0m56.0s), 900/900 VUs, 48635 complete and 0 interrupted iterations
+running (0m56.0s), 900/900 VUs, 49461 complete and 0 interrupted iterations
 default   [  93% ] 900 VUs  0m56.0s/1m0s
 
-running (0m57.0s), 900/900 VUs, 49522 complete and 0 interrupted iterations
+running (0m57.0s), 900/900 VUs, 50361 complete and 0 interrupted iterations
 default   [  95% ] 900 VUs  0m57.0s/1m0s
 
-running (0m58.0s), 900/900 VUs, 50410 complete and 0 interrupted iterations
+running (0m58.0s), 900/900 VUs, 51261 complete and 0 interrupted iterations
 default   [  97% ] 900 VUs  0m58.0s/1m0s
 
-running (0m59.0s), 900/900 VUs, 51296 complete and 0 interrupted iterations
+running (0m59.0s), 900/900 VUs, 52161 complete and 0 interrupted iterations
 default   [  98% ] 900 VUs  0m59.0s/1m0s
 
-running (1m00.0s), 900/900 VUs, 52173 complete and 0 interrupted iterations
+running (1m00.0s), 900/900 VUs, 53061 complete and 0 interrupted iterations
 default   [ 100% ] 900 VUs  1m00.0s/1m0s
-
-running (1m01.0s), 052/900 VUs, 53059 complete and 0 interrupted iterations
-default ↓ [ 100% ] 900 VUs  1m0s
 
 
   █ TOTAL RESULTS 
 
     HTTP
-    http_req_duration..............: avg=1.62ms min=0s       med=237.21µs max=207.36ms p(90)=3.74ms p(95)=7.27ms 
-      { expected_response:true }...: avg=3.06ms min=103.85µs med=1.45ms   max=207.36ms p(90)=7.06ms p(95)=10.95ms
-    http_req_failed................: 46.84% 24879 out of 53111
-    http_reqs......................: 53111  870.446488/s
+    http_req_duration..............: avg=1ms min=56.68µs med=679.33µs max=31.48ms p(90)=2.02ms p(95)=2.82ms
+      { expected_response:true }...: avg=1ms min=56.68µs med=679.33µs max=31.48ms p(90)=2.02ms p(95)=2.82ms
+    http_req_failed................: 0.00%  0 out of 53961
+    http_reqs......................: 53961  897.421857/s
 
     EXECUTION
-    iteration_duration.............: avg=1.02s  min=1s       med=1s       max=2.16s    p(90)=1.03s  p(95)=1.08s  
-    iterations.....................: 53111  870.446488/s
-    vus............................: 52     min=52             max=900
-    vus_max........................: 900    min=900            max=900
+    iteration_duration.............: avg=1s  min=1s      med=1s       max=2.05s   p(90)=1s     p(95)=1s    
+    iterations.....................: 53961  897.421857/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
 
     NETWORK
-    data_received..................: 7.6 MB 125 kB/s
-    data_sent......................: 2.2 MB 36 kB/s
+    data_received..................: 15 MB  247 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
 
 
 
 
-running (1m01.0s), 000/900 VUs, 53111 complete and 0 interrupted iterations
-default ✓ [ 100% ] 900 VUs  1m0s
-
-         /\      Grafana   /‾‾/  
-    /\  /  \     |\  __   /  /   
-   /  \/    \    | |/ /  /   ‾‾\ 
-  /          \   |   (  |  (‾)  |
- / __________ \  |_|\_\  \_____/ 
-
-     execution: local
-        script: benchmarkHummingbird.js
-        output: -
-
-     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
-              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
-
-
-running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
-default   [   2% ] 900 VUs  0m01.0s/1m0s
-
-running (0m02.0s), 900/900 VUs, 594 complete and 0 interrupted iterations
-default   [   3% ] 900 VUs  0m02.0s/1m0s
-
-running (0m03.0s), 900/900 VUs, 1447 complete and 0 interrupted iterations
-default   [   5% ] 900 VUs  0m03.0s/1m0s
-
-running (0m04.0s), 900/900 VUs, 2347 complete and 0 interrupted iterations
-default   [   7% ] 900 VUs  0m04.0s/1m0s
-
-running (0m05.0s), 900/900 VUs, 3247 complete and 0 interrupted iterations
-default   [   8% ] 900 VUs  0m05.0s/1m0s
-
-running (0m06.0s), 900/900 VUs, 4147 complete and 0 interrupted iterations
-default   [  10% ] 900 VUs  0m06.0s/1m0s
-
-running (0m07.0s), 900/900 VUs, 5047 complete and 0 interrupted iterations
-default   [  12% ] 900 VUs  0m07.0s/1m0s
-
-running (0m08.0s), 900/900 VUs, 5947 complete and 0 interrupted iterations
-default   [  13% ] 900 VUs  0m08.0s/1m0s
-
-running (0m09.0s), 900/900 VUs, 6847 complete and 0 interrupted iterations
-default   [  15% ] 900 VUs  0m09.0s/1m0s
-
-running (0m10.0s), 900/900 VUs, 7747 complete and 0 interrupted iterations
-default   [  17% ] 900 VUs  0m10.0s/1m0s
-
-running (0m11.0s), 900/900 VUs, 8647 complete and 0 interrupted iterations
-default   [  18% ] 900 VUs  0m11.0s/1m0s
-
-running (0m12.0s), 900/900 VUs, 9547 complete and 0 interrupted iterations
-default   [  20% ] 900 VUs  0m12.0s/1m0s
-
-running (0m13.0s), 900/900 VUs, 10447 complete and 0 interrupted iterations
-default   [  22% ] 900 VUs  0m13.0s/1m0s
-
-running (0m14.0s), 900/900 VUs, 11347 complete and 0 interrupted iterations
-default   [  23% ] 900 VUs  0m14.0s/1m0s
-
-running (0m15.0s), 900/900 VUs, 12247 complete and 0 interrupted iterations
-default   [  25% ] 900 VUs  0m15.0s/1m0s
-
-running (0m16.0s), 900/900 VUs, 13147 complete and 0 interrupted iterations
-default   [  27% ] 900 VUs  0m16.0s/1m0s
-
-running (0m17.0s), 900/900 VUs, 14047 complete and 0 interrupted iterations
-default   [  28% ] 900 VUs  0m17.0s/1m0s
-
-running (0m18.0s), 900/900 VUs, 14947 complete and 0 interrupted iterations
-default   [  30% ] 900 VUs  0m18.0s/1m0s
-
-running (0m19.0s), 900/900 VUs, 15847 complete and 0 interrupted iterations
-default   [  32% ] 900 VUs  0m19.0s/1m0s
-
-running (0m20.0s), 900/900 VUs, 16747 complete and 0 interrupted iterations
-default   [  33% ] 900 VUs  0m20.0s/1m0s
-
-running (0m21.0s), 900/900 VUs, 17647 complete and 0 interrupted iterations
-default   [  35% ] 900 VUs  0m21.0s/1m0s
-
-running (0m22.0s), 900/900 VUs, 18547 complete and 0 interrupted iterations
-default   [  37% ] 900 VUs  0m22.0s/1m0s
-
-running (0m23.0s), 900/900 VUs, 19447 complete and 0 interrupted iterations
-default   [  38% ] 900 VUs  0m23.0s/1m0s
-
-running (0m24.0s), 900/900 VUs, 20347 complete and 0 interrupted iterations
-default   [  40% ] 900 VUs  0m24.0s/1m0s
-
-running (0m25.0s), 900/900 VUs, 21247 complete and 0 interrupted iterations
-default   [  42% ] 900 VUs  0m25.0s/1m0s
-
-running (0m26.0s), 900/900 VUs, 22147 complete and 0 interrupted iterations
-default   [  43% ] 900 VUs  0m26.0s/1m0s
-
-running (0m27.0s), 900/900 VUs, 23047 complete and 0 interrupted iterations
-default   [  45% ] 900 VUs  0m27.0s/1m0s
-
-running (0m28.0s), 900/900 VUs, 23942 complete and 0 interrupted iterations
-default   [  47% ] 900 VUs  0m28.0s/1m0s
-
-running (0m29.0s), 900/900 VUs, 24618 complete and 0 interrupted iterations
-default   [  48% ] 900 VUs  0m29.0s/1m0s
-
-running (0m30.0s), 900/900 VUs, 25287 complete and 0 interrupted iterations
-default   [  50% ] 900 VUs  0m30.0s/1m0s
-
-running (0m31.0s), 900/900 VUs, 26187 complete and 0 interrupted iterations
-default   [  52% ] 900 VUs  0m31.0s/1m0s
-
-running (0m32.0s), 900/900 VUs, 27086 complete and 0 interrupted iterations
-default   [  53% ] 900 VUs  0m32.0s/1m0s
-
-running (0m33.0s), 900/900 VUs, 27985 complete and 0 interrupted iterations
-default   [  55% ] 900 VUs  0m33.0s/1m0s
-
-running (0m34.0s), 900/900 VUs, 28884 complete and 0 interrupted iterations
-default   [  57% ] 900 VUs  0m34.0s/1m0s
-
-running (0m35.0s), 900/900 VUs, 29784 complete and 0 interrupted iterations
-default   [  58% ] 900 VUs  0m35.0s/1m0s
-
-running (0m36.0s), 900/900 VUs, 30677 complete and 0 interrupted iterations
-default   [  60% ] 900 VUs  0m36.0s/1m0s
-
-running (0m37.0s), 900/900 VUs, 31573 complete and 0 interrupted iterations
-default   [  62% ] 900 VUs  0m37.0s/1m0s
-
-running (0m38.0s), 900/900 VUs, 32450 complete and 0 interrupted iterations
-default   [  63% ] 900 VUs  0m38.0s/1m0s
-
-running (0m39.0s), 900/900 VUs, 33338 complete and 0 interrupted iterations
-default   [  65% ] 900 VUs  0m39.0s/1m0s
-
-running (0m40.0s), 900/900 VUs, 34229 complete and 0 interrupted iterations
-default   [  67% ] 900 VUs  0m40.0s/1m0s
-
-running (0m41.0s), 900/900 VUs, 35090 complete and 0 interrupted iterations
-default   [  68% ] 900 VUs  0m41.0s/1m0s
-
-running (0m42.0s), 900/900 VUs, 35969 complete and 0 interrupted iterations
-default   [  70% ] 900 VUs  0m42.0s/1m0s
-
-running (0m43.0s), 900/900 VUs, 36869 complete and 0 interrupted iterations
-default   [  72% ] 900 VUs  0m43.0s/1m0s
-
-running (0m44.0s), 900/900 VUs, 37769 complete and 0 interrupted iterations
-default   [  73% ] 900 VUs  0m44.0s/1m0s
-
-running (0m45.0s), 900/900 VUs, 38669 complete and 0 interrupted iterations
-default   [  75% ] 900 VUs  0m45.0s/1m0s
-
-running (0m46.0s), 900/900 VUs, 39569 complete and 0 interrupted iterations
-default   [  77% ] 900 VUs  0m46.0s/1m0s
-
-running (0m47.0s), 900/900 VUs, 40469 complete and 0 interrupted iterations
-default   [  78% ] 900 VUs  0m47.0s/1m0s
-
-running (0m48.0s), 900/900 VUs, 41369 complete and 0 interrupted iterations
-default   [  80% ] 900 VUs  0m48.0s/1m0s
-
-running (0m49.0s), 900/900 VUs, 42269 complete and 0 interrupted iterations
-default   [  82% ] 900 VUs  0m49.0s/1m0s
-
-running (0m50.0s), 900/900 VUs, 43169 complete and 0 interrupted iterations
-default   [  83% ] 900 VUs  0m50.0s/1m0s
-
-running (0m51.0s), 900/900 VUs, 44069 complete and 0 interrupted iterations
-default   [  85% ] 900 VUs  0m51.0s/1m0s
-
-running (0m52.0s), 900/900 VUs, 44969 complete and 0 interrupted iterations
-default   [  87% ] 900 VUs  0m52.0s/1m0s
-
-running (0m53.0s), 900/900 VUs, 45858 complete and 0 interrupted iterations
-default   [  88% ] 900 VUs  0m53.0s/1m0s
-
-running (0m54.0s), 900/900 VUs, 46752 complete and 0 interrupted iterations
-default   [  90% ] 900 VUs  0m54.0s/1m0s
-
-running (0m55.0s), 900/900 VUs, 47643 complete and 0 interrupted iterations
-default   [  92% ] 900 VUs  0m55.0s/1m0s
-
-running (0m56.0s), 900/900 VUs, 48527 complete and 0 interrupted iterations
-default   [  93% ] 900 VUs  0m56.0s/1m0s
-
-running (0m57.0s), 900/900 VUs, 49417 complete and 0 interrupted iterations
-default   [  95% ] 900 VUs  0m57.0s/1m0s
-
-running (0m58.0s), 900/900 VUs, 50306 complete and 0 interrupted iterations
-default   [  97% ] 900 VUs  0m58.0s/1m0s
-
-running (0m59.0s), 900/900 VUs, 51194 complete and 0 interrupted iterations
-default   [  98% ] 900 VUs  0m59.0s/1m0s
-
-running (1m00.0s), 900/900 VUs, 52080 complete and 0 interrupted iterations
-default   [ 100% ] 900 VUs  1m00.0s/1m0s
-
-running (1m01.0s), 040/900 VUs, 52967 complete and 0 interrupted iterations
-default ↓ [ 100% ] 900 VUs  1m0s
-
-
-  █ TOTAL RESULTS 
-
-    HTTP
-    http_req_duration..............: avg=1.71ms min=0s      med=144.68µs max=285.75ms p(90)=3.2ms  p(95)=6.66ms 
-      { expected_response:true }...: avg=3.21ms min=96.27µs med=468.8µs  max=285.75ms p(90)=6.25ms p(95)=10.02ms
-    http_req_failed................: 46.73% 24775 out of 53007
-    http_reqs......................: 53007  868.85342/s
-
-    EXECUTION
-    iteration_duration.............: avg=1.02s  min=1s      med=1s       max=3.58s    p(90)=1.03s  p(95)=1.08s  
-    iterations.....................: 53007  868.85342/s
-    vus............................: 40     min=40             max=900
-    vus_max........................: 900    min=900            max=900
-
-    NETWORK
-    data_received..................: 7.6 MB 125 kB/s
-    data_sent......................: 2.2 MB 36 kB/s
-
-
-
-
-running (1m01.0s), 000/900 VUs, 53007 complete and 0 interrupted iterations
+running (1m00.1s), 000/900 VUs, 53961 complete and 0 interrupted iterations
 default ✓ [ 100% ] 900 VUs  1m0s
 
          /\      Grafana   /‾‾/  
@@ -466,201 +241,1950 @@ default   [   3% ] 900 VUs  0m02.0s/1m0s
 running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
 default   [   5% ] 900 VUs  0m03.0s/1m0s
 
-running (0m04.0s), 900/900 VUs, 2561 complete and 0 interrupted iterations
+running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
 default   [   7% ] 900 VUs  0m04.0s/1m0s
 
-running (0m05.0s), 900/900 VUs, 3268 complete and 0 interrupted iterations
+running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
 default   [   8% ] 900 VUs  0m05.0s/1m0s
 
-running (0m06.0s), 900/900 VUs, 4168 complete and 0 interrupted iterations
+running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
 default   [  10% ] 900 VUs  0m06.0s/1m0s
 
-running (0m07.0s), 900/900 VUs, 5068 complete and 0 interrupted iterations
+running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
 default   [  12% ] 900 VUs  0m07.0s/1m0s
 
-running (0m08.0s), 900/900 VUs, 5968 complete and 0 interrupted iterations
+running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
 default   [  13% ] 900 VUs  0m08.0s/1m0s
 
-running (0m09.0s), 900/900 VUs, 6868 complete and 0 interrupted iterations
+running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
 default   [  15% ] 900 VUs  0m09.0s/1m0s
 
-running (0m10.0s), 900/900 VUs, 7768 complete and 0 interrupted iterations
+running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
 default   [  17% ] 900 VUs  0m10.0s/1m0s
 
-running (0m11.0s), 900/900 VUs, 8668 complete and 0 interrupted iterations
+running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
 default   [  18% ] 900 VUs  0m11.0s/1m0s
 
-running (0m12.0s), 900/900 VUs, 9568 complete and 0 interrupted iterations
+running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
 default   [  20% ] 900 VUs  0m12.0s/1m0s
 
-running (0m13.0s), 900/900 VUs, 10468 complete and 0 interrupted iterations
+running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
 default   [  22% ] 900 VUs  0m13.0s/1m0s
 
-running (0m14.0s), 900/900 VUs, 11368 complete and 0 interrupted iterations
+running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
 default   [  23% ] 900 VUs  0m14.0s/1m0s
 
-running (0m15.0s), 900/900 VUs, 12268 complete and 0 interrupted iterations
+running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
 default   [  25% ] 900 VUs  0m15.0s/1m0s
 
-running (0m16.0s), 900/900 VUs, 13168 complete and 0 interrupted iterations
+running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
 default   [  27% ] 900 VUs  0m16.0s/1m0s
 
-running (0m17.0s), 900/900 VUs, 14068 complete and 0 interrupted iterations
+running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
 default   [  28% ] 900 VUs  0m17.0s/1m0s
 
-running (0m18.0s), 900/900 VUs, 14968 complete and 0 interrupted iterations
+running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
 default   [  30% ] 900 VUs  0m18.0s/1m0s
 
-running (0m19.0s), 900/900 VUs, 15868 complete and 0 interrupted iterations
+running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
 default   [  32% ] 900 VUs  0m19.0s/1m0s
 
-running (0m20.0s), 900/900 VUs, 16768 complete and 0 interrupted iterations
+running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
 default   [  33% ] 900 VUs  0m20.0s/1m0s
 
-running (0m21.0s), 900/900 VUs, 17668 complete and 0 interrupted iterations
+running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
 default   [  35% ] 900 VUs  0m21.0s/1m0s
 
-running (0m22.0s), 900/900 VUs, 18547 complete and 0 interrupted iterations
+running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
 default   [  37% ] 900 VUs  0m22.0s/1m0s
 
-running (0m23.0s), 900/900 VUs, 19447 complete and 0 interrupted iterations
+running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
 default   [  38% ] 900 VUs  0m23.0s/1m0s
 
-running (0m24.0s), 900/900 VUs, 20344 complete and 0 interrupted iterations
+running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
 default   [  40% ] 900 VUs  0m24.0s/1m0s
 
-running (0m25.0s), 900/900 VUs, 21243 complete and 0 interrupted iterations
+running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
 default   [  42% ] 900 VUs  0m25.0s/1m0s
 
-running (0m26.0s), 900/900 VUs, 22131 complete and 0 interrupted iterations
+running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
 default   [  43% ] 900 VUs  0m26.0s/1m0s
 
-running (0m27.0s), 900/900 VUs, 23029 complete and 0 interrupted iterations
+running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
 default   [  45% ] 900 VUs  0m27.0s/1m0s
 
-running (0m28.0s), 900/900 VUs, 23927 complete and 0 interrupted iterations
+running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
 default   [  47% ] 900 VUs  0m28.0s/1m0s
 
-running (0m29.0s), 900/900 VUs, 24822 complete and 0 interrupted iterations
+running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
 default   [  48% ] 900 VUs  0m29.0s/1m0s
 
-running (0m30.0s), 900/900 VUs, 25722 complete and 0 interrupted iterations
+running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
 default   [  50% ] 900 VUs  0m30.0s/1m0s
 
-running (0m31.0s), 900/900 VUs, 26622 complete and 0 interrupted iterations
+running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
 default   [  52% ] 900 VUs  0m31.0s/1m0s
 
-running (0m32.0s), 900/900 VUs, 27522 complete and 0 interrupted iterations
+running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
 default   [  53% ] 900 VUs  0m32.0s/1m0s
 
-running (0m33.0s), 900/900 VUs, 28422 complete and 0 interrupted iterations
+running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
 default   [  55% ] 900 VUs  0m33.0s/1m0s
 
-running (0m34.0s), 900/900 VUs, 29322 complete and 0 interrupted iterations
+running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
 default   [  57% ] 900 VUs  0m34.0s/1m0s
 
-running (0m35.0s), 900/900 VUs, 30222 complete and 0 interrupted iterations
+running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
 default   [  58% ] 900 VUs  0m35.0s/1m0s
 
-running (0m36.0s), 900/900 VUs, 31118 complete and 0 interrupted iterations
+running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
 default   [  60% ] 900 VUs  0m36.0s/1m0s
 
-running (0m37.0s), 900/900 VUs, 32013 complete and 0 interrupted iterations
+running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
 default   [  62% ] 900 VUs  0m37.0s/1m0s
 
-running (0m38.0s), 900/900 VUs, 32862 complete and 0 interrupted iterations
+running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
 default   [  63% ] 900 VUs  0m38.0s/1m0s
 
-running (0m39.0s), 900/900 VUs, 33732 complete and 0 interrupted iterations
+running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
 default   [  65% ] 900 VUs  0m39.0s/1m0s
 
-running (0m40.0s), 900/900 VUs, 34632 complete and 0 interrupted iterations
+running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
 default   [  67% ] 900 VUs  0m40.0s/1m0s
 
-running (0m41.0s), 900/900 VUs, 35532 complete and 0 interrupted iterations
+running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
 default   [  68% ] 900 VUs  0m41.0s/1m0s
 
-running (0m42.0s), 900/900 VUs, 36432 complete and 0 interrupted iterations
+running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
 default   [  70% ] 900 VUs  0m42.0s/1m0s
 
-running (0m43.0s), 900/900 VUs, 37332 complete and 0 interrupted iterations
+running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
 default   [  72% ] 900 VUs  0m43.0s/1m0s
 
-running (0m44.0s), 900/900 VUs, 38232 complete and 0 interrupted iterations
+running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
 default   [  73% ] 900 VUs  0m44.0s/1m0s
 
-running (0m45.0s), 900/900 VUs, 39120 complete and 0 interrupted iterations
+running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
 default   [  75% ] 900 VUs  0m45.0s/1m0s
 
-running (0m46.0s), 900/900 VUs, 40009 complete and 0 interrupted iterations
+running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
 default   [  77% ] 900 VUs  0m46.0s/1m0s
 
-running (0m47.0s), 900/900 VUs, 40903 complete and 0 interrupted iterations
+running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
 default   [  78% ] 900 VUs  0m47.0s/1m0s
 
-running (0m48.0s), 900/900 VUs, 41794 complete and 0 interrupted iterations
+running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
 default   [  80% ] 900 VUs  0m48.0s/1m0s
 
-running (0m49.0s), 900/900 VUs, 42684 complete and 0 interrupted iterations
+running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
 default   [  82% ] 900 VUs  0m49.0s/1m0s
 
-running (0m50.0s), 900/900 VUs, 43576 complete and 0 interrupted iterations
+running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
 default   [  83% ] 900 VUs  0m50.0s/1m0s
 
-running (0m51.0s), 900/900 VUs, 44465 complete and 0 interrupted iterations
+running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
 default   [  85% ] 900 VUs  0m51.0s/1m0s
 
-running (0m52.0s), 900/900 VUs, 45353 complete and 0 interrupted iterations
+running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
 default   [  87% ] 900 VUs  0m52.0s/1m0s
 
-running (0m53.0s), 900/900 VUs, 46242 complete and 0 interrupted iterations
+running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
 default   [  88% ] 900 VUs  0m53.0s/1m0s
 
-running (0m54.0s), 900/900 VUs, 47138 complete and 0 interrupted iterations
+running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
 default   [  90% ] 900 VUs  0m54.0s/1m0s
 
-running (0m55.0s), 900/900 VUs, 48033 complete and 0 interrupted iterations
+running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
 default   [  92% ] 900 VUs  0m55.0s/1m0s
 
-running (0m56.0s), 900/900 VUs, 48920 complete and 0 interrupted iterations
+running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
 default   [  93% ] 900 VUs  0m56.0s/1m0s
 
-running (0m57.0s), 900/900 VUs, 49813 complete and 0 interrupted iterations
+running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
 default   [  95% ] 900 VUs  0m57.0s/1m0s
 
-running (0m58.0s), 900/900 VUs, 50711 complete and 0 interrupted iterations
+running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
 default   [  97% ] 900 VUs  0m58.0s/1m0s
 
-running (0m59.0s), 900/900 VUs, 51610 complete and 0 interrupted iterations
+running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
 default   [  98% ] 900 VUs  0m59.0s/1m0s
 
-running (1m00.0s), 900/900 VUs, 52509 complete and 0 interrupted iterations
+running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
 default   [ 100% ] 900 VUs  1m00.0s/1m0s
-
-running (1m01.0s), 003/900 VUs, 53409 complete and 0 interrupted iterations
-default ↓ [ 100% ] 900 VUs  1m0s
 
 
   █ TOTAL RESULTS 
 
     HTTP
-    http_req_duration..............: avg=331.98µs min=0s      med=136.39µs max=259.99ms p(90)=863.43µs p(95)=1.73ms
-      { expected_response:true }...: avg=628.08µs min=95.65µs med=202.73µs max=259.99ms p(90)=1.66ms   p(95)=2.4ms 
-    http_req_failed................: 47.14% 25180 out of 53412
-    http_reqs......................: 53412  875.542128/s
+    http_req_duration..............: avg=972.59µs min=56.98µs med=615.65µs max=35.25ms p(90)=1.87ms p(95)=2.67ms
+      { expected_response:true }...: avg=972.59µs min=56.98µs med=615.65µs max=35.25ms p(90)=1.87ms p(95)=2.67ms
+    http_req_failed................: 0.00%  0 out of 54000
+    http_reqs......................: 54000  898.078766/s
 
     EXECUTION
-    iteration_duration.............: avg=1.01s    min=1s      med=1s       max=1.57s    p(90)=1.01s    p(95)=1.05s 
-    iterations.....................: 53412  875.542128/s
-    vus............................: 3      min=3              max=900
-    vus_max........................: 900    min=900            max=900
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.04s   p(90)=1s     p(95)=1s    
+    iterations.....................: 54000  898.078766/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
 
     NETWORK
-    data_received..................: 7.6 MB 125 kB/s
-    data_sent......................: 2.2 MB 36 kB/s
+    data_received..................: 15 MB  247 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
 
 
 
 
-running (1m01.0s), 000/900 VUs, 53412 complete and 0 interrupted iterations
+running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkHummingbird.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=846.04µs min=56.78µs med=575.54µs max=16.83ms p(90)=1.54ms p(95)=2.03ms
+      { expected_response:true }...: avg=846.04µs min=56.78µs med=575.54µs max=16.83ms p(90)=1.54ms p(95)=2.03ms
+    http_req_failed................: 0.00%  0 out of 54000
+    http_reqs......................: 54000  898.302009/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.03s   p(90)=1s     p(95)=1s    
+    iterations.....................: 54000  898.302009/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  247 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkHummingbird.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=816.42µs min=60.69µs med=564.8µs max=40.48ms p(90)=1.54ms p(95)=2.01ms
+      { expected_response:true }...: avg=816.42µs min=60.69µs med=564.8µs max=40.48ms p(90)=1.54ms p(95)=2.01ms
+    http_req_failed................: 0.00%  0 out of 54000
+    http_reqs......................: 54000  898.36769/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s       min=1s      med=1s      max=1.04s   p(90)=1s     p(95)=1s    
+    iterations.....................: 54000  898.36769/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  247 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkHummingbird.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 893 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1793 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2693 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3593 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4493 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5393 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6293 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7193 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8093 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 8993 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9893 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10793 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11693 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12593 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13493 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14393 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15293 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16193 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17093 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 17993 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18893 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19793 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20693 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21593 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22493 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23393 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24293 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25193 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26093 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 26993 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27893 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28793 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29693 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30593 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31493 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32393 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33293 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34193 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35093 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 35993 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36893 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37793 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38693 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39593 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40493 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41393 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42293 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43193 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44093 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 44993 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45893 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46793 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47693 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48593 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49493 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50393 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51293 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52193 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53093 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=980.32µs min=54µs med=748.56µs max=208.37ms p(90)=1.78ms p(95)=2.25ms
+      { expected_response:true }...: avg=980.32µs min=54µs med=748.56µs max=208.37ms p(90)=1.78ms p(95)=2.25ms
+    http_req_failed................: 0.00%  0 out of 53993
+    http_reqs......................: 53993  895.345854/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s       min=1s   med=1s       max=2.01s    p(90)=1s     p(95)=1s    
+    iterations.....................: 53993  895.345854/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  246 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.3s), 000/900 VUs, 53993 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkHummingbird.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=921.98µs min=54.28µs med=665.48µs max=23.66ms p(90)=1.71ms p(95)=2.37ms
+      { expected_response:true }...: avg=921.98µs min=54.28µs med=665.48µs max=23.66ms p(90)=1.71ms p(95)=2.37ms
+    http_req_failed................: 0.00%  0 out of 54000
+    http_reqs......................: 54000  898.218037/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.03s   p(90)=1s     p(95)=1s    
+    iterations.....................: 54000  898.218037/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  247 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkHummingbird.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=792.98µs min=62.06µs med=553.69µs max=24.98ms p(90)=1.41ms p(95)=1.98ms
+      { expected_response:true }...: avg=792.98µs min=62.06µs med=553.69µs max=24.98ms p(90)=1.41ms p(95)=1.98ms
+    http_req_failed................: 0.00%  0 out of 54000
+    http_reqs......................: 54000  898.365213/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.04s   p(90)=1s     p(95)=1s    
+    iterations.....................: 54000  898.365213/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  247 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkHummingbird.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=595.01µs min=62.78µs med=453.48µs max=19.59ms p(90)=1.09ms p(95)=1.4ms
+      { expected_response:true }...: avg=595.01µs min=62.78µs med=453.48µs max=19.59ms p(90)=1.09ms p(95)=1.4ms
+    http_req_failed................: 0.00%  0 out of 54000
+    http_reqs......................: 54000  898.482071/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.02s   p(90)=1s     p(95)=1s   
+    iterations.....................: 54000  898.482071/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  247 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkHummingbird.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=919.86µs min=62.4µs med=648.89µs max=28.08ms p(90)=1.71ms p(95)=2.33ms
+      { expected_response:true }...: avg=919.86µs min=62.4µs med=648.89µs max=28.08ms p(90)=1.71ms p(95)=2.33ms
+    http_req_failed................: 0.00%  0 out of 54000
+    http_reqs......................: 54000  898.240516/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s       min=1s     med=1s       max=1.03s   p(90)=1s     p(95)=1s    
+    iterations.....................: 54000  898.240516/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  247 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkHummingbird.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 866 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1766 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2666 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3566 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4466 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5366 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6266 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7166 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8066 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 8966 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9866 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10766 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11666 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12566 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13466 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14366 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15266 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16166 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17066 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 17966 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18866 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19766 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20666 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21566 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22466 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23366 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24266 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25166 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26066 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 26966 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27866 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28766 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29666 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30566 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31466 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32366 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33266 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34166 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35066 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 35966 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36866 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37766 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38666 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39566 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40466 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41366 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42266 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43166 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44066 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 44966 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45866 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46766 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47666 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48566 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49466 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50366 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51266 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52166 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53066 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=909.12µs min=66.69µs med=686.96µs max=206.88ms p(90)=1.65ms p(95)=2.19ms
+      { expected_response:true }...: avg=909.12µs min=66.69µs med=686.96µs max=206.88ms p(90)=1.65ms p(95)=2.19ms
+    http_req_failed................: 0.00%  0 out of 53966
+    http_reqs......................: 53966  894.896603/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=2.01s    p(90)=1s     p(95)=1s    
+    iterations.....................: 53966  894.896603/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  246 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.3s), 000/900 VUs, 53966 complete and 0 interrupted iterations
 default ✓ [ 100% ] 900 VUs  1m0s

--- a/Benchmarks/results_hummingbird.txt
+++ b/Benchmarks/results_hummingbird.txt
@@ -16,225 +16,6 @@
 running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
 default   [   2% ] 900 VUs  0m01.0s/1m0s
 
-running (0m02.0s), 900/900 VUs, 861 complete and 0 interrupted iterations
-default   [   3% ] 900 VUs  0m02.0s/1m0s
-
-running (0m03.0s), 900/900 VUs, 1761 complete and 0 interrupted iterations
-default   [   5% ] 900 VUs  0m03.0s/1m0s
-
-running (0m04.0s), 900/900 VUs, 2661 complete and 0 interrupted iterations
-default   [   7% ] 900 VUs  0m04.0s/1m0s
-
-running (0m05.0s), 900/900 VUs, 3561 complete and 0 interrupted iterations
-default   [   8% ] 900 VUs  0m05.0s/1m0s
-
-running (0m06.0s), 900/900 VUs, 4461 complete and 0 interrupted iterations
-default   [  10% ] 900 VUs  0m06.0s/1m0s
-
-running (0m07.0s), 900/900 VUs, 5361 complete and 0 interrupted iterations
-default   [  12% ] 900 VUs  0m07.0s/1m0s
-
-running (0m08.0s), 900/900 VUs, 6261 complete and 0 interrupted iterations
-default   [  13% ] 900 VUs  0m08.0s/1m0s
-
-running (0m09.0s), 900/900 VUs, 7161 complete and 0 interrupted iterations
-default   [  15% ] 900 VUs  0m09.0s/1m0s
-
-running (0m10.0s), 900/900 VUs, 8061 complete and 0 interrupted iterations
-default   [  17% ] 900 VUs  0m10.0s/1m0s
-
-running (0m11.0s), 900/900 VUs, 8961 complete and 0 interrupted iterations
-default   [  18% ] 900 VUs  0m11.0s/1m0s
-
-running (0m12.0s), 900/900 VUs, 9861 complete and 0 interrupted iterations
-default   [  20% ] 900 VUs  0m12.0s/1m0s
-
-running (0m13.0s), 900/900 VUs, 10761 complete and 0 interrupted iterations
-default   [  22% ] 900 VUs  0m13.0s/1m0s
-
-running (0m14.0s), 900/900 VUs, 11661 complete and 0 interrupted iterations
-default   [  23% ] 900 VUs  0m14.0s/1m0s
-
-running (0m15.0s), 900/900 VUs, 12561 complete and 0 interrupted iterations
-default   [  25% ] 900 VUs  0m15.0s/1m0s
-
-running (0m16.0s), 900/900 VUs, 13461 complete and 0 interrupted iterations
-default   [  27% ] 900 VUs  0m16.0s/1m0s
-
-running (0m17.0s), 900/900 VUs, 14361 complete and 0 interrupted iterations
-default   [  28% ] 900 VUs  0m17.0s/1m0s
-
-running (0m18.0s), 900/900 VUs, 15261 complete and 0 interrupted iterations
-default   [  30% ] 900 VUs  0m18.0s/1m0s
-
-running (0m19.0s), 900/900 VUs, 16161 complete and 0 interrupted iterations
-default   [  32% ] 900 VUs  0m19.0s/1m0s
-
-running (0m20.0s), 900/900 VUs, 17061 complete and 0 interrupted iterations
-default   [  33% ] 900 VUs  0m20.0s/1m0s
-
-running (0m21.0s), 900/900 VUs, 17961 complete and 0 interrupted iterations
-default   [  35% ] 900 VUs  0m21.0s/1m0s
-
-running (0m22.0s), 900/900 VUs, 18861 complete and 0 interrupted iterations
-default   [  37% ] 900 VUs  0m22.0s/1m0s
-
-running (0m23.0s), 900/900 VUs, 19761 complete and 0 interrupted iterations
-default   [  38% ] 900 VUs  0m23.0s/1m0s
-
-running (0m24.0s), 900/900 VUs, 20661 complete and 0 interrupted iterations
-default   [  40% ] 900 VUs  0m24.0s/1m0s
-
-running (0m25.0s), 900/900 VUs, 21561 complete and 0 interrupted iterations
-default   [  42% ] 900 VUs  0m25.0s/1m0s
-
-running (0m26.0s), 900/900 VUs, 22461 complete and 0 interrupted iterations
-default   [  43% ] 900 VUs  0m26.0s/1m0s
-
-running (0m27.0s), 900/900 VUs, 23361 complete and 0 interrupted iterations
-default   [  45% ] 900 VUs  0m27.0s/1m0s
-
-running (0m28.0s), 900/900 VUs, 24261 complete and 0 interrupted iterations
-default   [  47% ] 900 VUs  0m28.0s/1m0s
-
-running (0m29.0s), 900/900 VUs, 25161 complete and 0 interrupted iterations
-default   [  48% ] 900 VUs  0m29.0s/1m0s
-
-running (0m30.0s), 900/900 VUs, 26061 complete and 0 interrupted iterations
-default   [  50% ] 900 VUs  0m30.0s/1m0s
-
-running (0m31.0s), 900/900 VUs, 26961 complete and 0 interrupted iterations
-default   [  52% ] 900 VUs  0m31.0s/1m0s
-
-running (0m32.0s), 900/900 VUs, 27861 complete and 0 interrupted iterations
-default   [  53% ] 900 VUs  0m32.0s/1m0s
-
-running (0m33.0s), 900/900 VUs, 28761 complete and 0 interrupted iterations
-default   [  55% ] 900 VUs  0m33.0s/1m0s
-
-running (0m34.0s), 900/900 VUs, 29661 complete and 0 interrupted iterations
-default   [  57% ] 900 VUs  0m34.0s/1m0s
-
-running (0m35.0s), 900/900 VUs, 30561 complete and 0 interrupted iterations
-default   [  58% ] 900 VUs  0m35.0s/1m0s
-
-running (0m36.0s), 900/900 VUs, 31461 complete and 0 interrupted iterations
-default   [  60% ] 900 VUs  0m36.0s/1m0s
-
-running (0m37.0s), 900/900 VUs, 32361 complete and 0 interrupted iterations
-default   [  62% ] 900 VUs  0m37.0s/1m0s
-
-running (0m38.0s), 900/900 VUs, 33261 complete and 0 interrupted iterations
-default   [  63% ] 900 VUs  0m38.0s/1m0s
-
-running (0m39.0s), 900/900 VUs, 34161 complete and 0 interrupted iterations
-default   [  65% ] 900 VUs  0m39.0s/1m0s
-
-running (0m40.0s), 900/900 VUs, 35061 complete and 0 interrupted iterations
-default   [  67% ] 900 VUs  0m40.0s/1m0s
-
-running (0m41.0s), 900/900 VUs, 35961 complete and 0 interrupted iterations
-default   [  68% ] 900 VUs  0m41.0s/1m0s
-
-running (0m42.0s), 900/900 VUs, 36861 complete and 0 interrupted iterations
-default   [  70% ] 900 VUs  0m42.0s/1m0s
-
-running (0m43.0s), 900/900 VUs, 37761 complete and 0 interrupted iterations
-default   [  72% ] 900 VUs  0m43.0s/1m0s
-
-running (0m44.0s), 900/900 VUs, 38661 complete and 0 interrupted iterations
-default   [  73% ] 900 VUs  0m44.0s/1m0s
-
-running (0m45.0s), 900/900 VUs, 39561 complete and 0 interrupted iterations
-default   [  75% ] 900 VUs  0m45.0s/1m0s
-
-running (0m46.0s), 900/900 VUs, 40461 complete and 0 interrupted iterations
-default   [  77% ] 900 VUs  0m46.0s/1m0s
-
-running (0m47.0s), 900/900 VUs, 41361 complete and 0 interrupted iterations
-default   [  78% ] 900 VUs  0m47.0s/1m0s
-
-running (0m48.0s), 900/900 VUs, 42261 complete and 0 interrupted iterations
-default   [  80% ] 900 VUs  0m48.0s/1m0s
-
-running (0m49.0s), 900/900 VUs, 43161 complete and 0 interrupted iterations
-default   [  82% ] 900 VUs  0m49.0s/1m0s
-
-running (0m50.0s), 900/900 VUs, 44061 complete and 0 interrupted iterations
-default   [  83% ] 900 VUs  0m50.0s/1m0s
-
-running (0m51.0s), 900/900 VUs, 44961 complete and 0 interrupted iterations
-default   [  85% ] 900 VUs  0m51.0s/1m0s
-
-running (0m52.0s), 900/900 VUs, 45861 complete and 0 interrupted iterations
-default   [  87% ] 900 VUs  0m52.0s/1m0s
-
-running (0m53.0s), 900/900 VUs, 46761 complete and 0 interrupted iterations
-default   [  88% ] 900 VUs  0m53.0s/1m0s
-
-running (0m54.0s), 900/900 VUs, 47661 complete and 0 interrupted iterations
-default   [  90% ] 900 VUs  0m54.0s/1m0s
-
-running (0m55.0s), 900/900 VUs, 48561 complete and 0 interrupted iterations
-default   [  92% ] 900 VUs  0m55.0s/1m0s
-
-running (0m56.0s), 900/900 VUs, 49461 complete and 0 interrupted iterations
-default   [  93% ] 900 VUs  0m56.0s/1m0s
-
-running (0m57.0s), 900/900 VUs, 50361 complete and 0 interrupted iterations
-default   [  95% ] 900 VUs  0m57.0s/1m0s
-
-running (0m58.0s), 900/900 VUs, 51261 complete and 0 interrupted iterations
-default   [  97% ] 900 VUs  0m58.0s/1m0s
-
-running (0m59.0s), 900/900 VUs, 52161 complete and 0 interrupted iterations
-default   [  98% ] 900 VUs  0m59.0s/1m0s
-
-running (1m00.0s), 900/900 VUs, 53061 complete and 0 interrupted iterations
-default   [ 100% ] 900 VUs  1m00.0s/1m0s
-
-
-  █ TOTAL RESULTS 
-
-    HTTP
-    http_req_duration..............: avg=1ms min=56.68µs med=679.33µs max=31.48ms p(90)=2.02ms p(95)=2.82ms
-      { expected_response:true }...: avg=1ms min=56.68µs med=679.33µs max=31.48ms p(90)=2.02ms p(95)=2.82ms
-    http_req_failed................: 0.00%  0 out of 53961
-    http_reqs......................: 53961  897.421857/s
-
-    EXECUTION
-    iteration_duration.............: avg=1s  min=1s      med=1s       max=2.05s   p(90)=1s     p(95)=1s    
-    iterations.....................: 53961  897.421857/s
-    vus............................: 900    min=900        max=900
-    vus_max........................: 900    min=900        max=900
-
-    NETWORK
-    data_received..................: 15 MB  247 kB/s
-    data_sent......................: 4.2 MB 70 kB/s
-
-
-
-
-running (1m00.1s), 000/900 VUs, 53961 complete and 0 interrupted iterations
-default ✓ [ 100% ] 900 VUs  1m0s
-
-         /\      Grafana   /‾‾/  
-    /\  /  \     |\  __   /  /   
-   /  \/    \    | |/ /  /   ‾‾\ 
-  /          \   |   (  |  (‾)  |
- / __________ \  |_|\_\  \_____/ 
-
-     execution: local
-        script: benchmarkHummingbird.js
-        output: -
-
-     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
-              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
-
-
-running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
-default   [   2% ] 900 VUs  0m01.0s/1m0s
-
 running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
 default   [   3% ] 900 VUs  0m02.0s/1m0s
 
@@ -416,14 +197,14 @@ default   [ 100% ] 900 VUs  1m00.0s/1m0s
   █ TOTAL RESULTS 
 
     HTTP
-    http_req_duration..............: avg=972.59µs min=56.98µs med=615.65µs max=35.25ms p(90)=1.87ms p(95)=2.67ms
-      { expected_response:true }...: avg=972.59µs min=56.98µs med=615.65µs max=35.25ms p(90)=1.87ms p(95)=2.67ms
+    http_req_duration..............: avg=904.77µs min=59.03µs med=526.85µs max=27.9ms p(90)=1.55ms p(95)=2.24ms
+      { expected_response:true }...: avg=904.77µs min=59.03µs med=526.85µs max=27.9ms p(90)=1.55ms p(95)=2.24ms
     http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.078766/s
+    http_reqs......................: 54000  898.243675/s
 
     EXECUTION
-    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.04s   p(90)=1s     p(95)=1s    
-    iterations.....................: 54000  898.078766/s
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.04s  p(90)=1s     p(95)=1s    
+    iterations.....................: 54000  898.243675/s
     vus............................: 900    min=900        max=900
     vus_max........................: 900    min=900        max=900
 
@@ -454,633 +235,195 @@ default ✓ [ 100% ] 900 VUs  1m0s
 running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
 default   [   2% ] 900 VUs  0m01.0s/1m0s
 
-running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
+running (0m02.0s), 900/900 VUs, 862 complete and 0 interrupted iterations
 default   [   3% ] 900 VUs  0m02.0s/1m0s
 
-running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
+running (0m03.0s), 900/900 VUs, 1762 complete and 0 interrupted iterations
 default   [   5% ] 900 VUs  0m03.0s/1m0s
 
-running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
+running (0m04.0s), 900/900 VUs, 2662 complete and 0 interrupted iterations
 default   [   7% ] 900 VUs  0m04.0s/1m0s
 
-running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
+running (0m05.0s), 900/900 VUs, 3562 complete and 0 interrupted iterations
 default   [   8% ] 900 VUs  0m05.0s/1m0s
 
-running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
+running (0m06.0s), 900/900 VUs, 4462 complete and 0 interrupted iterations
 default   [  10% ] 900 VUs  0m06.0s/1m0s
 
-running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
+running (0m07.0s), 900/900 VUs, 5362 complete and 0 interrupted iterations
 default   [  12% ] 900 VUs  0m07.0s/1m0s
 
-running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
+running (0m08.0s), 900/900 VUs, 6262 complete and 0 interrupted iterations
 default   [  13% ] 900 VUs  0m08.0s/1m0s
 
-running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
+running (0m09.0s), 900/900 VUs, 7162 complete and 0 interrupted iterations
 default   [  15% ] 900 VUs  0m09.0s/1m0s
 
-running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
+running (0m10.0s), 900/900 VUs, 8062 complete and 0 interrupted iterations
 default   [  17% ] 900 VUs  0m10.0s/1m0s
 
-running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
+running (0m11.0s), 900/900 VUs, 8962 complete and 0 interrupted iterations
 default   [  18% ] 900 VUs  0m11.0s/1m0s
 
-running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
+running (0m12.0s), 900/900 VUs, 9862 complete and 0 interrupted iterations
 default   [  20% ] 900 VUs  0m12.0s/1m0s
 
-running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
+running (0m13.0s), 900/900 VUs, 10762 complete and 0 interrupted iterations
 default   [  22% ] 900 VUs  0m13.0s/1m0s
 
-running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
+running (0m14.0s), 900/900 VUs, 11662 complete and 0 interrupted iterations
 default   [  23% ] 900 VUs  0m14.0s/1m0s
 
-running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
+running (0m15.0s), 900/900 VUs, 12562 complete and 0 interrupted iterations
 default   [  25% ] 900 VUs  0m15.0s/1m0s
 
-running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
+running (0m16.0s), 900/900 VUs, 13462 complete and 0 interrupted iterations
 default   [  27% ] 900 VUs  0m16.0s/1m0s
 
-running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
+running (0m17.0s), 900/900 VUs, 14362 complete and 0 interrupted iterations
 default   [  28% ] 900 VUs  0m17.0s/1m0s
 
-running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
+running (0m18.0s), 900/900 VUs, 15262 complete and 0 interrupted iterations
 default   [  30% ] 900 VUs  0m18.0s/1m0s
 
-running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
+running (0m19.0s), 900/900 VUs, 16162 complete and 0 interrupted iterations
 default   [  32% ] 900 VUs  0m19.0s/1m0s
 
-running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
+running (0m20.0s), 900/900 VUs, 17062 complete and 0 interrupted iterations
 default   [  33% ] 900 VUs  0m20.0s/1m0s
 
-running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
+running (0m21.0s), 900/900 VUs, 17962 complete and 0 interrupted iterations
 default   [  35% ] 900 VUs  0m21.0s/1m0s
 
-running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
+running (0m22.0s), 900/900 VUs, 18862 complete and 0 interrupted iterations
 default   [  37% ] 900 VUs  0m22.0s/1m0s
 
-running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
+running (0m23.0s), 900/900 VUs, 19762 complete and 0 interrupted iterations
 default   [  38% ] 900 VUs  0m23.0s/1m0s
 
-running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
+running (0m24.0s), 900/900 VUs, 20662 complete and 0 interrupted iterations
 default   [  40% ] 900 VUs  0m24.0s/1m0s
 
-running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
+running (0m25.0s), 900/900 VUs, 21562 complete and 0 interrupted iterations
 default   [  42% ] 900 VUs  0m25.0s/1m0s
 
-running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
+running (0m26.0s), 900/900 VUs, 22462 complete and 0 interrupted iterations
 default   [  43% ] 900 VUs  0m26.0s/1m0s
 
-running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
+running (0m27.0s), 900/900 VUs, 23362 complete and 0 interrupted iterations
 default   [  45% ] 900 VUs  0m27.0s/1m0s
 
-running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
+running (0m28.0s), 900/900 VUs, 24262 complete and 0 interrupted iterations
 default   [  47% ] 900 VUs  0m28.0s/1m0s
 
-running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
+running (0m29.0s), 900/900 VUs, 25162 complete and 0 interrupted iterations
 default   [  48% ] 900 VUs  0m29.0s/1m0s
 
-running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
+running (0m30.0s), 900/900 VUs, 26062 complete and 0 interrupted iterations
 default   [  50% ] 900 VUs  0m30.0s/1m0s
 
-running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
+running (0m31.0s), 900/900 VUs, 26962 complete and 0 interrupted iterations
 default   [  52% ] 900 VUs  0m31.0s/1m0s
 
-running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
+running (0m32.0s), 900/900 VUs, 27862 complete and 0 interrupted iterations
 default   [  53% ] 900 VUs  0m32.0s/1m0s
 
-running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
+running (0m33.0s), 900/900 VUs, 28762 complete and 0 interrupted iterations
 default   [  55% ] 900 VUs  0m33.0s/1m0s
 
-running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
+running (0m34.0s), 900/900 VUs, 29662 complete and 0 interrupted iterations
 default   [  57% ] 900 VUs  0m34.0s/1m0s
 
-running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
+running (0m35.0s), 900/900 VUs, 30562 complete and 0 interrupted iterations
 default   [  58% ] 900 VUs  0m35.0s/1m0s
 
-running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
+running (0m36.0s), 900/900 VUs, 31462 complete and 0 interrupted iterations
 default   [  60% ] 900 VUs  0m36.0s/1m0s
 
-running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
+running (0m37.0s), 900/900 VUs, 32362 complete and 0 interrupted iterations
 default   [  62% ] 900 VUs  0m37.0s/1m0s
 
-running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
+running (0m38.0s), 900/900 VUs, 33262 complete and 0 interrupted iterations
 default   [  63% ] 900 VUs  0m38.0s/1m0s
 
-running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
+running (0m39.0s), 900/900 VUs, 34162 complete and 0 interrupted iterations
 default   [  65% ] 900 VUs  0m39.0s/1m0s
 
-running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
+running (0m40.0s), 900/900 VUs, 35062 complete and 0 interrupted iterations
 default   [  67% ] 900 VUs  0m40.0s/1m0s
 
-running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
+running (0m41.0s), 900/900 VUs, 35962 complete and 0 interrupted iterations
 default   [  68% ] 900 VUs  0m41.0s/1m0s
 
-running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
+running (0m42.0s), 900/900 VUs, 36862 complete and 0 interrupted iterations
 default   [  70% ] 900 VUs  0m42.0s/1m0s
 
-running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
+running (0m43.0s), 900/900 VUs, 37762 complete and 0 interrupted iterations
 default   [  72% ] 900 VUs  0m43.0s/1m0s
 
-running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
+running (0m44.0s), 900/900 VUs, 38662 complete and 0 interrupted iterations
 default   [  73% ] 900 VUs  0m44.0s/1m0s
 
-running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
+running (0m45.0s), 900/900 VUs, 39562 complete and 0 interrupted iterations
 default   [  75% ] 900 VUs  0m45.0s/1m0s
 
-running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
+running (0m46.0s), 900/900 VUs, 40462 complete and 0 interrupted iterations
 default   [  77% ] 900 VUs  0m46.0s/1m0s
 
-running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
+running (0m47.0s), 900/900 VUs, 41362 complete and 0 interrupted iterations
 default   [  78% ] 900 VUs  0m47.0s/1m0s
 
-running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
+running (0m48.0s), 900/900 VUs, 42262 complete and 0 interrupted iterations
 default   [  80% ] 900 VUs  0m48.0s/1m0s
 
-running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
+running (0m49.0s), 900/900 VUs, 43162 complete and 0 interrupted iterations
 default   [  82% ] 900 VUs  0m49.0s/1m0s
 
-running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
+running (0m50.0s), 900/900 VUs, 44062 complete and 0 interrupted iterations
 default   [  83% ] 900 VUs  0m50.0s/1m0s
 
-running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
+running (0m51.0s), 900/900 VUs, 44962 complete and 0 interrupted iterations
 default   [  85% ] 900 VUs  0m51.0s/1m0s
 
-running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
+running (0m52.0s), 900/900 VUs, 45862 complete and 0 interrupted iterations
 default   [  87% ] 900 VUs  0m52.0s/1m0s
 
-running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
+running (0m53.0s), 900/900 VUs, 46762 complete and 0 interrupted iterations
 default   [  88% ] 900 VUs  0m53.0s/1m0s
 
-running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
+running (0m54.0s), 900/900 VUs, 47662 complete and 0 interrupted iterations
 default   [  90% ] 900 VUs  0m54.0s/1m0s
 
-running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
+running (0m55.0s), 900/900 VUs, 48562 complete and 0 interrupted iterations
 default   [  92% ] 900 VUs  0m55.0s/1m0s
 
-running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
+running (0m56.0s), 900/900 VUs, 49462 complete and 0 interrupted iterations
 default   [  93% ] 900 VUs  0m56.0s/1m0s
 
-running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
+running (0m57.0s), 900/900 VUs, 50362 complete and 0 interrupted iterations
 default   [  95% ] 900 VUs  0m57.0s/1m0s
 
-running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
+running (0m58.0s), 900/900 VUs, 51262 complete and 0 interrupted iterations
 default   [  97% ] 900 VUs  0m58.0s/1m0s
 
-running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
+running (0m59.0s), 900/900 VUs, 52162 complete and 0 interrupted iterations
 default   [  98% ] 900 VUs  0m59.0s/1m0s
 
-running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
+running (1m00.0s), 900/900 VUs, 53062 complete and 0 interrupted iterations
 default   [ 100% ] 900 VUs  1m00.0s/1m0s
 
 
   █ TOTAL RESULTS 
 
     HTTP
-    http_req_duration..............: avg=846.04µs min=56.78µs med=575.54µs max=16.83ms p(90)=1.54ms p(95)=2.03ms
-      { expected_response:true }...: avg=846.04µs min=56.78µs med=575.54µs max=16.83ms p(90)=1.54ms p(95)=2.03ms
-    http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.302009/s
+    http_req_duration..............: avg=955.15µs min=54.07µs med=732.19µs max=205.36ms p(90)=1.83ms p(95)=2.36ms
+      { expected_response:true }...: avg=955.15µs min=54.07µs med=732.19µs max=205.36ms p(90)=1.83ms p(95)=2.36ms
+    http_req_failed................: 0.00%  0 out of 53962
+    http_reqs......................: 53962  894.844102/s
 
     EXECUTION
-    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.03s   p(90)=1s     p(95)=1s    
-    iterations.....................: 54000  898.302009/s
-    vus............................: 900    min=900        max=900
-    vus_max........................: 900    min=900        max=900
-
-    NETWORK
-    data_received..................: 15 MB  247 kB/s
-    data_sent......................: 4.2 MB 70 kB/s
-
-
-
-
-running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
-default ✓ [ 100% ] 900 VUs  1m0s
-
-         /\      Grafana   /‾‾/  
-    /\  /  \     |\  __   /  /   
-   /  \/    \    | |/ /  /   ‾‾\ 
-  /          \   |   (  |  (‾)  |
- / __________ \  |_|\_\  \_____/ 
-
-     execution: local
-        script: benchmarkHummingbird.js
-        output: -
-
-     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
-              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
-
-
-running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
-default   [   2% ] 900 VUs  0m01.0s/1m0s
-
-running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
-default   [   3% ] 900 VUs  0m02.0s/1m0s
-
-running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
-default   [   5% ] 900 VUs  0m03.0s/1m0s
-
-running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
-default   [   7% ] 900 VUs  0m04.0s/1m0s
-
-running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
-default   [   8% ] 900 VUs  0m05.0s/1m0s
-
-running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
-default   [  10% ] 900 VUs  0m06.0s/1m0s
-
-running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
-default   [  12% ] 900 VUs  0m07.0s/1m0s
-
-running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
-default   [  13% ] 900 VUs  0m08.0s/1m0s
-
-running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
-default   [  15% ] 900 VUs  0m09.0s/1m0s
-
-running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
-default   [  17% ] 900 VUs  0m10.0s/1m0s
-
-running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
-default   [  18% ] 900 VUs  0m11.0s/1m0s
-
-running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
-default   [  20% ] 900 VUs  0m12.0s/1m0s
-
-running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
-default   [  22% ] 900 VUs  0m13.0s/1m0s
-
-running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
-default   [  23% ] 900 VUs  0m14.0s/1m0s
-
-running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
-default   [  25% ] 900 VUs  0m15.0s/1m0s
-
-running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
-default   [  27% ] 900 VUs  0m16.0s/1m0s
-
-running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
-default   [  28% ] 900 VUs  0m17.0s/1m0s
-
-running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
-default   [  30% ] 900 VUs  0m18.0s/1m0s
-
-running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
-default   [  32% ] 900 VUs  0m19.0s/1m0s
-
-running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
-default   [  33% ] 900 VUs  0m20.0s/1m0s
-
-running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
-default   [  35% ] 900 VUs  0m21.0s/1m0s
-
-running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
-default   [  37% ] 900 VUs  0m22.0s/1m0s
-
-running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
-default   [  38% ] 900 VUs  0m23.0s/1m0s
-
-running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
-default   [  40% ] 900 VUs  0m24.0s/1m0s
-
-running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
-default   [  42% ] 900 VUs  0m25.0s/1m0s
-
-running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
-default   [  43% ] 900 VUs  0m26.0s/1m0s
-
-running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
-default   [  45% ] 900 VUs  0m27.0s/1m0s
-
-running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
-default   [  47% ] 900 VUs  0m28.0s/1m0s
-
-running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
-default   [  48% ] 900 VUs  0m29.0s/1m0s
-
-running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
-default   [  50% ] 900 VUs  0m30.0s/1m0s
-
-running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
-default   [  52% ] 900 VUs  0m31.0s/1m0s
-
-running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
-default   [  53% ] 900 VUs  0m32.0s/1m0s
-
-running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
-default   [  55% ] 900 VUs  0m33.0s/1m0s
-
-running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
-default   [  57% ] 900 VUs  0m34.0s/1m0s
-
-running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
-default   [  58% ] 900 VUs  0m35.0s/1m0s
-
-running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
-default   [  60% ] 900 VUs  0m36.0s/1m0s
-
-running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
-default   [  62% ] 900 VUs  0m37.0s/1m0s
-
-running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
-default   [  63% ] 900 VUs  0m38.0s/1m0s
-
-running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
-default   [  65% ] 900 VUs  0m39.0s/1m0s
-
-running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
-default   [  67% ] 900 VUs  0m40.0s/1m0s
-
-running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
-default   [  68% ] 900 VUs  0m41.0s/1m0s
-
-running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
-default   [  70% ] 900 VUs  0m42.0s/1m0s
-
-running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
-default   [  72% ] 900 VUs  0m43.0s/1m0s
-
-running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
-default   [  73% ] 900 VUs  0m44.0s/1m0s
-
-running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
-default   [  75% ] 900 VUs  0m45.0s/1m0s
-
-running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
-default   [  77% ] 900 VUs  0m46.0s/1m0s
-
-running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
-default   [  78% ] 900 VUs  0m47.0s/1m0s
-
-running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
-default   [  80% ] 900 VUs  0m48.0s/1m0s
-
-running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
-default   [  82% ] 900 VUs  0m49.0s/1m0s
-
-running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
-default   [  83% ] 900 VUs  0m50.0s/1m0s
-
-running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
-default   [  85% ] 900 VUs  0m51.0s/1m0s
-
-running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
-default   [  87% ] 900 VUs  0m52.0s/1m0s
-
-running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
-default   [  88% ] 900 VUs  0m53.0s/1m0s
-
-running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
-default   [  90% ] 900 VUs  0m54.0s/1m0s
-
-running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
-default   [  92% ] 900 VUs  0m55.0s/1m0s
-
-running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
-default   [  93% ] 900 VUs  0m56.0s/1m0s
-
-running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
-default   [  95% ] 900 VUs  0m57.0s/1m0s
-
-running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
-default   [  97% ] 900 VUs  0m58.0s/1m0s
-
-running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
-default   [  98% ] 900 VUs  0m59.0s/1m0s
-
-running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
-default   [ 100% ] 900 VUs  1m00.0s/1m0s
-
-
-  █ TOTAL RESULTS 
-
-    HTTP
-    http_req_duration..............: avg=816.42µs min=60.69µs med=564.8µs max=40.48ms p(90)=1.54ms p(95)=2.01ms
-      { expected_response:true }...: avg=816.42µs min=60.69µs med=564.8µs max=40.48ms p(90)=1.54ms p(95)=2.01ms
-    http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.36769/s
-
-    EXECUTION
-    iteration_duration.............: avg=1s       min=1s      med=1s      max=1.04s   p(90)=1s     p(95)=1s    
-    iterations.....................: 54000  898.36769/s
-    vus............................: 900    min=900        max=900
-    vus_max........................: 900    min=900        max=900
-
-    NETWORK
-    data_received..................: 15 MB  247 kB/s
-    data_sent......................: 4.2 MB 70 kB/s
-
-
-
-
-running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
-default ✓ [ 100% ] 900 VUs  1m0s
-
-         /\      Grafana   /‾‾/  
-    /\  /  \     |\  __   /  /   
-   /  \/    \    | |/ /  /   ‾‾\ 
-  /          \   |   (  |  (‾)  |
- / __________ \  |_|\_\  \_____/ 
-
-     execution: local
-        script: benchmarkHummingbird.js
-        output: -
-
-     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
-              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
-
-
-running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
-default   [   2% ] 900 VUs  0m01.0s/1m0s
-
-running (0m02.0s), 900/900 VUs, 893 complete and 0 interrupted iterations
-default   [   3% ] 900 VUs  0m02.0s/1m0s
-
-running (0m03.0s), 900/900 VUs, 1793 complete and 0 interrupted iterations
-default   [   5% ] 900 VUs  0m03.0s/1m0s
-
-running (0m04.0s), 900/900 VUs, 2693 complete and 0 interrupted iterations
-default   [   7% ] 900 VUs  0m04.0s/1m0s
-
-running (0m05.0s), 900/900 VUs, 3593 complete and 0 interrupted iterations
-default   [   8% ] 900 VUs  0m05.0s/1m0s
-
-running (0m06.0s), 900/900 VUs, 4493 complete and 0 interrupted iterations
-default   [  10% ] 900 VUs  0m06.0s/1m0s
-
-running (0m07.0s), 900/900 VUs, 5393 complete and 0 interrupted iterations
-default   [  12% ] 900 VUs  0m07.0s/1m0s
-
-running (0m08.0s), 900/900 VUs, 6293 complete and 0 interrupted iterations
-default   [  13% ] 900 VUs  0m08.0s/1m0s
-
-running (0m09.0s), 900/900 VUs, 7193 complete and 0 interrupted iterations
-default   [  15% ] 900 VUs  0m09.0s/1m0s
-
-running (0m10.0s), 900/900 VUs, 8093 complete and 0 interrupted iterations
-default   [  17% ] 900 VUs  0m10.0s/1m0s
-
-running (0m11.0s), 900/900 VUs, 8993 complete and 0 interrupted iterations
-default   [  18% ] 900 VUs  0m11.0s/1m0s
-
-running (0m12.0s), 900/900 VUs, 9893 complete and 0 interrupted iterations
-default   [  20% ] 900 VUs  0m12.0s/1m0s
-
-running (0m13.0s), 900/900 VUs, 10793 complete and 0 interrupted iterations
-default   [  22% ] 900 VUs  0m13.0s/1m0s
-
-running (0m14.0s), 900/900 VUs, 11693 complete and 0 interrupted iterations
-default   [  23% ] 900 VUs  0m14.0s/1m0s
-
-running (0m15.0s), 900/900 VUs, 12593 complete and 0 interrupted iterations
-default   [  25% ] 900 VUs  0m15.0s/1m0s
-
-running (0m16.0s), 900/900 VUs, 13493 complete and 0 interrupted iterations
-default   [  27% ] 900 VUs  0m16.0s/1m0s
-
-running (0m17.0s), 900/900 VUs, 14393 complete and 0 interrupted iterations
-default   [  28% ] 900 VUs  0m17.0s/1m0s
-
-running (0m18.0s), 900/900 VUs, 15293 complete and 0 interrupted iterations
-default   [  30% ] 900 VUs  0m18.0s/1m0s
-
-running (0m19.0s), 900/900 VUs, 16193 complete and 0 interrupted iterations
-default   [  32% ] 900 VUs  0m19.0s/1m0s
-
-running (0m20.0s), 900/900 VUs, 17093 complete and 0 interrupted iterations
-default   [  33% ] 900 VUs  0m20.0s/1m0s
-
-running (0m21.0s), 900/900 VUs, 17993 complete and 0 interrupted iterations
-default   [  35% ] 900 VUs  0m21.0s/1m0s
-
-running (0m22.0s), 900/900 VUs, 18893 complete and 0 interrupted iterations
-default   [  37% ] 900 VUs  0m22.0s/1m0s
-
-running (0m23.0s), 900/900 VUs, 19793 complete and 0 interrupted iterations
-default   [  38% ] 900 VUs  0m23.0s/1m0s
-
-running (0m24.0s), 900/900 VUs, 20693 complete and 0 interrupted iterations
-default   [  40% ] 900 VUs  0m24.0s/1m0s
-
-running (0m25.0s), 900/900 VUs, 21593 complete and 0 interrupted iterations
-default   [  42% ] 900 VUs  0m25.0s/1m0s
-
-running (0m26.0s), 900/900 VUs, 22493 complete and 0 interrupted iterations
-default   [  43% ] 900 VUs  0m26.0s/1m0s
-
-running (0m27.0s), 900/900 VUs, 23393 complete and 0 interrupted iterations
-default   [  45% ] 900 VUs  0m27.0s/1m0s
-
-running (0m28.0s), 900/900 VUs, 24293 complete and 0 interrupted iterations
-default   [  47% ] 900 VUs  0m28.0s/1m0s
-
-running (0m29.0s), 900/900 VUs, 25193 complete and 0 interrupted iterations
-default   [  48% ] 900 VUs  0m29.0s/1m0s
-
-running (0m30.0s), 900/900 VUs, 26093 complete and 0 interrupted iterations
-default   [  50% ] 900 VUs  0m30.0s/1m0s
-
-running (0m31.0s), 900/900 VUs, 26993 complete and 0 interrupted iterations
-default   [  52% ] 900 VUs  0m31.0s/1m0s
-
-running (0m32.0s), 900/900 VUs, 27893 complete and 0 interrupted iterations
-default   [  53% ] 900 VUs  0m32.0s/1m0s
-
-running (0m33.0s), 900/900 VUs, 28793 complete and 0 interrupted iterations
-default   [  55% ] 900 VUs  0m33.0s/1m0s
-
-running (0m34.0s), 900/900 VUs, 29693 complete and 0 interrupted iterations
-default   [  57% ] 900 VUs  0m34.0s/1m0s
-
-running (0m35.0s), 900/900 VUs, 30593 complete and 0 interrupted iterations
-default   [  58% ] 900 VUs  0m35.0s/1m0s
-
-running (0m36.0s), 900/900 VUs, 31493 complete and 0 interrupted iterations
-default   [  60% ] 900 VUs  0m36.0s/1m0s
-
-running (0m37.0s), 900/900 VUs, 32393 complete and 0 interrupted iterations
-default   [  62% ] 900 VUs  0m37.0s/1m0s
-
-running (0m38.0s), 900/900 VUs, 33293 complete and 0 interrupted iterations
-default   [  63% ] 900 VUs  0m38.0s/1m0s
-
-running (0m39.0s), 900/900 VUs, 34193 complete and 0 interrupted iterations
-default   [  65% ] 900 VUs  0m39.0s/1m0s
-
-running (0m40.0s), 900/900 VUs, 35093 complete and 0 interrupted iterations
-default   [  67% ] 900 VUs  0m40.0s/1m0s
-
-running (0m41.0s), 900/900 VUs, 35993 complete and 0 interrupted iterations
-default   [  68% ] 900 VUs  0m41.0s/1m0s
-
-running (0m42.0s), 900/900 VUs, 36893 complete and 0 interrupted iterations
-default   [  70% ] 900 VUs  0m42.0s/1m0s
-
-running (0m43.0s), 900/900 VUs, 37793 complete and 0 interrupted iterations
-default   [  72% ] 900 VUs  0m43.0s/1m0s
-
-running (0m44.0s), 900/900 VUs, 38693 complete and 0 interrupted iterations
-default   [  73% ] 900 VUs  0m44.0s/1m0s
-
-running (0m45.0s), 900/900 VUs, 39593 complete and 0 interrupted iterations
-default   [  75% ] 900 VUs  0m45.0s/1m0s
-
-running (0m46.0s), 900/900 VUs, 40493 complete and 0 interrupted iterations
-default   [  77% ] 900 VUs  0m46.0s/1m0s
-
-running (0m47.0s), 900/900 VUs, 41393 complete and 0 interrupted iterations
-default   [  78% ] 900 VUs  0m47.0s/1m0s
-
-running (0m48.0s), 900/900 VUs, 42293 complete and 0 interrupted iterations
-default   [  80% ] 900 VUs  0m48.0s/1m0s
-
-running (0m49.0s), 900/900 VUs, 43193 complete and 0 interrupted iterations
-default   [  82% ] 900 VUs  0m49.0s/1m0s
-
-running (0m50.0s), 900/900 VUs, 44093 complete and 0 interrupted iterations
-default   [  83% ] 900 VUs  0m50.0s/1m0s
-
-running (0m51.0s), 900/900 VUs, 44993 complete and 0 interrupted iterations
-default   [  85% ] 900 VUs  0m51.0s/1m0s
-
-running (0m52.0s), 900/900 VUs, 45893 complete and 0 interrupted iterations
-default   [  87% ] 900 VUs  0m52.0s/1m0s
-
-running (0m53.0s), 900/900 VUs, 46793 complete and 0 interrupted iterations
-default   [  88% ] 900 VUs  0m53.0s/1m0s
-
-running (0m54.0s), 900/900 VUs, 47693 complete and 0 interrupted iterations
-default   [  90% ] 900 VUs  0m54.0s/1m0s
-
-running (0m55.0s), 900/900 VUs, 48593 complete and 0 interrupted iterations
-default   [  92% ] 900 VUs  0m55.0s/1m0s
-
-running (0m56.0s), 900/900 VUs, 49493 complete and 0 interrupted iterations
-default   [  93% ] 900 VUs  0m56.0s/1m0s
-
-running (0m57.0s), 900/900 VUs, 50393 complete and 0 interrupted iterations
-default   [  95% ] 900 VUs  0m57.0s/1m0s
-
-running (0m58.0s), 900/900 VUs, 51293 complete and 0 interrupted iterations
-default   [  97% ] 900 VUs  0m58.0s/1m0s
-
-running (0m59.0s), 900/900 VUs, 52193 complete and 0 interrupted iterations
-default   [  98% ] 900 VUs  0m59.0s/1m0s
-
-running (1m00.0s), 900/900 VUs, 53093 complete and 0 interrupted iterations
-default   [ 100% ] 900 VUs  1m00.0s/1m0s
-
-
-  █ TOTAL RESULTS 
-
-    HTTP
-    http_req_duration..............: avg=980.32µs min=54µs med=748.56µs max=208.37ms p(90)=1.78ms p(95)=2.25ms
-      { expected_response:true }...: avg=980.32µs min=54µs med=748.56µs max=208.37ms p(90)=1.78ms p(95)=2.25ms
-    http_req_failed................: 0.00%  0 out of 53993
-    http_reqs......................: 53993  895.345854/s
-
-    EXECUTION
-    iteration_duration.............: avg=1s       min=1s   med=1s       max=2.01s    p(90)=1s     p(95)=1s    
-    iterations.....................: 53993  895.345854/s
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=2.04s    p(90)=1s     p(95)=1s    
+    iterations.....................: 53962  894.844102/s
     vus............................: 900    min=900        max=900
     vus_max........................: 900    min=900        max=900
 
@@ -1091,7 +434,7 @@ default   [ 100% ] 900 VUs  1m00.0s/1m0s
 
 
 
-running (1m00.3s), 000/900 VUs, 53993 complete and 0 interrupted iterations
+running (1m00.3s), 000/900 VUs, 53962 complete and 0 interrupted iterations
 default ✓ [ 100% ] 900 VUs  1m0s
 
          /\      Grafana   /‾‾/  
@@ -1111,1071 +454,195 @@ default ✓ [ 100% ] 900 VUs  1m0s
 running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
 default   [   2% ] 900 VUs  0m01.0s/1m0s
 
-running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
+running (0m02.0s), 900/900 VUs, 832 complete and 0 interrupted iterations
 default   [   3% ] 900 VUs  0m02.0s/1m0s
 
-running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
+running (0m03.0s), 900/900 VUs, 1732 complete and 0 interrupted iterations
 default   [   5% ] 900 VUs  0m03.0s/1m0s
 
-running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
+running (0m04.0s), 900/900 VUs, 2632 complete and 0 interrupted iterations
 default   [   7% ] 900 VUs  0m04.0s/1m0s
 
-running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
+running (0m05.0s), 900/900 VUs, 3532 complete and 0 interrupted iterations
 default   [   8% ] 900 VUs  0m05.0s/1m0s
 
-running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
+running (0m06.0s), 900/900 VUs, 4432 complete and 0 interrupted iterations
 default   [  10% ] 900 VUs  0m06.0s/1m0s
 
-running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
+running (0m07.0s), 900/900 VUs, 5332 complete and 0 interrupted iterations
 default   [  12% ] 900 VUs  0m07.0s/1m0s
 
-running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
+running (0m08.0s), 900/900 VUs, 6232 complete and 0 interrupted iterations
 default   [  13% ] 900 VUs  0m08.0s/1m0s
 
-running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
+running (0m09.0s), 900/900 VUs, 7132 complete and 0 interrupted iterations
 default   [  15% ] 900 VUs  0m09.0s/1m0s
 
-running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
+running (0m10.0s), 900/900 VUs, 8032 complete and 0 interrupted iterations
 default   [  17% ] 900 VUs  0m10.0s/1m0s
 
-running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
+running (0m11.0s), 900/900 VUs, 8932 complete and 0 interrupted iterations
 default   [  18% ] 900 VUs  0m11.0s/1m0s
 
-running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
+running (0m12.0s), 900/900 VUs, 9832 complete and 0 interrupted iterations
 default   [  20% ] 900 VUs  0m12.0s/1m0s
 
-running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
+running (0m13.0s), 900/900 VUs, 10732 complete and 0 interrupted iterations
 default   [  22% ] 900 VUs  0m13.0s/1m0s
 
-running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
+running (0m14.0s), 900/900 VUs, 11632 complete and 0 interrupted iterations
 default   [  23% ] 900 VUs  0m14.0s/1m0s
 
-running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
+running (0m15.0s), 900/900 VUs, 12532 complete and 0 interrupted iterations
 default   [  25% ] 900 VUs  0m15.0s/1m0s
 
-running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
+running (0m16.0s), 900/900 VUs, 13432 complete and 0 interrupted iterations
 default   [  27% ] 900 VUs  0m16.0s/1m0s
 
-running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
+running (0m17.0s), 900/900 VUs, 14332 complete and 0 interrupted iterations
 default   [  28% ] 900 VUs  0m17.0s/1m0s
 
-running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
+running (0m18.0s), 900/900 VUs, 15232 complete and 0 interrupted iterations
 default   [  30% ] 900 VUs  0m18.0s/1m0s
 
-running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
+running (0m19.0s), 900/900 VUs, 16132 complete and 0 interrupted iterations
 default   [  32% ] 900 VUs  0m19.0s/1m0s
 
-running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
+running (0m20.0s), 900/900 VUs, 17032 complete and 0 interrupted iterations
 default   [  33% ] 900 VUs  0m20.0s/1m0s
 
-running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
+running (0m21.0s), 900/900 VUs, 17932 complete and 0 interrupted iterations
 default   [  35% ] 900 VUs  0m21.0s/1m0s
 
-running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
+running (0m22.0s), 900/900 VUs, 18832 complete and 0 interrupted iterations
 default   [  37% ] 900 VUs  0m22.0s/1m0s
 
-running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
+running (0m23.0s), 900/900 VUs, 19732 complete and 0 interrupted iterations
 default   [  38% ] 900 VUs  0m23.0s/1m0s
 
-running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
+running (0m24.0s), 900/900 VUs, 20632 complete and 0 interrupted iterations
 default   [  40% ] 900 VUs  0m24.0s/1m0s
 
-running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
+running (0m25.0s), 900/900 VUs, 21532 complete and 0 interrupted iterations
 default   [  42% ] 900 VUs  0m25.0s/1m0s
 
-running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
+running (0m26.0s), 900/900 VUs, 22432 complete and 0 interrupted iterations
 default   [  43% ] 900 VUs  0m26.0s/1m0s
 
-running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
+running (0m27.0s), 900/900 VUs, 23332 complete and 0 interrupted iterations
 default   [  45% ] 900 VUs  0m27.0s/1m0s
 
-running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
+running (0m28.0s), 900/900 VUs, 24232 complete and 0 interrupted iterations
 default   [  47% ] 900 VUs  0m28.0s/1m0s
 
-running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
+running (0m29.0s), 900/900 VUs, 25132 complete and 0 interrupted iterations
 default   [  48% ] 900 VUs  0m29.0s/1m0s
 
-running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
+running (0m30.0s), 900/900 VUs, 26032 complete and 0 interrupted iterations
 default   [  50% ] 900 VUs  0m30.0s/1m0s
 
-running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
+running (0m31.0s), 900/900 VUs, 26932 complete and 0 interrupted iterations
 default   [  52% ] 900 VUs  0m31.0s/1m0s
 
-running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
+running (0m32.0s), 900/900 VUs, 27832 complete and 0 interrupted iterations
 default   [  53% ] 900 VUs  0m32.0s/1m0s
 
-running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
+running (0m33.0s), 900/900 VUs, 28732 complete and 0 interrupted iterations
 default   [  55% ] 900 VUs  0m33.0s/1m0s
 
-running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
+running (0m34.0s), 900/900 VUs, 29632 complete and 0 interrupted iterations
 default   [  57% ] 900 VUs  0m34.0s/1m0s
 
-running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
+running (0m35.0s), 900/900 VUs, 30532 complete and 0 interrupted iterations
 default   [  58% ] 900 VUs  0m35.0s/1m0s
 
-running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
+running (0m36.0s), 900/900 VUs, 31432 complete and 0 interrupted iterations
 default   [  60% ] 900 VUs  0m36.0s/1m0s
 
-running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
+running (0m37.0s), 900/900 VUs, 32332 complete and 0 interrupted iterations
 default   [  62% ] 900 VUs  0m37.0s/1m0s
 
-running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
+running (0m38.0s), 900/900 VUs, 33232 complete and 0 interrupted iterations
 default   [  63% ] 900 VUs  0m38.0s/1m0s
 
-running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
+running (0m39.0s), 900/900 VUs, 34132 complete and 0 interrupted iterations
 default   [  65% ] 900 VUs  0m39.0s/1m0s
 
-running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
+running (0m40.0s), 900/900 VUs, 35032 complete and 0 interrupted iterations
 default   [  67% ] 900 VUs  0m40.0s/1m0s
 
-running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
+running (0m41.0s), 900/900 VUs, 35932 complete and 0 interrupted iterations
 default   [  68% ] 900 VUs  0m41.0s/1m0s
 
-running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
+running (0m42.0s), 900/900 VUs, 36832 complete and 0 interrupted iterations
 default   [  70% ] 900 VUs  0m42.0s/1m0s
 
-running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
+running (0m43.0s), 900/900 VUs, 37732 complete and 0 interrupted iterations
 default   [  72% ] 900 VUs  0m43.0s/1m0s
 
-running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
+running (0m44.0s), 900/900 VUs, 38632 complete and 0 interrupted iterations
 default   [  73% ] 900 VUs  0m44.0s/1m0s
 
-running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
+running (0m45.0s), 900/900 VUs, 39532 complete and 0 interrupted iterations
 default   [  75% ] 900 VUs  0m45.0s/1m0s
 
-running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
+running (0m46.0s), 900/900 VUs, 40432 complete and 0 interrupted iterations
 default   [  77% ] 900 VUs  0m46.0s/1m0s
 
-running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
+running (0m47.0s), 900/900 VUs, 41332 complete and 0 interrupted iterations
 default   [  78% ] 900 VUs  0m47.0s/1m0s
 
-running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
+running (0m48.0s), 900/900 VUs, 42232 complete and 0 interrupted iterations
 default   [  80% ] 900 VUs  0m48.0s/1m0s
 
-running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
+running (0m49.0s), 900/900 VUs, 43132 complete and 0 interrupted iterations
 default   [  82% ] 900 VUs  0m49.0s/1m0s
 
-running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
+running (0m50.0s), 900/900 VUs, 44032 complete and 0 interrupted iterations
 default   [  83% ] 900 VUs  0m50.0s/1m0s
 
-running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
+running (0m51.0s), 900/900 VUs, 44932 complete and 0 interrupted iterations
 default   [  85% ] 900 VUs  0m51.0s/1m0s
 
-running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
+running (0m52.0s), 900/900 VUs, 45832 complete and 0 interrupted iterations
 default   [  87% ] 900 VUs  0m52.0s/1m0s
 
-running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
+running (0m53.0s), 900/900 VUs, 46732 complete and 0 interrupted iterations
 default   [  88% ] 900 VUs  0m53.0s/1m0s
 
-running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
+running (0m54.0s), 900/900 VUs, 47632 complete and 0 interrupted iterations
 default   [  90% ] 900 VUs  0m54.0s/1m0s
 
-running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
+running (0m55.0s), 900/900 VUs, 48532 complete and 0 interrupted iterations
 default   [  92% ] 900 VUs  0m55.0s/1m0s
 
-running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
+running (0m56.0s), 900/900 VUs, 49432 complete and 0 interrupted iterations
 default   [  93% ] 900 VUs  0m56.0s/1m0s
 
-running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
+running (0m57.0s), 900/900 VUs, 50332 complete and 0 interrupted iterations
 default   [  95% ] 900 VUs  0m57.0s/1m0s
 
-running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
+running (0m58.0s), 900/900 VUs, 51232 complete and 0 interrupted iterations
 default   [  97% ] 900 VUs  0m58.0s/1m0s
 
-running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
+running (0m59.0s), 900/900 VUs, 52132 complete and 0 interrupted iterations
 default   [  98% ] 900 VUs  0m59.0s/1m0s
 
-running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
+running (1m00.0s), 900/900 VUs, 53032 complete and 0 interrupted iterations
 default   [ 100% ] 900 VUs  1m00.0s/1m0s
 
 
   █ TOTAL RESULTS 
 
     HTTP
-    http_req_duration..............: avg=921.98µs min=54.28µs med=665.48µs max=23.66ms p(90)=1.71ms p(95)=2.37ms
-      { expected_response:true }...: avg=921.98µs min=54.28µs med=665.48µs max=23.66ms p(90)=1.71ms p(95)=2.37ms
-    http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.218037/s
+    http_req_duration..............: avg=954.14µs min=61.83µs med=694.36µs max=205.85ms p(90)=1.84ms p(95)=2.37ms
+      { expected_response:true }...: avg=954.14µs min=61.83µs med=694.36µs max=205.85ms p(90)=1.84ms p(95)=2.37ms
+    http_req_failed................: 0.00%  0 out of 53932
+    http_reqs......................: 53932  894.388352/s
 
     EXECUTION
-    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.03s   p(90)=1s     p(95)=1s    
-    iterations.....................: 54000  898.218037/s
-    vus............................: 900    min=900        max=900
-    vus_max........................: 900    min=900        max=900
-
-    NETWORK
-    data_received..................: 15 MB  247 kB/s
-    data_sent......................: 4.2 MB 70 kB/s
-
-
-
-
-running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
-default ✓ [ 100% ] 900 VUs  1m0s
-
-         /\      Grafana   /‾‾/  
-    /\  /  \     |\  __   /  /   
-   /  \/    \    | |/ /  /   ‾‾\ 
-  /          \   |   (  |  (‾)  |
- / __________ \  |_|\_\  \_____/ 
-
-     execution: local
-        script: benchmarkHummingbird.js
-        output: -
-
-     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
-              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
-
-
-running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
-default   [   2% ] 900 VUs  0m01.0s/1m0s
-
-running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
-default   [   3% ] 900 VUs  0m02.0s/1m0s
-
-running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
-default   [   5% ] 900 VUs  0m03.0s/1m0s
-
-running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
-default   [   7% ] 900 VUs  0m04.0s/1m0s
-
-running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
-default   [   8% ] 900 VUs  0m05.0s/1m0s
-
-running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
-default   [  10% ] 900 VUs  0m06.0s/1m0s
-
-running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
-default   [  12% ] 900 VUs  0m07.0s/1m0s
-
-running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
-default   [  13% ] 900 VUs  0m08.0s/1m0s
-
-running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
-default   [  15% ] 900 VUs  0m09.0s/1m0s
-
-running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
-default   [  17% ] 900 VUs  0m10.0s/1m0s
-
-running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
-default   [  18% ] 900 VUs  0m11.0s/1m0s
-
-running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
-default   [  20% ] 900 VUs  0m12.0s/1m0s
-
-running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
-default   [  22% ] 900 VUs  0m13.0s/1m0s
-
-running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
-default   [  23% ] 900 VUs  0m14.0s/1m0s
-
-running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
-default   [  25% ] 900 VUs  0m15.0s/1m0s
-
-running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
-default   [  27% ] 900 VUs  0m16.0s/1m0s
-
-running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
-default   [  28% ] 900 VUs  0m17.0s/1m0s
-
-running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
-default   [  30% ] 900 VUs  0m18.0s/1m0s
-
-running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
-default   [  32% ] 900 VUs  0m19.0s/1m0s
-
-running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
-default   [  33% ] 900 VUs  0m20.0s/1m0s
-
-running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
-default   [  35% ] 900 VUs  0m21.0s/1m0s
-
-running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
-default   [  37% ] 900 VUs  0m22.0s/1m0s
-
-running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
-default   [  38% ] 900 VUs  0m23.0s/1m0s
-
-running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
-default   [  40% ] 900 VUs  0m24.0s/1m0s
-
-running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
-default   [  42% ] 900 VUs  0m25.0s/1m0s
-
-running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
-default   [  43% ] 900 VUs  0m26.0s/1m0s
-
-running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
-default   [  45% ] 900 VUs  0m27.0s/1m0s
-
-running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
-default   [  47% ] 900 VUs  0m28.0s/1m0s
-
-running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
-default   [  48% ] 900 VUs  0m29.0s/1m0s
-
-running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
-default   [  50% ] 900 VUs  0m30.0s/1m0s
-
-running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
-default   [  52% ] 900 VUs  0m31.0s/1m0s
-
-running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
-default   [  53% ] 900 VUs  0m32.0s/1m0s
-
-running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
-default   [  55% ] 900 VUs  0m33.0s/1m0s
-
-running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
-default   [  57% ] 900 VUs  0m34.0s/1m0s
-
-running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
-default   [  58% ] 900 VUs  0m35.0s/1m0s
-
-running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
-default   [  60% ] 900 VUs  0m36.0s/1m0s
-
-running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
-default   [  62% ] 900 VUs  0m37.0s/1m0s
-
-running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
-default   [  63% ] 900 VUs  0m38.0s/1m0s
-
-running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
-default   [  65% ] 900 VUs  0m39.0s/1m0s
-
-running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
-default   [  67% ] 900 VUs  0m40.0s/1m0s
-
-running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
-default   [  68% ] 900 VUs  0m41.0s/1m0s
-
-running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
-default   [  70% ] 900 VUs  0m42.0s/1m0s
-
-running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
-default   [  72% ] 900 VUs  0m43.0s/1m0s
-
-running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
-default   [  73% ] 900 VUs  0m44.0s/1m0s
-
-running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
-default   [  75% ] 900 VUs  0m45.0s/1m0s
-
-running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
-default   [  77% ] 900 VUs  0m46.0s/1m0s
-
-running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
-default   [  78% ] 900 VUs  0m47.0s/1m0s
-
-running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
-default   [  80% ] 900 VUs  0m48.0s/1m0s
-
-running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
-default   [  82% ] 900 VUs  0m49.0s/1m0s
-
-running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
-default   [  83% ] 900 VUs  0m50.0s/1m0s
-
-running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
-default   [  85% ] 900 VUs  0m51.0s/1m0s
-
-running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
-default   [  87% ] 900 VUs  0m52.0s/1m0s
-
-running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
-default   [  88% ] 900 VUs  0m53.0s/1m0s
-
-running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
-default   [  90% ] 900 VUs  0m54.0s/1m0s
-
-running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
-default   [  92% ] 900 VUs  0m55.0s/1m0s
-
-running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
-default   [  93% ] 900 VUs  0m56.0s/1m0s
-
-running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
-default   [  95% ] 900 VUs  0m57.0s/1m0s
-
-running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
-default   [  97% ] 900 VUs  0m58.0s/1m0s
-
-running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
-default   [  98% ] 900 VUs  0m59.0s/1m0s
-
-running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
-default   [ 100% ] 900 VUs  1m00.0s/1m0s
-
-
-  █ TOTAL RESULTS 
-
-    HTTP
-    http_req_duration..............: avg=792.98µs min=62.06µs med=553.69µs max=24.98ms p(90)=1.41ms p(95)=1.98ms
-      { expected_response:true }...: avg=792.98µs min=62.06µs med=553.69µs max=24.98ms p(90)=1.41ms p(95)=1.98ms
-    http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.365213/s
-
-    EXECUTION
-    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.04s   p(90)=1s     p(95)=1s    
-    iterations.....................: 54000  898.365213/s
-    vus............................: 900    min=900        max=900
-    vus_max........................: 900    min=900        max=900
-
-    NETWORK
-    data_received..................: 15 MB  247 kB/s
-    data_sent......................: 4.2 MB 70 kB/s
-
-
-
-
-running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
-default ✓ [ 100% ] 900 VUs  1m0s
-
-         /\      Grafana   /‾‾/  
-    /\  /  \     |\  __   /  /   
-   /  \/    \    | |/ /  /   ‾‾\ 
-  /          \   |   (  |  (‾)  |
- / __________ \  |_|\_\  \_____/ 
-
-     execution: local
-        script: benchmarkHummingbird.js
-        output: -
-
-     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
-              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
-
-
-running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
-default   [   2% ] 900 VUs  0m01.0s/1m0s
-
-running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
-default   [   3% ] 900 VUs  0m02.0s/1m0s
-
-running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
-default   [   5% ] 900 VUs  0m03.0s/1m0s
-
-running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
-default   [   7% ] 900 VUs  0m04.0s/1m0s
-
-running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
-default   [   8% ] 900 VUs  0m05.0s/1m0s
-
-running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
-default   [  10% ] 900 VUs  0m06.0s/1m0s
-
-running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
-default   [  12% ] 900 VUs  0m07.0s/1m0s
-
-running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
-default   [  13% ] 900 VUs  0m08.0s/1m0s
-
-running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
-default   [  15% ] 900 VUs  0m09.0s/1m0s
-
-running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
-default   [  17% ] 900 VUs  0m10.0s/1m0s
-
-running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
-default   [  18% ] 900 VUs  0m11.0s/1m0s
-
-running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
-default   [  20% ] 900 VUs  0m12.0s/1m0s
-
-running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
-default   [  22% ] 900 VUs  0m13.0s/1m0s
-
-running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
-default   [  23% ] 900 VUs  0m14.0s/1m0s
-
-running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
-default   [  25% ] 900 VUs  0m15.0s/1m0s
-
-running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
-default   [  27% ] 900 VUs  0m16.0s/1m0s
-
-running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
-default   [  28% ] 900 VUs  0m17.0s/1m0s
-
-running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
-default   [  30% ] 900 VUs  0m18.0s/1m0s
-
-running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
-default   [  32% ] 900 VUs  0m19.0s/1m0s
-
-running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
-default   [  33% ] 900 VUs  0m20.0s/1m0s
-
-running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
-default   [  35% ] 900 VUs  0m21.0s/1m0s
-
-running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
-default   [  37% ] 900 VUs  0m22.0s/1m0s
-
-running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
-default   [  38% ] 900 VUs  0m23.0s/1m0s
-
-running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
-default   [  40% ] 900 VUs  0m24.0s/1m0s
-
-running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
-default   [  42% ] 900 VUs  0m25.0s/1m0s
-
-running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
-default   [  43% ] 900 VUs  0m26.0s/1m0s
-
-running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
-default   [  45% ] 900 VUs  0m27.0s/1m0s
-
-running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
-default   [  47% ] 900 VUs  0m28.0s/1m0s
-
-running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
-default   [  48% ] 900 VUs  0m29.0s/1m0s
-
-running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
-default   [  50% ] 900 VUs  0m30.0s/1m0s
-
-running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
-default   [  52% ] 900 VUs  0m31.0s/1m0s
-
-running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
-default   [  53% ] 900 VUs  0m32.0s/1m0s
-
-running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
-default   [  55% ] 900 VUs  0m33.0s/1m0s
-
-running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
-default   [  57% ] 900 VUs  0m34.0s/1m0s
-
-running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
-default   [  58% ] 900 VUs  0m35.0s/1m0s
-
-running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
-default   [  60% ] 900 VUs  0m36.0s/1m0s
-
-running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
-default   [  62% ] 900 VUs  0m37.0s/1m0s
-
-running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
-default   [  63% ] 900 VUs  0m38.0s/1m0s
-
-running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
-default   [  65% ] 900 VUs  0m39.0s/1m0s
-
-running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
-default   [  67% ] 900 VUs  0m40.0s/1m0s
-
-running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
-default   [  68% ] 900 VUs  0m41.0s/1m0s
-
-running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
-default   [  70% ] 900 VUs  0m42.0s/1m0s
-
-running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
-default   [  72% ] 900 VUs  0m43.0s/1m0s
-
-running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
-default   [  73% ] 900 VUs  0m44.0s/1m0s
-
-running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
-default   [  75% ] 900 VUs  0m45.0s/1m0s
-
-running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
-default   [  77% ] 900 VUs  0m46.0s/1m0s
-
-running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
-default   [  78% ] 900 VUs  0m47.0s/1m0s
-
-running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
-default   [  80% ] 900 VUs  0m48.0s/1m0s
-
-running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
-default   [  82% ] 900 VUs  0m49.0s/1m0s
-
-running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
-default   [  83% ] 900 VUs  0m50.0s/1m0s
-
-running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
-default   [  85% ] 900 VUs  0m51.0s/1m0s
-
-running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
-default   [  87% ] 900 VUs  0m52.0s/1m0s
-
-running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
-default   [  88% ] 900 VUs  0m53.0s/1m0s
-
-running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
-default   [  90% ] 900 VUs  0m54.0s/1m0s
-
-running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
-default   [  92% ] 900 VUs  0m55.0s/1m0s
-
-running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
-default   [  93% ] 900 VUs  0m56.0s/1m0s
-
-running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
-default   [  95% ] 900 VUs  0m57.0s/1m0s
-
-running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
-default   [  97% ] 900 VUs  0m58.0s/1m0s
-
-running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
-default   [  98% ] 900 VUs  0m59.0s/1m0s
-
-running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
-default   [ 100% ] 900 VUs  1m00.0s/1m0s
-
-
-  █ TOTAL RESULTS 
-
-    HTTP
-    http_req_duration..............: avg=595.01µs min=62.78µs med=453.48µs max=19.59ms p(90)=1.09ms p(95)=1.4ms
-      { expected_response:true }...: avg=595.01µs min=62.78µs med=453.48µs max=19.59ms p(90)=1.09ms p(95)=1.4ms
-    http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.482071/s
-
-    EXECUTION
-    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.02s   p(90)=1s     p(95)=1s   
-    iterations.....................: 54000  898.482071/s
-    vus............................: 900    min=900        max=900
-    vus_max........................: 900    min=900        max=900
-
-    NETWORK
-    data_received..................: 15 MB  247 kB/s
-    data_sent......................: 4.2 MB 70 kB/s
-
-
-
-
-running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
-default ✓ [ 100% ] 900 VUs  1m0s
-
-         /\      Grafana   /‾‾/  
-    /\  /  \     |\  __   /  /   
-   /  \/    \    | |/ /  /   ‾‾\ 
-  /          \   |   (  |  (‾)  |
- / __________ \  |_|\_\  \_____/ 
-
-     execution: local
-        script: benchmarkHummingbird.js
-        output: -
-
-     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
-              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
-
-
-running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
-default   [   2% ] 900 VUs  0m01.0s/1m0s
-
-running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
-default   [   3% ] 900 VUs  0m02.0s/1m0s
-
-running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
-default   [   5% ] 900 VUs  0m03.0s/1m0s
-
-running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
-default   [   7% ] 900 VUs  0m04.0s/1m0s
-
-running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
-default   [   8% ] 900 VUs  0m05.0s/1m0s
-
-running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
-default   [  10% ] 900 VUs  0m06.0s/1m0s
-
-running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
-default   [  12% ] 900 VUs  0m07.0s/1m0s
-
-running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
-default   [  13% ] 900 VUs  0m08.0s/1m0s
-
-running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
-default   [  15% ] 900 VUs  0m09.0s/1m0s
-
-running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
-default   [  17% ] 900 VUs  0m10.0s/1m0s
-
-running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
-default   [  18% ] 900 VUs  0m11.0s/1m0s
-
-running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
-default   [  20% ] 900 VUs  0m12.0s/1m0s
-
-running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
-default   [  22% ] 900 VUs  0m13.0s/1m0s
-
-running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
-default   [  23% ] 900 VUs  0m14.0s/1m0s
-
-running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
-default   [  25% ] 900 VUs  0m15.0s/1m0s
-
-running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
-default   [  27% ] 900 VUs  0m16.0s/1m0s
-
-running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
-default   [  28% ] 900 VUs  0m17.0s/1m0s
-
-running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
-default   [  30% ] 900 VUs  0m18.0s/1m0s
-
-running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
-default   [  32% ] 900 VUs  0m19.0s/1m0s
-
-running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
-default   [  33% ] 900 VUs  0m20.0s/1m0s
-
-running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
-default   [  35% ] 900 VUs  0m21.0s/1m0s
-
-running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
-default   [  37% ] 900 VUs  0m22.0s/1m0s
-
-running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
-default   [  38% ] 900 VUs  0m23.0s/1m0s
-
-running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
-default   [  40% ] 900 VUs  0m24.0s/1m0s
-
-running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
-default   [  42% ] 900 VUs  0m25.0s/1m0s
-
-running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
-default   [  43% ] 900 VUs  0m26.0s/1m0s
-
-running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
-default   [  45% ] 900 VUs  0m27.0s/1m0s
-
-running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
-default   [  47% ] 900 VUs  0m28.0s/1m0s
-
-running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
-default   [  48% ] 900 VUs  0m29.0s/1m0s
-
-running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
-default   [  50% ] 900 VUs  0m30.0s/1m0s
-
-running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
-default   [  52% ] 900 VUs  0m31.0s/1m0s
-
-running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
-default   [  53% ] 900 VUs  0m32.0s/1m0s
-
-running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
-default   [  55% ] 900 VUs  0m33.0s/1m0s
-
-running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
-default   [  57% ] 900 VUs  0m34.0s/1m0s
-
-running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
-default   [  58% ] 900 VUs  0m35.0s/1m0s
-
-running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
-default   [  60% ] 900 VUs  0m36.0s/1m0s
-
-running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
-default   [  62% ] 900 VUs  0m37.0s/1m0s
-
-running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
-default   [  63% ] 900 VUs  0m38.0s/1m0s
-
-running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
-default   [  65% ] 900 VUs  0m39.0s/1m0s
-
-running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
-default   [  67% ] 900 VUs  0m40.0s/1m0s
-
-running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
-default   [  68% ] 900 VUs  0m41.0s/1m0s
-
-running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
-default   [  70% ] 900 VUs  0m42.0s/1m0s
-
-running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
-default   [  72% ] 900 VUs  0m43.0s/1m0s
-
-running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
-default   [  73% ] 900 VUs  0m44.0s/1m0s
-
-running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
-default   [  75% ] 900 VUs  0m45.0s/1m0s
-
-running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
-default   [  77% ] 900 VUs  0m46.0s/1m0s
-
-running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
-default   [  78% ] 900 VUs  0m47.0s/1m0s
-
-running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
-default   [  80% ] 900 VUs  0m48.0s/1m0s
-
-running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
-default   [  82% ] 900 VUs  0m49.0s/1m0s
-
-running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
-default   [  83% ] 900 VUs  0m50.0s/1m0s
-
-running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
-default   [  85% ] 900 VUs  0m51.0s/1m0s
-
-running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
-default   [  87% ] 900 VUs  0m52.0s/1m0s
-
-running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
-default   [  88% ] 900 VUs  0m53.0s/1m0s
-
-running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
-default   [  90% ] 900 VUs  0m54.0s/1m0s
-
-running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
-default   [  92% ] 900 VUs  0m55.0s/1m0s
-
-running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
-default   [  93% ] 900 VUs  0m56.0s/1m0s
-
-running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
-default   [  95% ] 900 VUs  0m57.0s/1m0s
-
-running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
-default   [  97% ] 900 VUs  0m58.0s/1m0s
-
-running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
-default   [  98% ] 900 VUs  0m59.0s/1m0s
-
-running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
-default   [ 100% ] 900 VUs  1m00.0s/1m0s
-
-
-  █ TOTAL RESULTS 
-
-    HTTP
-    http_req_duration..............: avg=919.86µs min=62.4µs med=648.89µs max=28.08ms p(90)=1.71ms p(95)=2.33ms
-      { expected_response:true }...: avg=919.86µs min=62.4µs med=648.89µs max=28.08ms p(90)=1.71ms p(95)=2.33ms
-    http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.240516/s
-
-    EXECUTION
-    iteration_duration.............: avg=1s       min=1s     med=1s       max=1.03s   p(90)=1s     p(95)=1s    
-    iterations.....................: 54000  898.240516/s
-    vus............................: 900    min=900        max=900
-    vus_max........................: 900    min=900        max=900
-
-    NETWORK
-    data_received..................: 15 MB  247 kB/s
-    data_sent......................: 4.2 MB 70 kB/s
-
-
-
-
-running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
-default ✓ [ 100% ] 900 VUs  1m0s
-
-         /\      Grafana   /‾‾/  
-    /\  /  \     |\  __   /  /   
-   /  \/    \    | |/ /  /   ‾‾\ 
-  /          \   |   (  |  (‾)  |
- / __________ \  |_|\_\  \_____/ 
-
-     execution: local
-        script: benchmarkHummingbird.js
-        output: -
-
-     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
-              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
-
-
-running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
-default   [   2% ] 900 VUs  0m01.0s/1m0s
-
-running (0m02.0s), 900/900 VUs, 866 complete and 0 interrupted iterations
-default   [   3% ] 900 VUs  0m02.0s/1m0s
-
-running (0m03.0s), 900/900 VUs, 1766 complete and 0 interrupted iterations
-default   [   5% ] 900 VUs  0m03.0s/1m0s
-
-running (0m04.0s), 900/900 VUs, 2666 complete and 0 interrupted iterations
-default   [   7% ] 900 VUs  0m04.0s/1m0s
-
-running (0m05.0s), 900/900 VUs, 3566 complete and 0 interrupted iterations
-default   [   8% ] 900 VUs  0m05.0s/1m0s
-
-running (0m06.0s), 900/900 VUs, 4466 complete and 0 interrupted iterations
-default   [  10% ] 900 VUs  0m06.0s/1m0s
-
-running (0m07.0s), 900/900 VUs, 5366 complete and 0 interrupted iterations
-default   [  12% ] 900 VUs  0m07.0s/1m0s
-
-running (0m08.0s), 900/900 VUs, 6266 complete and 0 interrupted iterations
-default   [  13% ] 900 VUs  0m08.0s/1m0s
-
-running (0m09.0s), 900/900 VUs, 7166 complete and 0 interrupted iterations
-default   [  15% ] 900 VUs  0m09.0s/1m0s
-
-running (0m10.0s), 900/900 VUs, 8066 complete and 0 interrupted iterations
-default   [  17% ] 900 VUs  0m10.0s/1m0s
-
-running (0m11.0s), 900/900 VUs, 8966 complete and 0 interrupted iterations
-default   [  18% ] 900 VUs  0m11.0s/1m0s
-
-running (0m12.0s), 900/900 VUs, 9866 complete and 0 interrupted iterations
-default   [  20% ] 900 VUs  0m12.0s/1m0s
-
-running (0m13.0s), 900/900 VUs, 10766 complete and 0 interrupted iterations
-default   [  22% ] 900 VUs  0m13.0s/1m0s
-
-running (0m14.0s), 900/900 VUs, 11666 complete and 0 interrupted iterations
-default   [  23% ] 900 VUs  0m14.0s/1m0s
-
-running (0m15.0s), 900/900 VUs, 12566 complete and 0 interrupted iterations
-default   [  25% ] 900 VUs  0m15.0s/1m0s
-
-running (0m16.0s), 900/900 VUs, 13466 complete and 0 interrupted iterations
-default   [  27% ] 900 VUs  0m16.0s/1m0s
-
-running (0m17.0s), 900/900 VUs, 14366 complete and 0 interrupted iterations
-default   [  28% ] 900 VUs  0m17.0s/1m0s
-
-running (0m18.0s), 900/900 VUs, 15266 complete and 0 interrupted iterations
-default   [  30% ] 900 VUs  0m18.0s/1m0s
-
-running (0m19.0s), 900/900 VUs, 16166 complete and 0 interrupted iterations
-default   [  32% ] 900 VUs  0m19.0s/1m0s
-
-running (0m20.0s), 900/900 VUs, 17066 complete and 0 interrupted iterations
-default   [  33% ] 900 VUs  0m20.0s/1m0s
-
-running (0m21.0s), 900/900 VUs, 17966 complete and 0 interrupted iterations
-default   [  35% ] 900 VUs  0m21.0s/1m0s
-
-running (0m22.0s), 900/900 VUs, 18866 complete and 0 interrupted iterations
-default   [  37% ] 900 VUs  0m22.0s/1m0s
-
-running (0m23.0s), 900/900 VUs, 19766 complete and 0 interrupted iterations
-default   [  38% ] 900 VUs  0m23.0s/1m0s
-
-running (0m24.0s), 900/900 VUs, 20666 complete and 0 interrupted iterations
-default   [  40% ] 900 VUs  0m24.0s/1m0s
-
-running (0m25.0s), 900/900 VUs, 21566 complete and 0 interrupted iterations
-default   [  42% ] 900 VUs  0m25.0s/1m0s
-
-running (0m26.0s), 900/900 VUs, 22466 complete and 0 interrupted iterations
-default   [  43% ] 900 VUs  0m26.0s/1m0s
-
-running (0m27.0s), 900/900 VUs, 23366 complete and 0 interrupted iterations
-default   [  45% ] 900 VUs  0m27.0s/1m0s
-
-running (0m28.0s), 900/900 VUs, 24266 complete and 0 interrupted iterations
-default   [  47% ] 900 VUs  0m28.0s/1m0s
-
-running (0m29.0s), 900/900 VUs, 25166 complete and 0 interrupted iterations
-default   [  48% ] 900 VUs  0m29.0s/1m0s
-
-running (0m30.0s), 900/900 VUs, 26066 complete and 0 interrupted iterations
-default   [  50% ] 900 VUs  0m30.0s/1m0s
-
-running (0m31.0s), 900/900 VUs, 26966 complete and 0 interrupted iterations
-default   [  52% ] 900 VUs  0m31.0s/1m0s
-
-running (0m32.0s), 900/900 VUs, 27866 complete and 0 interrupted iterations
-default   [  53% ] 900 VUs  0m32.0s/1m0s
-
-running (0m33.0s), 900/900 VUs, 28766 complete and 0 interrupted iterations
-default   [  55% ] 900 VUs  0m33.0s/1m0s
-
-running (0m34.0s), 900/900 VUs, 29666 complete and 0 interrupted iterations
-default   [  57% ] 900 VUs  0m34.0s/1m0s
-
-running (0m35.0s), 900/900 VUs, 30566 complete and 0 interrupted iterations
-default   [  58% ] 900 VUs  0m35.0s/1m0s
-
-running (0m36.0s), 900/900 VUs, 31466 complete and 0 interrupted iterations
-default   [  60% ] 900 VUs  0m36.0s/1m0s
-
-running (0m37.0s), 900/900 VUs, 32366 complete and 0 interrupted iterations
-default   [  62% ] 900 VUs  0m37.0s/1m0s
-
-running (0m38.0s), 900/900 VUs, 33266 complete and 0 interrupted iterations
-default   [  63% ] 900 VUs  0m38.0s/1m0s
-
-running (0m39.0s), 900/900 VUs, 34166 complete and 0 interrupted iterations
-default   [  65% ] 900 VUs  0m39.0s/1m0s
-
-running (0m40.0s), 900/900 VUs, 35066 complete and 0 interrupted iterations
-default   [  67% ] 900 VUs  0m40.0s/1m0s
-
-running (0m41.0s), 900/900 VUs, 35966 complete and 0 interrupted iterations
-default   [  68% ] 900 VUs  0m41.0s/1m0s
-
-running (0m42.0s), 900/900 VUs, 36866 complete and 0 interrupted iterations
-default   [  70% ] 900 VUs  0m42.0s/1m0s
-
-running (0m43.0s), 900/900 VUs, 37766 complete and 0 interrupted iterations
-default   [  72% ] 900 VUs  0m43.0s/1m0s
-
-running (0m44.0s), 900/900 VUs, 38666 complete and 0 interrupted iterations
-default   [  73% ] 900 VUs  0m44.0s/1m0s
-
-running (0m45.0s), 900/900 VUs, 39566 complete and 0 interrupted iterations
-default   [  75% ] 900 VUs  0m45.0s/1m0s
-
-running (0m46.0s), 900/900 VUs, 40466 complete and 0 interrupted iterations
-default   [  77% ] 900 VUs  0m46.0s/1m0s
-
-running (0m47.0s), 900/900 VUs, 41366 complete and 0 interrupted iterations
-default   [  78% ] 900 VUs  0m47.0s/1m0s
-
-running (0m48.0s), 900/900 VUs, 42266 complete and 0 interrupted iterations
-default   [  80% ] 900 VUs  0m48.0s/1m0s
-
-running (0m49.0s), 900/900 VUs, 43166 complete and 0 interrupted iterations
-default   [  82% ] 900 VUs  0m49.0s/1m0s
-
-running (0m50.0s), 900/900 VUs, 44066 complete and 0 interrupted iterations
-default   [  83% ] 900 VUs  0m50.0s/1m0s
-
-running (0m51.0s), 900/900 VUs, 44966 complete and 0 interrupted iterations
-default   [  85% ] 900 VUs  0m51.0s/1m0s
-
-running (0m52.0s), 900/900 VUs, 45866 complete and 0 interrupted iterations
-default   [  87% ] 900 VUs  0m52.0s/1m0s
-
-running (0m53.0s), 900/900 VUs, 46766 complete and 0 interrupted iterations
-default   [  88% ] 900 VUs  0m53.0s/1m0s
-
-running (0m54.0s), 900/900 VUs, 47666 complete and 0 interrupted iterations
-default   [  90% ] 900 VUs  0m54.0s/1m0s
-
-running (0m55.0s), 900/900 VUs, 48566 complete and 0 interrupted iterations
-default   [  92% ] 900 VUs  0m55.0s/1m0s
-
-running (0m56.0s), 900/900 VUs, 49466 complete and 0 interrupted iterations
-default   [  93% ] 900 VUs  0m56.0s/1m0s
-
-running (0m57.0s), 900/900 VUs, 50366 complete and 0 interrupted iterations
-default   [  95% ] 900 VUs  0m57.0s/1m0s
-
-running (0m58.0s), 900/900 VUs, 51266 complete and 0 interrupted iterations
-default   [  97% ] 900 VUs  0m58.0s/1m0s
-
-running (0m59.0s), 900/900 VUs, 52166 complete and 0 interrupted iterations
-default   [  98% ] 900 VUs  0m59.0s/1m0s
-
-running (1m00.0s), 900/900 VUs, 53066 complete and 0 interrupted iterations
-default   [ 100% ] 900 VUs  1m00.0s/1m0s
-
-
-  █ TOTAL RESULTS 
-
-    HTTP
-    http_req_duration..............: avg=909.12µs min=66.69µs med=686.96µs max=206.88ms p(90)=1.65ms p(95)=2.19ms
-      { expected_response:true }...: avg=909.12µs min=66.69µs med=686.96µs max=206.88ms p(90)=1.65ms p(95)=2.19ms
-    http_req_failed................: 0.00%  0 out of 53966
-    http_reqs......................: 53966  894.896603/s
-
-    EXECUTION
-    iteration_duration.............: avg=1s       min=1s      med=1s       max=2.01s    p(90)=1s     p(95)=1s    
-    iterations.....................: 53966  894.896603/s
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=2.07s    p(90)=1s     p(95)=1s    
+    iterations.....................: 53932  894.388352/s
     vus............................: 900    min=900        max=900
     vus_max........................: 900    min=900        max=900
 
@@ -2186,5 +653,1538 @@ default   [ 100% ] 900 VUs  1m00.0s/1m0s
 
 
 
-running (1m00.3s), 000/900 VUs, 53966 complete and 0 interrupted iterations
+running (1m00.3s), 000/900 VUs, 53932 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkHummingbird.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 878 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1778 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2678 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3578 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4478 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5378 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6278 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7178 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8078 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 8978 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9878 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10778 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11678 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12578 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13478 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14378 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15278 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16178 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17078 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 17978 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18878 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19778 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20678 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21578 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22478 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23378 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24278 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25178 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26078 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 26978 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27878 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28778 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29678 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30578 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31478 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32378 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33278 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34178 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35078 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 35978 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36878 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37778 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38678 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39578 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40478 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41378 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42278 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43178 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44078 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 44978 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45878 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46778 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47678 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48578 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49478 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50378 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51278 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52178 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53078 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=977.86µs min=62.21µs med=707.75µs max=34.91ms p(90)=1.82ms p(95)=2.52ms
+      { expected_response:true }...: avg=977.86µs min=62.21µs med=707.75µs max=34.91ms p(90)=1.82ms p(95)=2.52ms
+    http_req_failed................: 0.00%  0 out of 53978
+    http_reqs......................: 53978  897.642121/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=2.03s   p(90)=1s     p(95)=1s    
+    iterations.....................: 53978  897.642121/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  247 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.1s), 000/900 VUs, 53978 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkHummingbird.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=647.87µs min=60.9µs med=472.67µs max=13.2ms p(90)=1.28ms p(95)=1.73ms
+      { expected_response:true }...: avg=647.87µs min=60.9µs med=472.67µs max=13.2ms p(90)=1.28ms p(95)=1.73ms
+    http_req_failed................: 0.00%  0 out of 54000
+    http_reqs......................: 54000  898.319589/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s       min=1s     med=1s       max=1.01s  p(90)=1s     p(95)=1s    
+    iterations.....................: 54000  898.319589/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  247 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkHummingbird.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 838 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1738 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2638 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3538 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4438 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5338 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6238 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7138 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8038 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 8938 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9838 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10738 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11638 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12538 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13438 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14338 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15238 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16138 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17038 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 17938 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18838 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19738 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20638 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21538 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22438 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23338 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24238 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25138 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26038 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 26938 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27838 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28738 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29638 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30538 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31438 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32338 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33238 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34138 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35038 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 35938 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36838 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37738 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38638 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39538 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40438 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41338 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42238 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43138 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44038 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 44938 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45838 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46738 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47638 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48538 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49438 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50338 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51238 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52138 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53038 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=920.36µs min=56.09µs med=577.65µs max=203.42ms p(90)=1.84ms p(95)=2.66ms
+      { expected_response:true }...: avg=920.36µs min=56.09µs med=577.65µs max=203.42ms p(90)=1.84ms p(95)=2.66ms
+    http_req_failed................: 0.00%  0 out of 53938
+    http_reqs......................: 53938  894.676565/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=2.03s    p(90)=1s     p(95)=1s    
+    iterations.....................: 53938  894.676565/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  246 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.3s), 000/900 VUs, 53938 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkHummingbird.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 852 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1752 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2652 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3552 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4452 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5352 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6252 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7152 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8052 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 8952 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9852 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10752 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11652 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12552 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13452 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14352 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15252 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16152 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17052 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 17952 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18852 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19752 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20652 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21552 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22452 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23352 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24252 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25152 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26052 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 26952 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27852 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28752 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29652 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30552 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31452 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32352 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33252 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34152 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35052 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 35952 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36852 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37752 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38652 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39552 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40452 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41352 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42252 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43152 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44052 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 44952 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45852 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46752 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47652 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48552 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49452 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50352 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51252 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52152 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53052 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=930.33µs min=57.87µs med=705.94µs max=29.14ms p(90)=1.76ms p(95)=2.18ms
+      { expected_response:true }...: avg=930.33µs min=57.87µs med=705.94µs max=29.14ms p(90)=1.76ms p(95)=2.18ms
+    http_req_failed................: 0.00%  0 out of 53952
+    http_reqs......................: 53952  897.0673/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=2.04s   p(90)=1s     p(95)=1s    
+    iterations.....................: 53952  897.0673/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  247 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.1s), 000/900 VUs, 53952 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkHummingbird.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 871 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1771 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2671 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3571 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4471 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5371 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6271 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7171 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8071 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 8971 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9871 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10771 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11671 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12571 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13471 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14371 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15271 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16171 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17071 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 17971 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18871 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19771 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20671 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21571 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22471 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23371 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24271 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25171 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26071 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 26971 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27871 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28771 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29671 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30571 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31471 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32371 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33271 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34171 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35071 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 35971 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36871 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37771 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38671 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39571 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40471 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41371 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42271 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43171 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44071 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 44971 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45871 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46771 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47671 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48571 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49471 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50371 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51271 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52171 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53071 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=1ms min=60.18µs med=722.36µs max=16.57ms p(90)=2.04ms p(95)=2.64ms
+      { expected_response:true }...: avg=1ms min=60.18µs med=722.36µs max=16.57ms p(90)=2.04ms p(95)=2.64ms
+    http_req_failed................: 0.00%  0 out of 53971
+    http_reqs......................: 53971  897.69689/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s  min=1s      med=1s       max=2.01s   p(90)=1s     p(95)=1s    
+    iterations.....................: 53971  897.69689/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  247 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.1s), 000/900 VUs, 53971 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkHummingbird.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=848.73µs min=58.31µs med=590.18µs max=39.54ms p(90)=1.54ms p(95)=2.24ms
+      { expected_response:true }...: avg=848.73µs min=58.31µs med=590.18µs max=39.54ms p(90)=1.54ms p(95)=2.24ms
+    http_req_failed................: 0.00%  0 out of 54000
+    http_reqs......................: 54000  898.248063/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.04s   p(90)=1s     p(95)=1s    
+    iterations.....................: 54000  898.248063/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  247 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkHummingbird.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=647.16µs min=53.54µs med=427.26µs max=62.31ms p(90)=971.88µs p(95)=1.26ms
+      { expected_response:true }...: avg=647.16µs min=53.54µs med=427.26µs max=62.31ms p(90)=971.88µs p(95)=1.26ms
+    http_req_failed................: 0.00%  0 out of 54000
+    http_reqs......................: 54000  898.255261/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.06s   p(90)=1s       p(95)=1s    
+    iterations.....................: 54000  898.255261/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  247 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
 default ✓ [ 100% ] 900 VUs  1m0s

--- a/Benchmarks/results_vapor.txt
+++ b/Benchmarks/results_vapor.txt
@@ -197,14 +197,14 @@ default   [ 100% ] 900 VUs  1m00.0s/1m0s
   █ TOTAL RESULTS 
 
     HTTP
-    http_req_duration..............: avg=540.7µs min=56.52µs med=366.18µs max=27.78ms p(90)=1.1ms p(95)=1.42ms
-      { expected_response:true }...: avg=540.7µs min=56.52µs med=366.18µs max=27.78ms p(90)=1.1ms p(95)=1.42ms
+    http_req_duration..............: avg=509.14µs min=57.3µs med=316.87µs max=45.72ms p(90)=878.52µs p(95)=1.1ms
+      { expected_response:true }...: avg=509.14µs min=57.3µs med=316.87µs max=45.72ms p(90)=878.52µs p(95)=1.1ms
     http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.435931/s
+    http_reqs......................: 54000  898.456235/s
 
     EXECUTION
-    iteration_duration.............: avg=1s      min=1s      med=1s       max=1.02s   p(90)=1s    p(95)=1s    
-    iterations.....................: 54000  898.435931/s
+    iteration_duration.............: avg=1s       min=1s     med=1s       max=1.04s   p(90)=1s       p(95)=1s   
+    iterations.....................: 54000  898.456235/s
     vus............................: 900    min=900        max=900
     vus_max........................: 900    min=900        max=900
 
@@ -416,14 +416,14 @@ default   [ 100% ] 900 VUs  1m00.0s/1m0s
   █ TOTAL RESULTS 
 
     HTTP
-    http_req_duration..............: avg=661.9µs min=53.21µs med=422.43µs max=44.55ms p(90)=1.3ms p(95)=1.69ms
-      { expected_response:true }...: avg=661.9µs min=53.21µs med=422.43µs max=44.55ms p(90)=1.3ms p(95)=1.69ms
+    http_req_duration..............: avg=898.17µs min=52.73µs med=618.4µs max=33.29ms p(90)=1.87ms p(95)=2.49ms
+      { expected_response:true }...: avg=898.17µs min=52.73µs med=618.4µs max=33.29ms p(90)=1.87ms p(95)=2.49ms
     http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.625477/s
+    http_reqs......................: 54000  898.238713/s
 
     EXECUTION
-    iteration_duration.............: avg=1s      min=1s      med=1s       max=1.04s   p(90)=1s    p(95)=1s    
-    iterations.....................: 54000  898.625477/s
+    iteration_duration.............: avg=1s       min=1s      med=1s      max=1.03s   p(90)=1s     p(95)=1s    
+    iterations.....................: 54000  898.238713/s
     vus............................: 900    min=900        max=900
     vus_max........................: 900    min=900        max=900
 
@@ -635,14 +635,14 @@ default   [ 100% ] 900 VUs  1m00.0s/1m0s
   █ TOTAL RESULTS 
 
     HTTP
-    http_req_duration..............: avg=787.15µs min=55.47µs med=541.97µs max=25.06ms p(90)=1.46ms p(95)=1.9ms
-      { expected_response:true }...: avg=787.15µs min=55.47µs med=541.97µs max=25.06ms p(90)=1.46ms p(95)=1.9ms
+    http_req_duration..............: avg=560.4µs min=48.17µs med=319.45µs max=52.86ms p(90)=885.44µs p(95)=1.19ms
+      { expected_response:true }...: avg=560.4µs min=48.17µs med=319.45µs max=52.86ms p(90)=885.44µs p(95)=1.19ms
     http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.403809/s
+    http_reqs......................: 54000  898.490146/s
 
     EXECUTION
-    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.04s   p(90)=1s     p(95)=1s   
-    iterations.....................: 54000  898.403809/s
+    iteration_duration.............: avg=1s      min=1s      med=1s       max=1.05s   p(90)=1s       p(95)=1s    
+    iterations.....................: 54000  898.490146/s
     vus............................: 900    min=900        max=900
     vus_max........................: 900    min=900        max=900
 
@@ -854,233 +854,14 @@ default   [ 100% ] 900 VUs  1m00.0s/1m0s
   █ TOTAL RESULTS 
 
     HTTP
-    http_req_duration..............: avg=711.82µs min=58.74µs med=458.52µs max=34.95ms p(90)=1.37ms p(95)=1.78ms
-      { expected_response:true }...: avg=711.82µs min=58.74µs med=458.52µs max=34.95ms p(90)=1.37ms p(95)=1.78ms
+    http_req_duration..............: avg=870.28µs min=55.68µs med=565.38µs max=31.57ms p(90)=1.66ms p(95)=2.31ms
+      { expected_response:true }...: avg=870.28µs min=55.68µs med=565.38µs max=31.57ms p(90)=1.66ms p(95)=2.31ms
     http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.502485/s
-
-    EXECUTION
-    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.04s   p(90)=1s     p(95)=1s    
-    iterations.....................: 54000  898.502485/s
-    vus............................: 900    min=900        max=900
-    vus_max........................: 900    min=900        max=900
-
-    NETWORK
-    data_received..................: 15 MB  247 kB/s
-    data_sent......................: 4.2 MB 70 kB/s
-
-
-
-
-running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
-default ✓ [ 100% ] 900 VUs  1m0s
-
-         /\      Grafana   /‾‾/  
-    /\  /  \     |\  __   /  /   
-   /  \/    \    | |/ /  /   ‾‾\ 
-  /          \   |   (  |  (‾)  |
- / __________ \  |_|\_\  \_____/ 
-
-     execution: local
-        script: benchmarkVapor.js
-        output: -
-
-     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
-              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
-
-
-running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
-default   [   2% ] 900 VUs  0m01.0s/1m0s
-
-running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
-default   [   3% ] 900 VUs  0m02.0s/1m0s
-
-running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
-default   [   5% ] 900 VUs  0m03.0s/1m0s
-
-running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
-default   [   7% ] 900 VUs  0m04.0s/1m0s
-
-running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
-default   [   8% ] 900 VUs  0m05.0s/1m0s
-
-running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
-default   [  10% ] 900 VUs  0m06.0s/1m0s
-
-running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
-default   [  12% ] 900 VUs  0m07.0s/1m0s
-
-running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
-default   [  13% ] 900 VUs  0m08.0s/1m0s
-
-running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
-default   [  15% ] 900 VUs  0m09.0s/1m0s
-
-running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
-default   [  17% ] 900 VUs  0m10.0s/1m0s
-
-running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
-default   [  18% ] 900 VUs  0m11.0s/1m0s
-
-running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
-default   [  20% ] 900 VUs  0m12.0s/1m0s
-
-running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
-default   [  22% ] 900 VUs  0m13.0s/1m0s
-
-running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
-default   [  23% ] 900 VUs  0m14.0s/1m0s
-
-running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
-default   [  25% ] 900 VUs  0m15.0s/1m0s
-
-running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
-default   [  27% ] 900 VUs  0m16.0s/1m0s
-
-running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
-default   [  28% ] 900 VUs  0m17.0s/1m0s
-
-running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
-default   [  30% ] 900 VUs  0m18.0s/1m0s
-
-running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
-default   [  32% ] 900 VUs  0m19.0s/1m0s
-
-running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
-default   [  33% ] 900 VUs  0m20.0s/1m0s
-
-running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
-default   [  35% ] 900 VUs  0m21.0s/1m0s
-
-running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
-default   [  37% ] 900 VUs  0m22.0s/1m0s
-
-running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
-default   [  38% ] 900 VUs  0m23.0s/1m0s
-
-running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
-default   [  40% ] 900 VUs  0m24.0s/1m0s
-
-running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
-default   [  42% ] 900 VUs  0m25.0s/1m0s
-
-running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
-default   [  43% ] 900 VUs  0m26.0s/1m0s
-
-running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
-default   [  45% ] 900 VUs  0m27.0s/1m0s
-
-running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
-default   [  47% ] 900 VUs  0m28.0s/1m0s
-
-running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
-default   [  48% ] 900 VUs  0m29.0s/1m0s
-
-running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
-default   [  50% ] 900 VUs  0m30.0s/1m0s
-
-running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
-default   [  52% ] 900 VUs  0m31.0s/1m0s
-
-running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
-default   [  53% ] 900 VUs  0m32.0s/1m0s
-
-running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
-default   [  55% ] 900 VUs  0m33.0s/1m0s
-
-running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
-default   [  57% ] 900 VUs  0m34.0s/1m0s
-
-running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
-default   [  58% ] 900 VUs  0m35.0s/1m0s
-
-running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
-default   [  60% ] 900 VUs  0m36.0s/1m0s
-
-running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
-default   [  62% ] 900 VUs  0m37.0s/1m0s
-
-running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
-default   [  63% ] 900 VUs  0m38.0s/1m0s
-
-running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
-default   [  65% ] 900 VUs  0m39.0s/1m0s
-
-running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
-default   [  67% ] 900 VUs  0m40.0s/1m0s
-
-running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
-default   [  68% ] 900 VUs  0m41.0s/1m0s
-
-running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
-default   [  70% ] 900 VUs  0m42.0s/1m0s
-
-running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
-default   [  72% ] 900 VUs  0m43.0s/1m0s
-
-running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
-default   [  73% ] 900 VUs  0m44.0s/1m0s
-
-running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
-default   [  75% ] 900 VUs  0m45.0s/1m0s
-
-running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
-default   [  77% ] 900 VUs  0m46.0s/1m0s
-
-running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
-default   [  78% ] 900 VUs  0m47.0s/1m0s
-
-running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
-default   [  80% ] 900 VUs  0m48.0s/1m0s
-
-running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
-default   [  82% ] 900 VUs  0m49.0s/1m0s
-
-running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
-default   [  83% ] 900 VUs  0m50.0s/1m0s
-
-running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
-default   [  85% ] 900 VUs  0m51.0s/1m0s
-
-running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
-default   [  87% ] 900 VUs  0m52.0s/1m0s
-
-running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
-default   [  88% ] 900 VUs  0m53.0s/1m0s
-
-running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
-default   [  90% ] 900 VUs  0m54.0s/1m0s
-
-running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
-default   [  92% ] 900 VUs  0m55.0s/1m0s
-
-running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
-default   [  93% ] 900 VUs  0m56.0s/1m0s
-
-running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
-default   [  95% ] 900 VUs  0m57.0s/1m0s
-
-running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
-default   [  97% ] 900 VUs  0m58.0s/1m0s
-
-running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
-default   [  98% ] 900 VUs  0m59.0s/1m0s
-
-running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
-default   [ 100% ] 900 VUs  1m00.0s/1m0s
-
-
-  █ TOTAL RESULTS 
-
-    HTTP
-    http_req_duration..............: avg=966.49µs min=57.29µs med=692.83µs max=28.93ms p(90)=1.75ms p(95)=2.34ms
-      { expected_response:true }...: avg=966.49µs min=57.29µs med=692.83µs max=28.93ms p(90)=1.75ms p(95)=2.34ms
-    http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.313067/s
+    http_reqs......................: 54000  898.257169/s
 
     EXECUTION
     iteration_duration.............: avg=1s       min=1s      med=1s       max=1.04s   p(90)=1s     p(95)=1s    
-    iterations.....................: 54000  898.313067/s
+    iterations.....................: 54000  898.257169/s
     vus............................: 900    min=900        max=900
     vus_max........................: 900    min=900        max=900
 
@@ -1292,14 +1073,14 @@ default   [ 100% ] 900 VUs  1m00.0s/1m0s
   █ TOTAL RESULTS 
 
     HTTP
-    http_req_duration..............: avg=734.21µs min=53.09µs med=431.83µs max=25.77ms p(90)=1.4ms p(95)=2.09ms
-      { expected_response:true }...: avg=734.21µs min=53.09µs med=431.83µs max=25.77ms p(90)=1.4ms p(95)=2.09ms
+    http_req_duration..............: avg=919.52µs min=52.88µs med=611.16µs max=40.18ms p(90)=1.91ms p(95)=2.65ms
+      { expected_response:true }...: avg=919.52µs min=52.88µs med=611.16µs max=40.18ms p(90)=1.91ms p(95)=2.65ms
     http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.528115/s
+    http_reqs......................: 54000  898.20544/s
 
     EXECUTION
-    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.03s   p(90)=1s    p(95)=1s    
-    iterations.....................: 54000  898.528115/s
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.04s   p(90)=1s     p(95)=1s    
+    iterations.....................: 54000  898.20544/s
     vus............................: 900    min=900        max=900
     vus_max........................: 900    min=900        max=900
 
@@ -1511,14 +1292,452 @@ default   [ 100% ] 900 VUs  1m00.0s/1m0s
   █ TOTAL RESULTS 
 
     HTTP
-    http_req_duration..............: avg=848.52µs min=53.85µs med=563.26µs max=24.66ms p(90)=1.72ms p(95)=2.33ms
-      { expected_response:true }...: avg=848.52µs min=53.85µs med=563.26µs max=24.66ms p(90)=1.72ms p(95)=2.33ms
+    http_req_duration..............: avg=839.3µs min=52.2µs med=631.21µs max=22.63ms p(90)=1.67ms p(95)=2.28ms
+      { expected_response:true }...: avg=839.3µs min=52.2µs med=631.21µs max=22.63ms p(90)=1.67ms p(95)=2.28ms
     http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.441747/s
+    http_reqs......................: 54000  898.454423/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s      min=1s     med=1s       max=1.03s   p(90)=1s     p(95)=1s    
+    iterations.....................: 54000  898.454423/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  247 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkVapor.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=849.07µs min=52.39µs med=537.94µs max=18.56ms p(90)=1.66ms p(95)=2.18ms
+      { expected_response:true }...: avg=849.07µs min=52.39µs med=537.94µs max=18.56ms p(90)=1.66ms p(95)=2.18ms
+    http_req_failed................: 0.00%  0 out of 54000
+    http_reqs......................: 54000  898.171441/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.04s   p(90)=1s     p(95)=1s    
+    iterations.....................: 54000  898.171441/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  247 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkVapor.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=854.21µs min=54.06µs med=551.49µs max=33.21ms p(90)=1.74ms p(95)=2.38ms
+      { expected_response:true }...: avg=854.21µs min=54.06µs med=551.49µs max=33.21ms p(90)=1.74ms p(95)=2.38ms
+    http_req_failed................: 0.00%  0 out of 54000
+    http_reqs......................: 54000  898.291783/s
 
     EXECUTION
     iteration_duration.............: avg=1s       min=1s      med=1s       max=1.03s   p(90)=1s     p(95)=1s    
-    iterations.....................: 54000  898.441747/s
+    iterations.....................: 54000  898.291783/s
     vus............................: 900    min=900        max=900
     vus_max........................: 900    min=900        max=900
 
@@ -1730,14 +1949,14 @@ default   [ 100% ] 900 VUs  1m00.0s/1m0s
   █ TOTAL RESULTS 
 
     HTTP
-    http_req_duration..............: avg=707.47µs min=54.5µs med=425.19µs max=22.13ms p(90)=1.33ms p(95)=1.73ms
-      { expected_response:true }...: avg=707.47µs min=54.5µs med=425.19µs max=22.13ms p(90)=1.33ms p(95)=1.73ms
+    http_req_duration..............: avg=597.92µs min=58.59µs med=353.02µs max=37.42ms p(90)=922.07µs p(95)=1.22ms
+      { expected_response:true }...: avg=597.92µs min=58.59µs med=353.02µs max=37.42ms p(90)=922.07µs p(95)=1.22ms
     http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.421715/s
+    http_reqs......................: 54000  898.652881/s
 
     EXECUTION
-    iteration_duration.............: avg=1s       min=1s     med=1s       max=1.03s   p(90)=1s     p(95)=1s    
-    iterations.....................: 54000  898.421715/s
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.03s   p(90)=1s       p(95)=1s    
+    iterations.....................: 54000  898.652881/s
     vus............................: 900    min=900        max=900
     vus_max........................: 900    min=900        max=900
 
@@ -1949,233 +2168,14 @@ default   [ 100% ] 900 VUs  1m00.0s/1m0s
   █ TOTAL RESULTS 
 
     HTTP
-    http_req_duration..............: avg=930.37µs min=53.97µs med=653.21µs max=15.7ms p(90)=1.95ms p(95)=2.76ms
-      { expected_response:true }...: avg=930.37µs min=53.97µs med=653.21µs max=15.7ms p(90)=1.95ms p(95)=2.76ms
+    http_req_duration..............: avg=892.87µs min=53.22µs med=626.25µs max=37.81ms p(90)=1.85ms p(95)=2.46ms
+      { expected_response:true }...: avg=892.87µs min=53.22µs med=626.25µs max=37.81ms p(90)=1.85ms p(95)=2.46ms
     http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.204545/s
-
-    EXECUTION
-    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.04s  p(90)=1s     p(95)=1s    
-    iterations.....................: 54000  898.204545/s
-    vus............................: 900    min=900        max=900
-    vus_max........................: 900    min=900        max=900
-
-    NETWORK
-    data_received..................: 15 MB  247 kB/s
-    data_sent......................: 4.2 MB 70 kB/s
-
-
-
-
-running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
-default ✓ [ 100% ] 900 VUs  1m0s
-
-         /\      Grafana   /‾‾/  
-    /\  /  \     |\  __   /  /   
-   /  \/    \    | |/ /  /   ‾‾\ 
-  /          \   |   (  |  (‾)  |
- / __________ \  |_|\_\  \_____/ 
-
-     execution: local
-        script: benchmarkVapor.js
-        output: -
-
-     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
-              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
-
-
-running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
-default   [   2% ] 900 VUs  0m01.0s/1m0s
-
-running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
-default   [   3% ] 900 VUs  0m02.0s/1m0s
-
-running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
-default   [   5% ] 900 VUs  0m03.0s/1m0s
-
-running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
-default   [   7% ] 900 VUs  0m04.0s/1m0s
-
-running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
-default   [   8% ] 900 VUs  0m05.0s/1m0s
-
-running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
-default   [  10% ] 900 VUs  0m06.0s/1m0s
-
-running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
-default   [  12% ] 900 VUs  0m07.0s/1m0s
-
-running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
-default   [  13% ] 900 VUs  0m08.0s/1m0s
-
-running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
-default   [  15% ] 900 VUs  0m09.0s/1m0s
-
-running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
-default   [  17% ] 900 VUs  0m10.0s/1m0s
-
-running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
-default   [  18% ] 900 VUs  0m11.0s/1m0s
-
-running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
-default   [  20% ] 900 VUs  0m12.0s/1m0s
-
-running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
-default   [  22% ] 900 VUs  0m13.0s/1m0s
-
-running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
-default   [  23% ] 900 VUs  0m14.0s/1m0s
-
-running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
-default   [  25% ] 900 VUs  0m15.0s/1m0s
-
-running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
-default   [  27% ] 900 VUs  0m16.0s/1m0s
-
-running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
-default   [  28% ] 900 VUs  0m17.0s/1m0s
-
-running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
-default   [  30% ] 900 VUs  0m18.0s/1m0s
-
-running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
-default   [  32% ] 900 VUs  0m19.0s/1m0s
-
-running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
-default   [  33% ] 900 VUs  0m20.0s/1m0s
-
-running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
-default   [  35% ] 900 VUs  0m21.0s/1m0s
-
-running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
-default   [  37% ] 900 VUs  0m22.0s/1m0s
-
-running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
-default   [  38% ] 900 VUs  0m23.0s/1m0s
-
-running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
-default   [  40% ] 900 VUs  0m24.0s/1m0s
-
-running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
-default   [  42% ] 900 VUs  0m25.0s/1m0s
-
-running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
-default   [  43% ] 900 VUs  0m26.0s/1m0s
-
-running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
-default   [  45% ] 900 VUs  0m27.0s/1m0s
-
-running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
-default   [  47% ] 900 VUs  0m28.0s/1m0s
-
-running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
-default   [  48% ] 900 VUs  0m29.0s/1m0s
-
-running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
-default   [  50% ] 900 VUs  0m30.0s/1m0s
-
-running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
-default   [  52% ] 900 VUs  0m31.0s/1m0s
-
-running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
-default   [  53% ] 900 VUs  0m32.0s/1m0s
-
-running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
-default   [  55% ] 900 VUs  0m33.0s/1m0s
-
-running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
-default   [  57% ] 900 VUs  0m34.0s/1m0s
-
-running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
-default   [  58% ] 900 VUs  0m35.0s/1m0s
-
-running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
-default   [  60% ] 900 VUs  0m36.0s/1m0s
-
-running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
-default   [  62% ] 900 VUs  0m37.0s/1m0s
-
-running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
-default   [  63% ] 900 VUs  0m38.0s/1m0s
-
-running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
-default   [  65% ] 900 VUs  0m39.0s/1m0s
-
-running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
-default   [  67% ] 900 VUs  0m40.0s/1m0s
-
-running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
-default   [  68% ] 900 VUs  0m41.0s/1m0s
-
-running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
-default   [  70% ] 900 VUs  0m42.0s/1m0s
-
-running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
-default   [  72% ] 900 VUs  0m43.0s/1m0s
-
-running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
-default   [  73% ] 900 VUs  0m44.0s/1m0s
-
-running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
-default   [  75% ] 900 VUs  0m45.0s/1m0s
-
-running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
-default   [  77% ] 900 VUs  0m46.0s/1m0s
-
-running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
-default   [  78% ] 900 VUs  0m47.0s/1m0s
-
-running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
-default   [  80% ] 900 VUs  0m48.0s/1m0s
-
-running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
-default   [  82% ] 900 VUs  0m49.0s/1m0s
-
-running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
-default   [  83% ] 900 VUs  0m50.0s/1m0s
-
-running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
-default   [  85% ] 900 VUs  0m51.0s/1m0s
-
-running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
-default   [  87% ] 900 VUs  0m52.0s/1m0s
-
-running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
-default   [  88% ] 900 VUs  0m53.0s/1m0s
-
-running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
-default   [  90% ] 900 VUs  0m54.0s/1m0s
-
-running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
-default   [  92% ] 900 VUs  0m55.0s/1m0s
-
-running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
-default   [  93% ] 900 VUs  0m56.0s/1m0s
-
-running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
-default   [  95% ] 900 VUs  0m57.0s/1m0s
-
-running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
-default   [  97% ] 900 VUs  0m58.0s/1m0s
-
-running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
-default   [  98% ] 900 VUs  0m59.0s/1m0s
-
-running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
-default   [ 100% ] 900 VUs  1m00.0s/1m0s
-
-
-  █ TOTAL RESULTS 
-
-    HTTP
-    http_req_duration..............: avg=752.19µs min=52.89µs med=428.85µs max=31.98ms p(90)=1.31ms p(95)=1.78ms
-      { expected_response:true }...: avg=752.19µs min=52.89µs med=428.85µs max=31.98ms p(90)=1.31ms p(95)=1.78ms
-    http_req_failed................: 0.00%  0 out of 54000
-    http_reqs......................: 54000  898.466633/s
+    http_reqs......................: 54000  898.193245/s
 
     EXECUTION
     iteration_duration.............: avg=1s       min=1s      med=1s       max=1.04s   p(90)=1s     p(95)=1s    
-    iterations.....................: 54000  898.466633/s
+    iterations.....................: 54000  898.193245/s
     vus............................: 900    min=900        max=900
     vus_max........................: 900    min=900        max=900
 

--- a/Benchmarks/results_vapor.txt
+++ b/Benchmarks/results_vapor.txt
@@ -127,98 +127,95 @@ default   [  62% ] 900 VUs  0m37.0s/1m0s
 running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
 default   [  63% ] 900 VUs  0m38.0s/1m0s
 
-running (0m39.0s), 900/900 VUs, 34158 complete and 0 interrupted iterations
+running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
 default   [  65% ] 900 VUs  0m39.0s/1m0s
 
-running (0m40.0s), 900/900 VUs, 35016 complete and 0 interrupted iterations
+running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
 default   [  67% ] 900 VUs  0m40.0s/1m0s
 
-running (0m41.0s), 900/900 VUs, 35908 complete and 0 interrupted iterations
+running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
 default   [  68% ] 900 VUs  0m41.0s/1m0s
 
-running (0m42.0s), 900/900 VUs, 36794 complete and 0 interrupted iterations
+running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
 default   [  70% ] 900 VUs  0m42.0s/1m0s
 
-running (0m43.0s), 900/900 VUs, 37668 complete and 0 interrupted iterations
+running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
 default   [  72% ] 900 VUs  0m43.0s/1m0s
 
-running (0m44.0s), 900/900 VUs, 38555 complete and 0 interrupted iterations
+running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
 default   [  73% ] 900 VUs  0m44.0s/1m0s
 
-running (0m45.0s), 900/900 VUs, 39444 complete and 0 interrupted iterations
+running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
 default   [  75% ] 900 VUs  0m45.0s/1m0s
 
-running (0m46.0s), 900/900 VUs, 40311 complete and 0 interrupted iterations
+running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
 default   [  77% ] 900 VUs  0m46.0s/1m0s
 
-running (0m47.0s), 900/900 VUs, 41198 complete and 0 interrupted iterations
+running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
 default   [  78% ] 900 VUs  0m47.0s/1m0s
 
-running (0m48.0s), 900/900 VUs, 42080 complete and 0 interrupted iterations
+running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
 default   [  80% ] 900 VUs  0m48.0s/1m0s
 
-running (0m49.0s), 900/900 VUs, 42962 complete and 0 interrupted iterations
+running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
 default   [  82% ] 900 VUs  0m49.0s/1m0s
 
-running (0m50.0s), 900/900 VUs, 43852 complete and 0 interrupted iterations
+running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
 default   [  83% ] 900 VUs  0m50.0s/1m0s
 
-running (0m51.0s), 900/900 VUs, 44738 complete and 0 interrupted iterations
+running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
 default   [  85% ] 900 VUs  0m51.0s/1m0s
 
-running (0m52.0s), 900/900 VUs, 45622 complete and 0 interrupted iterations
+running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
 default   [  87% ] 900 VUs  0m52.0s/1m0s
 
-running (0m53.0s), 900/900 VUs, 46515 complete and 0 interrupted iterations
+running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
 default   [  88% ] 900 VUs  0m53.0s/1m0s
 
-running (0m54.0s), 900/900 VUs, 47403 complete and 0 interrupted iterations
+running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
 default   [  90% ] 900 VUs  0m54.0s/1m0s
 
-running (0m55.0s), 900/900 VUs, 48296 complete and 0 interrupted iterations
+running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
 default   [  92% ] 900 VUs  0m55.0s/1m0s
 
-running (0m56.0s), 900/900 VUs, 49185 complete and 0 interrupted iterations
+running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
 default   [  93% ] 900 VUs  0m56.0s/1m0s
 
-running (0m57.0s), 900/900 VUs, 50068 complete and 0 interrupted iterations
+running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
 default   [  95% ] 900 VUs  0m57.0s/1m0s
 
-running (0m58.0s), 900/900 VUs, 50957 complete and 0 interrupted iterations
+running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
 default   [  97% ] 900 VUs  0m58.0s/1m0s
 
-running (0m59.0s), 900/900 VUs, 51847 complete and 0 interrupted iterations
+running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
 default   [  98% ] 900 VUs  0m59.0s/1m0s
 
-running (1m00.0s), 900/900 VUs, 52735 complete and 0 interrupted iterations
+running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
 default   [ 100% ] 900 VUs  1m00.0s/1m0s
-
-running (1m01.0s), 034/900 VUs, 53629 complete and 0 interrupted iterations
-default ↓ [ 100% ] 900 VUs  1m0s
 
 
   █ TOTAL RESULTS 
 
     HTTP
-    http_req_duration..............: avg=1.39ms min=0s      med=175.04µs max=120.23ms p(90)=4.12ms p(95)=5.34ms
-      { expected_response:true }...: avg=2.65ms min=88.32µs med=2.02ms   max=120.23ms p(90)=5.25ms p(95)=6.77ms
-    http_req_failed................: 47.38% 25430 out of 53662
-    http_reqs......................: 53662  879.585128/s
+    http_req_duration..............: avg=540.7µs min=56.52µs med=366.18µs max=27.78ms p(90)=1.1ms p(95)=1.42ms
+      { expected_response:true }...: avg=540.7µs min=56.52µs med=366.18µs max=27.78ms p(90)=1.1ms p(95)=1.42ms
+    http_req_failed................: 0.00%  0 out of 54000
+    http_reqs......................: 54000  898.435931/s
 
     EXECUTION
-    iteration_duration.............: avg=1.01s  min=1s      med=1s       max=1.61s    p(90)=1.02s  p(95)=1.04s 
-    iterations.....................: 53662  879.585128/s
-    vus............................: 33     min=33             max=900
-    vus_max........................: 900    min=900            max=900
+    iteration_duration.............: avg=1s      min=1s      med=1s       max=1.02s   p(90)=1s    p(95)=1s    
+    iterations.....................: 54000  898.435931/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
 
     NETWORK
-    data_received..................: 8.3 MB 136 kB/s
-    data_sent......................: 2.2 MB 36 kB/s
+    data_received..................: 15 MB  247 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
 
 
 
 
-running (1m01.0s), 000/900 VUs, 53662 complete and 0 interrupted iterations
+running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
 default ✓ [ 100% ] 900 VUs  1m0s
 
          /\      Grafana   /‾‾/  
@@ -325,122 +322,119 @@ default   [  48% ] 900 VUs  0m29.0s/1m0s
 running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
 default   [  50% ] 900 VUs  0m30.0s/1m0s
 
-running (0m31.0s), 900/900 VUs, 26977 complete and 0 interrupted iterations
+running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
 default   [  52% ] 900 VUs  0m31.0s/1m0s
 
-running (0m32.0s), 900/900 VUs, 27793 complete and 0 interrupted iterations
+running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
 default   [  53% ] 900 VUs  0m32.0s/1m0s
 
-running (0m33.0s), 900/900 VUs, 28626 complete and 0 interrupted iterations
+running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
 default   [  55% ] 900 VUs  0m33.0s/1m0s
 
-running (0m34.0s), 900/900 VUs, 29408 complete and 0 interrupted iterations
+running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
 default   [  57% ] 900 VUs  0m34.0s/1m0s
 
-running (0m35.0s), 900/900 VUs, 30244 complete and 0 interrupted iterations
+running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
 default   [  58% ] 900 VUs  0m35.0s/1m0s
 
-running (0m36.0s), 900/900 VUs, 31135 complete and 0 interrupted iterations
+running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
 default   [  60% ] 900 VUs  0m36.0s/1m0s
 
-running (0m37.0s), 900/900 VUs, 32035 complete and 0 interrupted iterations
+running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
 default   [  62% ] 900 VUs  0m37.0s/1m0s
 
-running (0m38.0s), 900/900 VUs, 32935 complete and 0 interrupted iterations
+running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
 default   [  63% ] 900 VUs  0m38.0s/1m0s
 
-running (0m39.0s), 900/900 VUs, 33835 complete and 0 interrupted iterations
+running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
 default   [  65% ] 900 VUs  0m39.0s/1m0s
 
-running (0m40.0s), 900/900 VUs, 34683 complete and 0 interrupted iterations
+running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
 default   [  67% ] 900 VUs  0m40.0s/1m0s
 
-running (0m41.0s), 900/900 VUs, 35451 complete and 0 interrupted iterations
+running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
 default   [  68% ] 900 VUs  0m41.0s/1m0s
 
-running (0m42.0s), 900/900 VUs, 36338 complete and 0 interrupted iterations
+running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
 default   [  70% ] 900 VUs  0m42.0s/1m0s
 
-running (0m43.0s), 900/900 VUs, 37222 complete and 0 interrupted iterations
+running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
 default   [  72% ] 900 VUs  0m43.0s/1m0s
 
-running (0m44.0s), 900/900 VUs, 38114 complete and 0 interrupted iterations
+running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
 default   [  73% ] 900 VUs  0m44.0s/1m0s
 
-running (0m45.0s), 900/900 VUs, 39009 complete and 0 interrupted iterations
+running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
 default   [  75% ] 900 VUs  0m45.0s/1m0s
 
-running (0m46.0s), 900/900 VUs, 39902 complete and 0 interrupted iterations
+running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
 default   [  77% ] 900 VUs  0m46.0s/1m0s
 
-running (0m47.0s), 900/900 VUs, 40796 complete and 0 interrupted iterations
+running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
 default   [  78% ] 900 VUs  0m47.0s/1m0s
 
-running (0m48.0s), 900/900 VUs, 41693 complete and 0 interrupted iterations
+running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
 default   [  80% ] 900 VUs  0m48.0s/1m0s
 
-running (0m49.0s), 900/900 VUs, 42585 complete and 0 interrupted iterations
+running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
 default   [  82% ] 900 VUs  0m49.0s/1m0s
 
-running (0m50.0s), 900/900 VUs, 43479 complete and 0 interrupted iterations
+running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
 default   [  83% ] 900 VUs  0m50.0s/1m0s
 
-running (0m51.0s), 900/900 VUs, 44371 complete and 0 interrupted iterations
+running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
 default   [  85% ] 900 VUs  0m51.0s/1m0s
 
-running (0m52.0s), 900/900 VUs, 45268 complete and 0 interrupted iterations
+running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
 default   [  87% ] 900 VUs  0m52.0s/1m0s
 
-running (0m53.0s), 900/900 VUs, 46168 complete and 0 interrupted iterations
+running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
 default   [  88% ] 900 VUs  0m53.0s/1m0s
 
-running (0m54.0s), 900/900 VUs, 47068 complete and 0 interrupted iterations
+running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
 default   [  90% ] 900 VUs  0m54.0s/1m0s
 
-running (0m55.0s), 900/900 VUs, 47966 complete and 0 interrupted iterations
+running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
 default   [  92% ] 900 VUs  0m55.0s/1m0s
 
-running (0m56.0s), 900/900 VUs, 48851 complete and 0 interrupted iterations
+running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
 default   [  93% ] 900 VUs  0m56.0s/1m0s
 
-running (0m57.0s), 900/900 VUs, 49731 complete and 0 interrupted iterations
+running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
 default   [  95% ] 900 VUs  0m57.0s/1m0s
 
-running (0m58.0s), 900/900 VUs, 50624 complete and 0 interrupted iterations
+running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
 default   [  97% ] 900 VUs  0m58.0s/1m0s
 
-running (0m59.0s), 900/900 VUs, 51508 complete and 0 interrupted iterations
+running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
 default   [  98% ] 900 VUs  0m59.0s/1m0s
 
-running (1m00.0s), 900/900 VUs, 52396 complete and 0 interrupted iterations
+running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
 default   [ 100% ] 900 VUs  1m00.0s/1m0s
-
-running (1m01.0s), 043/900 VUs, 53282 complete and 0 interrupted iterations
-default ↓ [ 100% ] 900 VUs  1m0s
 
 
   █ TOTAL RESULTS 
 
     HTTP
-    http_req_duration..............: avg=686.14µs min=0s      med=124.01µs max=49.42ms p(90)=2.1ms  p(95)=3.33ms
-      { expected_response:true }...: avg=1.29ms   min=88.61µs med=369.62µs max=49.42ms p(90)=3.22ms p(95)=5.22ms
-    http_req_failed................: 47.05% 25093 out of 53325
-    http_reqs......................: 53325  874.063054/s
+    http_req_duration..............: avg=661.9µs min=53.21µs med=422.43µs max=44.55ms p(90)=1.3ms p(95)=1.69ms
+      { expected_response:true }...: avg=661.9µs min=53.21µs med=422.43µs max=44.55ms p(90)=1.3ms p(95)=1.69ms
+    http_req_failed................: 0.00%  0 out of 54000
+    http_reqs......................: 54000  898.625477/s
 
     EXECUTION
-    iteration_duration.............: avg=1.01s    min=1s      med=1s       max=1.56s   p(90)=1.04s  p(95)=1.07s 
-    iterations.....................: 53325  874.063054/s
-    vus............................: 43     min=43             max=900
-    vus_max........................: 900    min=900            max=900
+    iteration_duration.............: avg=1s      min=1s      med=1s       max=1.04s   p(90)=1s    p(95)=1s    
+    iterations.....................: 54000  898.625477/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
 
     NETWORK
-    data_received..................: 8.3 MB 136 kB/s
-    data_sent......................: 2.2 MB 36 kB/s
+    data_received..................: 15 MB  247 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
 
 
 
 
-running (1m01.0s), 000/900 VUs, 53325 complete and 0 interrupted iterations
+running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
 default ✓ [ 100% ] 900 VUs  1m0s
 
          /\      Grafana   /‾‾/  
@@ -463,201 +457,1734 @@ default   [   2% ] 900 VUs  0m01.0s/1m0s
 running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
 default   [   3% ] 900 VUs  0m02.0s/1m0s
 
-running (0m03.0s), 900/900 VUs, 1514 complete and 0 interrupted iterations
+running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
 default   [   5% ] 900 VUs  0m03.0s/1m0s
 
-running (0m04.0s), 900/900 VUs, 2413 complete and 0 interrupted iterations
+running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
 default   [   7% ] 900 VUs  0m04.0s/1m0s
 
-running (0m05.0s), 900/900 VUs, 2577 complete and 0 interrupted iterations
+running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
 default   [   8% ] 900 VUs  0m05.0s/1m0s
 
-running (0m06.0s), 900/900 VUs, 3477 complete and 0 interrupted iterations
+running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
 default   [  10% ] 900 VUs  0m06.0s/1m0s
 
-running (0m07.0s), 900/900 VUs, 4377 complete and 0 interrupted iterations
+running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
 default   [  12% ] 900 VUs  0m07.0s/1m0s
 
-running (0m08.0s), 900/900 VUs, 5277 complete and 0 interrupted iterations
+running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
 default   [  13% ] 900 VUs  0m08.0s/1m0s
 
-running (0m09.0s), 900/900 VUs, 6177 complete and 0 interrupted iterations
+running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
 default   [  15% ] 900 VUs  0m09.0s/1m0s
 
-running (0m10.0s), 900/900 VUs, 7062 complete and 0 interrupted iterations
+running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
 default   [  17% ] 900 VUs  0m10.0s/1m0s
 
-running (0m11.0s), 900/900 VUs, 7897 complete and 0 interrupted iterations
+running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
 default   [  18% ] 900 VUs  0m11.0s/1m0s
 
-running (0m12.0s), 900/900 VUs, 8797 complete and 0 interrupted iterations
+running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
 default   [  20% ] 900 VUs  0m12.0s/1m0s
 
-running (0m13.0s), 900/900 VUs, 9697 complete and 0 interrupted iterations
+running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
 default   [  22% ] 900 VUs  0m13.0s/1m0s
 
-running (0m14.0s), 900/900 VUs, 10597 complete and 0 interrupted iterations
+running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
 default   [  23% ] 900 VUs  0m14.0s/1m0s
 
-running (0m15.0s), 900/900 VUs, 11437 complete and 0 interrupted iterations
+running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
 default   [  25% ] 900 VUs  0m15.0s/1m0s
 
-running (0m16.0s), 900/900 VUs, 12337 complete and 0 interrupted iterations
+running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
 default   [  27% ] 900 VUs  0m16.0s/1m0s
 
-running (0m17.0s), 900/900 VUs, 13237 complete and 0 interrupted iterations
+running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
 default   [  28% ] 900 VUs  0m17.0s/1m0s
 
-running (0m18.0s), 900/900 VUs, 14136 complete and 0 interrupted iterations
+running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
 default   [  30% ] 900 VUs  0m18.0s/1m0s
 
-running (0m19.0s), 900/900 VUs, 15004 complete and 0 interrupted iterations
+running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
 default   [  32% ] 900 VUs  0m19.0s/1m0s
 
-running (0m20.0s), 900/900 VUs, 15874 complete and 0 interrupted iterations
+running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
 default   [  33% ] 900 VUs  0m20.0s/1m0s
 
-running (0m21.0s), 900/900 VUs, 16770 complete and 0 interrupted iterations
+running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
 default   [  35% ] 900 VUs  0m21.0s/1m0s
 
-running (0m22.0s), 900/900 VUs, 17430 complete and 0 interrupted iterations
+running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
 default   [  37% ] 900 VUs  0m22.0s/1m0s
 
-running (0m23.0s), 900/900 VUs, 18308 complete and 0 interrupted iterations
+running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
 default   [  38% ] 900 VUs  0m23.0s/1m0s
 
-running (0m24.0s), 900/900 VUs, 19208 complete and 0 interrupted iterations
+running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
 default   [  40% ] 900 VUs  0m24.0s/1m0s
 
-running (0m25.0s), 900/900 VUs, 20097 complete and 0 interrupted iterations
+running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
 default   [  42% ] 900 VUs  0m25.0s/1m0s
 
-running (0m26.0s), 900/900 VUs, 20992 complete and 0 interrupted iterations
+running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
 default   [  43% ] 900 VUs  0m26.0s/1m0s
 
-running (0m27.0s), 900/900 VUs, 21892 complete and 0 interrupted iterations
+running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
 default   [  45% ] 900 VUs  0m27.0s/1m0s
 
-running (0m28.0s), 900/900 VUs, 22792 complete and 0 interrupted iterations
+running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
 default   [  47% ] 900 VUs  0m28.0s/1m0s
 
-running (0m29.0s), 900/900 VUs, 23692 complete and 0 interrupted iterations
+running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
 default   [  48% ] 900 VUs  0m29.0s/1m0s
 
-running (0m30.0s), 900/900 VUs, 24589 complete and 0 interrupted iterations
+running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
 default   [  50% ] 900 VUs  0m30.0s/1m0s
 
-running (0m31.0s), 900/900 VUs, 25489 complete and 0 interrupted iterations
+running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
 default   [  52% ] 900 VUs  0m31.0s/1m0s
 
-running (0m32.0s), 900/900 VUs, 26387 complete and 0 interrupted iterations
+running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
 default   [  53% ] 900 VUs  0m32.0s/1m0s
 
-running (0m33.0s), 900/900 VUs, 27287 complete and 0 interrupted iterations
+running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
 default   [  55% ] 900 VUs  0m33.0s/1m0s
 
-running (0m34.0s), 900/900 VUs, 28187 complete and 0 interrupted iterations
+running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
 default   [  57% ] 900 VUs  0m34.0s/1m0s
 
-running (0m35.0s), 900/900 VUs, 29087 complete and 0 interrupted iterations
+running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
 default   [  58% ] 900 VUs  0m35.0s/1m0s
 
-running (0m36.0s), 900/900 VUs, 29986 complete and 0 interrupted iterations
+running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
 default   [  60% ] 900 VUs  0m36.0s/1m0s
 
-running (0m37.0s), 900/900 VUs, 30886 complete and 0 interrupted iterations
+running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
 default   [  62% ] 900 VUs  0m37.0s/1m0s
 
-running (0m38.0s), 900/900 VUs, 31659 complete and 0 interrupted iterations
+running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
 default   [  63% ] 900 VUs  0m38.0s/1m0s
 
-running (0m39.0s), 900/900 VUs, 32363 complete and 0 interrupted iterations
+running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
 default   [  65% ] 900 VUs  0m39.0s/1m0s
 
-running (0m40.0s), 900/900 VUs, 33259 complete and 0 interrupted iterations
+running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
 default   [  67% ] 900 VUs  0m40.0s/1m0s
 
-running (0m41.0s), 900/900 VUs, 34150 complete and 0 interrupted iterations
+running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
 default   [  68% ] 900 VUs  0m41.0s/1m0s
 
-running (0m42.0s), 900/900 VUs, 34902 complete and 0 interrupted iterations
+running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
 default   [  70% ] 900 VUs  0m42.0s/1m0s
 
-running (0m43.0s), 900/900 VUs, 35703 complete and 0 interrupted iterations
+running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
 default   [  72% ] 900 VUs  0m43.0s/1m0s
 
-running (0m44.0s), 900/900 VUs, 36546 complete and 0 interrupted iterations
+running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
 default   [  73% ] 900 VUs  0m44.0s/1m0s
 
-running (0m45.0s), 900/900 VUs, 37439 complete and 0 interrupted iterations
+running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
 default   [  75% ] 900 VUs  0m45.0s/1m0s
 
-running (0m46.0s), 900/900 VUs, 38323 complete and 0 interrupted iterations
+running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
 default   [  77% ] 900 VUs  0m46.0s/1m0s
 
-running (0m47.0s), 900/900 VUs, 39209 complete and 0 interrupted iterations
+running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
 default   [  78% ] 900 VUs  0m47.0s/1m0s
 
-running (0m48.0s), 900/900 VUs, 40100 complete and 0 interrupted iterations
+running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
 default   [  80% ] 900 VUs  0m48.0s/1m0s
 
-running (0m49.0s), 900/900 VUs, 40988 complete and 0 interrupted iterations
+running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
 default   [  82% ] 900 VUs  0m49.0s/1m0s
 
-running (0m50.0s), 900/900 VUs, 41876 complete and 0 interrupted iterations
+running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
 default   [  83% ] 900 VUs  0m50.0s/1m0s
 
-running (0m51.0s), 900/900 VUs, 42763 complete and 0 interrupted iterations
+running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
 default   [  85% ] 900 VUs  0m51.0s/1m0s
 
-running (0m52.0s), 900/900 VUs, 43631 complete and 0 interrupted iterations
+running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
 default   [  87% ] 900 VUs  0m52.0s/1m0s
 
-running (0m53.0s), 900/900 VUs, 44513 complete and 0 interrupted iterations
+running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
 default   [  88% ] 900 VUs  0m53.0s/1m0s
 
-running (0m54.0s), 900/900 VUs, 45386 complete and 0 interrupted iterations
+running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
 default   [  90% ] 900 VUs  0m54.0s/1m0s
 
-running (0m55.0s), 900/900 VUs, 46251 complete and 0 interrupted iterations
+running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
 default   [  92% ] 900 VUs  0m55.0s/1m0s
 
-running (0m56.0s), 900/900 VUs, 47145 complete and 0 interrupted iterations
+running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
 default   [  93% ] 900 VUs  0m56.0s/1m0s
 
-running (0m57.0s), 900/900 VUs, 48013 complete and 0 interrupted iterations
+running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
 default   [  95% ] 900 VUs  0m57.0s/1m0s
 
-running (0m58.0s), 900/900 VUs, 48908 complete and 0 interrupted iterations
+running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
 default   [  97% ] 900 VUs  0m58.0s/1m0s
 
-running (0m59.0s), 900/900 VUs, 49808 complete and 0 interrupted iterations
+running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
 default   [  98% ] 900 VUs  0m59.0s/1m0s
 
-running (1m00.0s), 900/900 VUs, 50708 complete and 0 interrupted iterations
+running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
 default   [ 100% ] 900 VUs  1m00.0s/1m0s
 
 
   █ TOTAL RESULTS 
 
     HTTP
-    http_req_duration..............: avg=1.04ms min=0s      med=130.99µs max=467.78ms p(90)=2.95ms p(95)=4.55ms
-      { expected_response:true }...: avg=1.91ms min=90.07µs med=642.45µs max=467.78ms p(90)=4.36ms p(95)=6.03ms
-    http_req_failed................: 45.29% 23376 out of 51608
-    http_reqs......................: 51608  848.400694/s
+    http_req_duration..............: avg=787.15µs min=55.47µs med=541.97µs max=25.06ms p(90)=1.46ms p(95)=1.9ms
+      { expected_response:true }...: avg=787.15µs min=55.47µs med=541.97µs max=25.06ms p(90)=1.46ms p(95)=1.9ms
+    http_req_failed................: 0.00%  0 out of 54000
+    http_reqs......................: 54000  898.403809/s
 
     EXECUTION
-    iteration_duration.............: avg=1.04s  min=1s      med=1s       max=2.37s    p(90)=1.09s  p(95)=1.28s 
-    iterations.....................: 51608  848.400694/s
-    vus............................: 900    min=900            max=900
-    vus_max........................: 900    min=900            max=900
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.04s   p(90)=1s     p(95)=1s   
+    iterations.....................: 54000  898.403809/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
 
     NETWORK
-    data_received..................: 8.3 MB 136 kB/s
-    data_sent......................: 2.2 MB 36 kB/s
+    data_received..................: 15 MB  247 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
 
 
 
 
-running (1m00.8s), 000/900 VUs, 51608 complete and 0 interrupted iterations
+running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkVapor.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=711.82µs min=58.74µs med=458.52µs max=34.95ms p(90)=1.37ms p(95)=1.78ms
+      { expected_response:true }...: avg=711.82µs min=58.74µs med=458.52µs max=34.95ms p(90)=1.37ms p(95)=1.78ms
+    http_req_failed................: 0.00%  0 out of 54000
+    http_reqs......................: 54000  898.502485/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.04s   p(90)=1s     p(95)=1s    
+    iterations.....................: 54000  898.502485/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  247 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkVapor.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=966.49µs min=57.29µs med=692.83µs max=28.93ms p(90)=1.75ms p(95)=2.34ms
+      { expected_response:true }...: avg=966.49µs min=57.29µs med=692.83µs max=28.93ms p(90)=1.75ms p(95)=2.34ms
+    http_req_failed................: 0.00%  0 out of 54000
+    http_reqs......................: 54000  898.313067/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.04s   p(90)=1s     p(95)=1s    
+    iterations.....................: 54000  898.313067/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  247 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkVapor.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=734.21µs min=53.09µs med=431.83µs max=25.77ms p(90)=1.4ms p(95)=2.09ms
+      { expected_response:true }...: avg=734.21µs min=53.09µs med=431.83µs max=25.77ms p(90)=1.4ms p(95)=2.09ms
+    http_req_failed................: 0.00%  0 out of 54000
+    http_reqs......................: 54000  898.528115/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.03s   p(90)=1s    p(95)=1s    
+    iterations.....................: 54000  898.528115/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  247 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkVapor.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=848.52µs min=53.85µs med=563.26µs max=24.66ms p(90)=1.72ms p(95)=2.33ms
+      { expected_response:true }...: avg=848.52µs min=53.85µs med=563.26µs max=24.66ms p(90)=1.72ms p(95)=2.33ms
+    http_req_failed................: 0.00%  0 out of 54000
+    http_reqs......................: 54000  898.441747/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.03s   p(90)=1s     p(95)=1s    
+    iterations.....................: 54000  898.441747/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  247 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkVapor.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=707.47µs min=54.5µs med=425.19µs max=22.13ms p(90)=1.33ms p(95)=1.73ms
+      { expected_response:true }...: avg=707.47µs min=54.5µs med=425.19µs max=22.13ms p(90)=1.33ms p(95)=1.73ms
+    http_req_failed................: 0.00%  0 out of 54000
+    http_reqs......................: 54000  898.421715/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s       min=1s     med=1s       max=1.03s   p(90)=1s     p(95)=1s    
+    iterations.....................: 54000  898.421715/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  247 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkVapor.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=930.37µs min=53.97µs med=653.21µs max=15.7ms p(90)=1.95ms p(95)=2.76ms
+      { expected_response:true }...: avg=930.37µs min=53.97µs med=653.21µs max=15.7ms p(90)=1.95ms p(95)=2.76ms
+    http_req_failed................: 0.00%  0 out of 54000
+    http_reqs......................: 54000  898.204545/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.04s  p(90)=1s     p(95)=1s    
+    iterations.....................: 54000  898.204545/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  247 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
+default ✓ [ 100% ] 900 VUs  1m0s
+
+         /\      Grafana   /‾‾/  
+    /\  /  \     |\  __   /  /   
+   /  \/    \    | |/ /  /   ‾‾\ 
+  /          \   |   (  |  (‾)  |
+ / __________ \  |_|\_\  \_____/ 
+
+     execution: local
+        script: benchmarkVapor.js
+        output: -
+
+     scenarios: (100.00%) 1 scenario, 900 max VUs, 1m30s max duration (incl. graceful stop):
+              * default: 900 looping VUs for 1m0s (gracefulStop: 30s)
+
+
+running (0m01.0s), 900/900 VUs, 0 complete and 0 interrupted iterations
+default   [   2% ] 900 VUs  0m01.0s/1m0s
+
+running (0m02.0s), 900/900 VUs, 900 complete and 0 interrupted iterations
+default   [   3% ] 900 VUs  0m02.0s/1m0s
+
+running (0m03.0s), 900/900 VUs, 1800 complete and 0 interrupted iterations
+default   [   5% ] 900 VUs  0m03.0s/1m0s
+
+running (0m04.0s), 900/900 VUs, 2700 complete and 0 interrupted iterations
+default   [   7% ] 900 VUs  0m04.0s/1m0s
+
+running (0m05.0s), 900/900 VUs, 3600 complete and 0 interrupted iterations
+default   [   8% ] 900 VUs  0m05.0s/1m0s
+
+running (0m06.0s), 900/900 VUs, 4500 complete and 0 interrupted iterations
+default   [  10% ] 900 VUs  0m06.0s/1m0s
+
+running (0m07.0s), 900/900 VUs, 5400 complete and 0 interrupted iterations
+default   [  12% ] 900 VUs  0m07.0s/1m0s
+
+running (0m08.0s), 900/900 VUs, 6300 complete and 0 interrupted iterations
+default   [  13% ] 900 VUs  0m08.0s/1m0s
+
+running (0m09.0s), 900/900 VUs, 7200 complete and 0 interrupted iterations
+default   [  15% ] 900 VUs  0m09.0s/1m0s
+
+running (0m10.0s), 900/900 VUs, 8100 complete and 0 interrupted iterations
+default   [  17% ] 900 VUs  0m10.0s/1m0s
+
+running (0m11.0s), 900/900 VUs, 9000 complete and 0 interrupted iterations
+default   [  18% ] 900 VUs  0m11.0s/1m0s
+
+running (0m12.0s), 900/900 VUs, 9900 complete and 0 interrupted iterations
+default   [  20% ] 900 VUs  0m12.0s/1m0s
+
+running (0m13.0s), 900/900 VUs, 10800 complete and 0 interrupted iterations
+default   [  22% ] 900 VUs  0m13.0s/1m0s
+
+running (0m14.0s), 900/900 VUs, 11700 complete and 0 interrupted iterations
+default   [  23% ] 900 VUs  0m14.0s/1m0s
+
+running (0m15.0s), 900/900 VUs, 12600 complete and 0 interrupted iterations
+default   [  25% ] 900 VUs  0m15.0s/1m0s
+
+running (0m16.0s), 900/900 VUs, 13500 complete and 0 interrupted iterations
+default   [  27% ] 900 VUs  0m16.0s/1m0s
+
+running (0m17.0s), 900/900 VUs, 14400 complete and 0 interrupted iterations
+default   [  28% ] 900 VUs  0m17.0s/1m0s
+
+running (0m18.0s), 900/900 VUs, 15300 complete and 0 interrupted iterations
+default   [  30% ] 900 VUs  0m18.0s/1m0s
+
+running (0m19.0s), 900/900 VUs, 16200 complete and 0 interrupted iterations
+default   [  32% ] 900 VUs  0m19.0s/1m0s
+
+running (0m20.0s), 900/900 VUs, 17100 complete and 0 interrupted iterations
+default   [  33% ] 900 VUs  0m20.0s/1m0s
+
+running (0m21.0s), 900/900 VUs, 18000 complete and 0 interrupted iterations
+default   [  35% ] 900 VUs  0m21.0s/1m0s
+
+running (0m22.0s), 900/900 VUs, 18900 complete and 0 interrupted iterations
+default   [  37% ] 900 VUs  0m22.0s/1m0s
+
+running (0m23.0s), 900/900 VUs, 19800 complete and 0 interrupted iterations
+default   [  38% ] 900 VUs  0m23.0s/1m0s
+
+running (0m24.0s), 900/900 VUs, 20700 complete and 0 interrupted iterations
+default   [  40% ] 900 VUs  0m24.0s/1m0s
+
+running (0m25.0s), 900/900 VUs, 21600 complete and 0 interrupted iterations
+default   [  42% ] 900 VUs  0m25.0s/1m0s
+
+running (0m26.0s), 900/900 VUs, 22500 complete and 0 interrupted iterations
+default   [  43% ] 900 VUs  0m26.0s/1m0s
+
+running (0m27.0s), 900/900 VUs, 23400 complete and 0 interrupted iterations
+default   [  45% ] 900 VUs  0m27.0s/1m0s
+
+running (0m28.0s), 900/900 VUs, 24300 complete and 0 interrupted iterations
+default   [  47% ] 900 VUs  0m28.0s/1m0s
+
+running (0m29.0s), 900/900 VUs, 25200 complete and 0 interrupted iterations
+default   [  48% ] 900 VUs  0m29.0s/1m0s
+
+running (0m30.0s), 900/900 VUs, 26100 complete and 0 interrupted iterations
+default   [  50% ] 900 VUs  0m30.0s/1m0s
+
+running (0m31.0s), 900/900 VUs, 27000 complete and 0 interrupted iterations
+default   [  52% ] 900 VUs  0m31.0s/1m0s
+
+running (0m32.0s), 900/900 VUs, 27900 complete and 0 interrupted iterations
+default   [  53% ] 900 VUs  0m32.0s/1m0s
+
+running (0m33.0s), 900/900 VUs, 28800 complete and 0 interrupted iterations
+default   [  55% ] 900 VUs  0m33.0s/1m0s
+
+running (0m34.0s), 900/900 VUs, 29700 complete and 0 interrupted iterations
+default   [  57% ] 900 VUs  0m34.0s/1m0s
+
+running (0m35.0s), 900/900 VUs, 30600 complete and 0 interrupted iterations
+default   [  58% ] 900 VUs  0m35.0s/1m0s
+
+running (0m36.0s), 900/900 VUs, 31500 complete and 0 interrupted iterations
+default   [  60% ] 900 VUs  0m36.0s/1m0s
+
+running (0m37.0s), 900/900 VUs, 32400 complete and 0 interrupted iterations
+default   [  62% ] 900 VUs  0m37.0s/1m0s
+
+running (0m38.0s), 900/900 VUs, 33300 complete and 0 interrupted iterations
+default   [  63% ] 900 VUs  0m38.0s/1m0s
+
+running (0m39.0s), 900/900 VUs, 34200 complete and 0 interrupted iterations
+default   [  65% ] 900 VUs  0m39.0s/1m0s
+
+running (0m40.0s), 900/900 VUs, 35100 complete and 0 interrupted iterations
+default   [  67% ] 900 VUs  0m40.0s/1m0s
+
+running (0m41.0s), 900/900 VUs, 36000 complete and 0 interrupted iterations
+default   [  68% ] 900 VUs  0m41.0s/1m0s
+
+running (0m42.0s), 900/900 VUs, 36900 complete and 0 interrupted iterations
+default   [  70% ] 900 VUs  0m42.0s/1m0s
+
+running (0m43.0s), 900/900 VUs, 37800 complete and 0 interrupted iterations
+default   [  72% ] 900 VUs  0m43.0s/1m0s
+
+running (0m44.0s), 900/900 VUs, 38700 complete and 0 interrupted iterations
+default   [  73% ] 900 VUs  0m44.0s/1m0s
+
+running (0m45.0s), 900/900 VUs, 39600 complete and 0 interrupted iterations
+default   [  75% ] 900 VUs  0m45.0s/1m0s
+
+running (0m46.0s), 900/900 VUs, 40500 complete and 0 interrupted iterations
+default   [  77% ] 900 VUs  0m46.0s/1m0s
+
+running (0m47.0s), 900/900 VUs, 41400 complete and 0 interrupted iterations
+default   [  78% ] 900 VUs  0m47.0s/1m0s
+
+running (0m48.0s), 900/900 VUs, 42300 complete and 0 interrupted iterations
+default   [  80% ] 900 VUs  0m48.0s/1m0s
+
+running (0m49.0s), 900/900 VUs, 43200 complete and 0 interrupted iterations
+default   [  82% ] 900 VUs  0m49.0s/1m0s
+
+running (0m50.0s), 900/900 VUs, 44100 complete and 0 interrupted iterations
+default   [  83% ] 900 VUs  0m50.0s/1m0s
+
+running (0m51.0s), 900/900 VUs, 45000 complete and 0 interrupted iterations
+default   [  85% ] 900 VUs  0m51.0s/1m0s
+
+running (0m52.0s), 900/900 VUs, 45900 complete and 0 interrupted iterations
+default   [  87% ] 900 VUs  0m52.0s/1m0s
+
+running (0m53.0s), 900/900 VUs, 46800 complete and 0 interrupted iterations
+default   [  88% ] 900 VUs  0m53.0s/1m0s
+
+running (0m54.0s), 900/900 VUs, 47700 complete and 0 interrupted iterations
+default   [  90% ] 900 VUs  0m54.0s/1m0s
+
+running (0m55.0s), 900/900 VUs, 48600 complete and 0 interrupted iterations
+default   [  92% ] 900 VUs  0m55.0s/1m0s
+
+running (0m56.0s), 900/900 VUs, 49500 complete and 0 interrupted iterations
+default   [  93% ] 900 VUs  0m56.0s/1m0s
+
+running (0m57.0s), 900/900 VUs, 50400 complete and 0 interrupted iterations
+default   [  95% ] 900 VUs  0m57.0s/1m0s
+
+running (0m58.0s), 900/900 VUs, 51300 complete and 0 interrupted iterations
+default   [  97% ] 900 VUs  0m58.0s/1m0s
+
+running (0m59.0s), 900/900 VUs, 52200 complete and 0 interrupted iterations
+default   [  98% ] 900 VUs  0m59.0s/1m0s
+
+running (1m00.0s), 900/900 VUs, 53100 complete and 0 interrupted iterations
+default   [ 100% ] 900 VUs  1m00.0s/1m0s
+
+
+  █ TOTAL RESULTS 
+
+    HTTP
+    http_req_duration..............: avg=752.19µs min=52.89µs med=428.85µs max=31.98ms p(90)=1.31ms p(95)=1.78ms
+      { expected_response:true }...: avg=752.19µs min=52.89µs med=428.85µs max=31.98ms p(90)=1.31ms p(95)=1.78ms
+    http_req_failed................: 0.00%  0 out of 54000
+    http_reqs......................: 54000  898.466633/s
+
+    EXECUTION
+    iteration_duration.............: avg=1s       min=1s      med=1s       max=1.04s   p(90)=1s     p(95)=1s    
+    iterations.....................: 54000  898.466633/s
+    vus............................: 900    min=900        max=900
+    vus_max........................: 900    min=900        max=900
+
+    NETWORK
+    data_received..................: 15 MB  247 kB/s
+    data_sent......................: 4.2 MB 70 kB/s
+
+
+
+
+running (1m00.1s), 000/900 VUs, 54000 complete and 0 interrupted iterations
 default ✓ [ 100% ] 900 VUs  1m0s

--- a/Benchmarks/runBenchmarks.sh
+++ b/Benchmarks/runBenchmarks.sh
@@ -1,18 +1,14 @@
 #!/bin/bash
 function bench_destiny {
-    for ((i = 0; i < 3; i++)); do k6 run benchmarkDestiny.js >> results_destiny.txt; done;
+    for ((i = 0; i < 10; i++)); do k6 run benchmarkDestiny.js >> results_destiny.txt; done;
 }
 function bench_hummingbird {
-    for ((i = 0; i < 3; i++)); do k6 run benchmarkHummingbird.js >> results_hummingbird.txt; done;
+    for ((i = 0; i < 10; i++)); do k6 run benchmarkHummingbird.js >> results_hummingbird.txt; done;
 }
 function bench_vapor {
-    for ((i = 0; i < 3; i++)); do k6 run benchmarkVapor.js >> results_vapor.txt; done;
+    for ((i = 0; i < 10; i++)); do k6 run benchmarkVapor.js >> results_vapor.txt; done;
 }
-swiftly run swift build -c release
-swiftly run swift run -c release &
-echo "Waiting 1 minute to make sure the servers are booted..." \
-&& sleep 1m \
-&& echo "Benchmarking Destiny..." \
+echo "Benchmarking Destiny..." \
 && bench_destiny \
 && echo "Benchmarking Hummingbird..." \
 && bench_hummingbird \

--- a/Sources/Destiny/http/NonCopyableHTTPServer.swift
+++ b/Sources/Destiny/http/NonCopyableHTTPServer.swift
@@ -44,7 +44,7 @@ public final class NonCopyableHTTPServer<
 
     #if Epoll
     @usableFromInline
-    nonisolated(unsafe) private(set) var epollWorker:EpollWorker<64>! = nil
+    nonisolated(unsafe) private(set) var epollWorker:EpollWorker<128>! = nil
     #endif
 
     // MARK: Init
@@ -99,7 +99,7 @@ public final class NonCopyableHTTPServer<
 
         do throws(DestinyError) {
             #if Epoll
-            epollWorker = try EpollWorker<64>.create(workerId: 0, backlog: backlog, port: port)
+            epollWorker = try EpollWorker<128>.create(workerId: 0, backlog: backlog, port: port)
             epollWorker.run(router: router)
             #else
             let serverFD1 = try bindAndListen()

--- a/Sources/Documentation.docc/Performance.md
+++ b/Sources/Documentation.docc/Performance.md
@@ -138,7 +138,7 @@ Last benchmark conducted: Nov 9, 2025
 - Desktop Environment: Xfce 4.20
 - CPU: stock AMD Ryzen 7 7800X3D (16 threads) @ 5.053G (powersave governors)
 - RAM: 2x16GB DDR5 @ 4800 MT/s
-- Storage: 1TB NVME SSD (511.7 GiB free; swap disabled)
+- Storage: 1TB NVME SSD (550.6 GiB free; swap disabled)
 - [Swift](https://www.swift.org/): 6.2 (swift-6.2-RELEASE)
 - [Swiftly](https://github.com/swiftlang/swiftly): 1.0.0
 - [k6](https://grafana.com/docs/k6/latest/): v1.3.0 (commit/89149e9087, go1.25.2 X:nodwarf5, linux/amd64)

--- a/Sources/Documentation.docc/Performance.md
+++ b/Sources/Documentation.docc/Performance.md
@@ -131,22 +131,22 @@ Areas that Swift needs more development/support to unlock more abstraction/perfo
 
 ## Benchmarks
 
-Last benchmark conducted: Oct 16, 2025
+Last benchmark conducted: Nov 9, 2025
 
 ### Setup
-- Operating System: Arch Linux (6.17.1-arch1-1; x86_64)
+- Operating System: Arch Linux (6.17.7-arch1-1; x86_64)
 - Desktop Environment: Xfce 4.20
 - CPU: stock AMD Ryzen 7 7800X3D (16 threads) @ 5.053G (powersave governors)
 - RAM: 2x16GB DDR5 @ 4800 MT/s
-- Storage: 1TB NVME SSD (550.6 GiB free; swap disabled)
+- Storage: 1TB NVME SSD (511.7 GiB free; swap disabled)
 - [Swift](https://www.swift.org/): 6.2 (swift-6.2-RELEASE)
 - [Swiftly](https://github.com/swiftlang/swiftly): 1.0.0
 - [k6](https://grafana.com/docs/k6/latest/): v1.3.0 (commit/89149e9087, go1.25.2 X:nodwarf5, linux/amd64)
 
 ### Libraries tested
-- [RandomHashTags/destiny](https://github.com/RandomHashTags/destiny) v0.3.0 (this library)
-- [hummingbird-project/hummingbird](https://github.com/hummingbird-project/hummingbird) v2.16.0
-- [vapor/vapor](https://github.com/vapor/vapor) v4.117.0
+- [RandomHashTags/destiny](https://github.com/RandomHashTags/destiny) v0.4.0 (this library)
+- [hummingbird-project/hummingbird](https://github.com/hummingbird-project/hummingbird) v2.17.0
+- [vapor/vapor](https://github.com/vapor/vapor) v4.119.0
 
 ### Results
 
@@ -157,15 +157,6 @@ Initial testing of a basic HTML response shows this library has the lowest serve
 #### Dynamic
 
 Depends on how much dynamic content you add; initial testing compared to a Static response performs about the same but usually costs a few microseconds more (~10-50).
-
-#### Performance Rankings
-
-Destiny ranks #1 in all categories compared to the other libraries:
-- [x] Highest Throughput
-- [x] Highest Sustained Load (no dropped/failed/reset connections)
-- [x] Lowest Latency
-- [x] Lowest System Resource Utilization
-- [x] Most Consistent Timings
 
 #### Conclusion
 


### PR DESCRIPTION
Update benchmark dependencies to latest versions.

<hr>

It looks like `swift-nio` (or somebody somewhere) fixed something so Hummingbird and Vapor no longer drop connections and their performance was greatly improved, comparable to Destiny.

However, checking the performance in the browser results in no performance improvement to Hummingbird or Vapor, making Destiny vastly superior in a browser environment for some reason. Should probably run the benchmark on a different machine than the one hosting the servers.