### PR TITLE
fix infinite recursion when trying to stream data via `AsyncHTTPChunkDataStream`

### DIFF
--- a/Sources/Destiny/http/AsyncHTTPChunkDataStream.swift
+++ b/Sources/Destiny/http/AsyncHTTPChunkDataStream.swift
@@ -40,7 +40,7 @@ public struct AsyncHTTPChunkDataStream<T: HTTPChunkDataProtocol>: Sendable {
 // MARK: Write
 extension AsyncHTTPChunkDataStream {
     public func write(
-        to socket: some FileDescriptor
+        to socket: borrowing some FileDescriptor & ~Copyable
     ) async throws(DestinyError) {
         // 20 = length in hexadecimal (16) + "\r\n".count * 2 (4)
         let buffer = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: 20 +! chunkSize)

--- a/Sources/Destiny/http/protocols/AsyncHTTPSocketWritable.swift
+++ b/Sources/Destiny/http/protocols/AsyncHTTPSocketWritable.swift
@@ -13,20 +13,6 @@ public protocol AsyncHTTPSocketWritable: Sendable, ~Copyable {
     ) async throws(DestinyError)
 }
 
-extension AsyncHTTPSocketWritable {
-    /// Asynchronously writes data to the socket.
-    /// 
-    /// - Parameters:
-    ///   - socket: some noncopyable `FileDescriptor`.
-    /// 
-    /// - Throws: `DestinyError`
-    public func write(
-        to socket: borrowing some FileDescriptor & ~Copyable
-    ) async throws(DestinyError) {
-        try await write(to: socket.fileDescriptor)
-    }
-}
-
 // MARK: Default conformances
 extension String: AsyncHTTPSocketWritable {
     public func write(


### PR DESCRIPTION
Also removes the default `write(to:)` function from `AsyncHTTPSocketWritable`