### PR TITLE
fix http response if it has no body

### DIFF
--- a/Sources/Destiny/http/HTTPResponseMessage+Convenience+NonEmbedded.swift
+++ b/Sources/Destiny/http/HTTPResponseMessage+Convenience+NonEmbedded.swift
@@ -52,6 +52,8 @@ extension HTTPResponseMessage {
                 string += "content-type: \(mediaType.template)\((charset != nil ? "; charset=" + charset!.rawName : ""))\(suffix)"
             }
             string += "content-length: \(contentLength)\(suffix)\(suffix)\(body)"
+        } else {
+            string += suffix
         }
         return string
     }

--- a/Sources/Destiny/http/HTTPResponseMessage.swift
+++ b/Sources/Destiny/http/HTTPResponseMessage.swift
@@ -272,6 +272,8 @@ extension HTTPResponseMessage {
                 string += "content-type: \(contentType)\((charset != nil ? "; charset=" + charset!.rawName : ""))\(suffix)"
             }
             string += "content-length: \(contentLength)\(suffix)\(suffix)\(body)"
+        } else {
+            string += suffix
         }
         return string
     }

--- a/Sources/DestinyMacros/extensions/HTTPResponseMessageExtensions.swift
+++ b/Sources/DestinyMacros/extensions/HTTPResponseMessageExtensions.swift
@@ -16,6 +16,8 @@ extension HTTPResponseMessage {
             if body.hasContentLength {
                 string += "content-length: \(contentLength)\(suffix)\(suffix)"
             }
+        } else {
+            string += suffix
         }
         return string
     }


### PR DESCRIPTION
HTTP responses didn't have a final `\r\n` if it was bodyless (think redirects), resulting in incorrect client behavior due to the server not indicating the message is complete.